### PR TITLE
Fix: pass execution_mode through to IR resource_hints

### DIFF
--- a/evals/golden/sample_gpu_cpu_fallback.expected.json
+++ b/evals/golden/sample_gpu_cpu_fallback.expected.json
@@ -15,6 +15,7 @@
       "orbit": null,
       "duration_seconds": null,
       "landscape_type": null,
+      "execution_mode": "sequential",
       "requires_gpu": true,
       "requires_fpga": false,
       "fallback_enabled": true

--- a/evals/golden/sample_maritime_surveillance.expected.json
+++ b/evals/golden/sample_maritime_surveillance.expected.json
@@ -15,6 +15,7 @@
       "orbit": null,
       "duration_seconds": null,
       "landscape_type": null,
+      "execution_mode": "sequential",
       "requires_gpu": true,
       "requires_fpga": false,
       "fallback_enabled": true

--- a/src/orbital_mission_compiler/compiler.py
+++ b/src/orbital_mission_compiler/compiler.py
@@ -40,6 +40,7 @@ def compile_plan_to_intents(plan: MissionPlan) -> List[WorkflowIntent]:
                 "orbit": event.orbit,
                 "duration_seconds": event.duration_seconds,
                 "landscape_type": svc.landscape_type,
+                "execution_mode": svc.execution_mode.value,
                 "requires_gpu": bool(gpu_steps),
                 "requires_fpga": bool(fpga_steps),
                 "fallback_enabled": bool(fallback_steps),

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -76,6 +76,16 @@ def test_ir_carries_duration():
     assert hints["duration_seconds"] == 4.0
 
 
+# ── IR carries execution_mode (slide 10) ─────────────────────────────
+
+
+def test_ir_carries_execution_mode():
+    """IR resource_hints should include execution_mode from the service (slide 10)."""
+    intents = _load_intents("configs/mission_plans/sample_orchide_format.yaml")
+    hints = intents[0].resource_hints
+    assert hints["execution_mode"] == "sequential"
+
+
 # ── IR is independent of renderers ────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
`compile_plan_to_intents()` now includes `execution_mode` in `resource_hints`.

Previously, `AIService.execution_mode` was defined in the schema (Phase 1)
but never carried into the `WorkflowIntent` IR. A plan with
`execution_mode: parallel` would silently render as sequential.

## Changes
- `compiler.py`: 1 line — add `"execution_mode": svc.execution_mode.value` to hints
- `test_ir.py`: 1 test — `test_ir_carries_execution_mode`
- `evals/golden/*.json`: add `execution_mode` field

## Small CL scope
4 files, +13 lines. Single semantic fix.

## Test plan
- [x] 98 tests pass
- [x] 2 golden evals pass
- [x] `python3 scripts/verify.py` passes

Found during P3 verification audit.