### PR TITLE
Fix #8: log skipped non-acquisition events

### DIFF
--- a/src/orbital_mission_compiler/compiler.py
+++ b/src/orbital_mission_compiler/compiler.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import logging
+import re
 from pathlib import Path
 from typing import Any, Dict, List
 
 import yaml
 
-import re
-
 from .schemas import MissionPlan, WorkflowIntent, ResourceClass, WorkflowStep
+
+logger = logging.getLogger(__name__)
 
 
 def _sanitize_k8s_name(name: str) -> str:
@@ -28,6 +30,11 @@ def compile_plan_to_intents(plan: MissionPlan) -> List[WorkflowIntent]:
     intents: List[WorkflowIntent] = []
     for event in plan.events:
         if event.event_type.value != "acquisition":
+            logger.info(
+                "Skipping %s event at %s (only acquisition events produce workflow intents)",
+                event.event_type.value,
+                event.timestamp,
+            )
             continue
         for svc in event.services:
             gpu_steps = [s for s in svc.steps if s.resource_class == ResourceClass.GPU]

--- a/tests/test_compiler_logging.py
+++ b/tests/test_compiler_logging.py
@@ -1,0 +1,35 @@
+"""Tests for compiler logging and skip reporting.
+
+Issue #8: compile_plan_to_intents() silently skips non-acquisition events.
+"""
+
+import logging
+
+from orbital_mission_compiler.compiler import load_mission_plan, compile_plan_to_intents
+
+
+def test_download_event_logged_as_skipped(caplog):
+    """Skipped DOWNLOAD events must be logged at INFO level."""
+    plan = load_mission_plan("configs/mission_plans/sample_maritime_surveillance.yaml")
+    with caplog.at_level(logging.INFO, logger="orbital_mission_compiler.compiler"):
+        compile_plan_to_intents(plan)
+    assert any("download" in r.message.lower() and "skip" in r.message.lower() for r in caplog.records), \
+        "Expected a log message about skipping download event"
+
+
+def test_all_acquisition_events_not_logged_as_skipped(caplog):
+    """Plans with only ACQ events should produce no skip logs."""
+    plan = load_mission_plan("configs/mission_plans/sample_gpu_cpu_fallback.yaml")
+    with caplog.at_level(logging.INFO, logger="orbital_mission_compiler.compiler"):
+        compile_plan_to_intents(plan)
+    skip_msgs = [r for r in caplog.records if "skip" in r.message.lower()]
+    assert skip_msgs == [], "No skip messages expected for ACQ-only plan"
+
+
+def test_orchide_plan_logs_one_skip(caplog):
+    """ORCHIDE plan has 3 events (2 ACQ + 1 DOWNLOAD), should log 1 skip."""
+    plan = load_mission_plan("configs/mission_plans/sample_orchide_format.yaml")
+    with caplog.at_level(logging.INFO, logger="orbital_mission_compiler.compiler"):
+        compile_plan_to_intents(plan)
+    skip_msgs = [r for r in caplog.records if "skip" in r.message.lower()]
+    assert len(skip_msgs) == 1


### PR DESCRIPTION
## Summary
`compile_plan_to_intents()` now logs at INFO level when skipping non-acquisition events,
instead of silently `continue`.

## Changes
- `compiler.py`: add `logging.getLogger(__name__)`, log skip with event type + timestamp
- `tests/test_compiler_logging.py`: 3 tests (skip logged, no false positives, correct count)

## Small CL scope
2 files, +44/-2 lines.

## Test plan
- [x] 104 tests pass
- [x] 2 evals pass
- [x] verify + lint pass

Closes: #8