### PR TITLE
Fix schema negative gaps: orbit, duration, mission_id

### DIFF
--- a/src/orbital_mission_compiler/schemas.py
+++ b/src/orbital_mission_compiler/schemas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import Enum
 from typing import List, Optional, Dict, Any
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class ResourceClass(str, Enum):
@@ -51,8 +51,8 @@ class AIService(BaseModel):
 class MissionEvent(BaseModel):
     timestamp: str
     event_type: MissionEventType
-    orbit: Optional[int] = None
-    duration_seconds: Optional[float] = None
+    orbit: Optional[int] = Field(default=None, ge=0)
+    duration_seconds: Optional[float] = Field(default=None, ge=0)
     instrument: Optional[str] = None
     sensor: Optional[str] = None
     ground_visibility: bool = False
@@ -84,6 +84,13 @@ class MissionPlan(BaseModel):
     mission_id: str
     client_id: Optional[str] = None
     events: List[MissionEvent]
+
+    @field_validator("mission_id")
+    @classmethod
+    def mission_id_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("mission_id must not be empty")
+        return v
 
 
 class WorkflowIntent(BaseModel):

--- a/tests/test_schema_negative.py
+++ b/tests/test_schema_negative.py
@@ -106,7 +106,40 @@ def test_reject_download_without_visibility():
         )
 
 
-# ── 6. Valid edge cases that should NOT be rejected ───────────────────
+# ── 6. Numeric field constraints ──────────────────────────────────────
+
+
+def test_reject_negative_orbit():
+    """Orbit number must be non-negative."""
+    with pytest.raises(ValidationError, match="orbit"):
+        MissionEvent(
+            timestamp="2029-01-01T00:00:00Z",
+            event_type=MissionEventType.ACQUISITION,
+            instrument="INST_1",
+            orbit=-1,
+        )
+
+
+def test_reject_negative_duration():
+    """Duration must be non-negative."""
+    with pytest.raises(ValidationError, match="duration"):
+        MissionEvent(
+            timestamp="2029-01-01T00:00:00Z",
+            event_type=MissionEventType.DOWNLOAD,
+            duration_seconds=-10.0,
+            ground_visibility=True,
+        )
+
+
+def test_reject_empty_mission_id():
+    """mission_id must not be empty string."""
+    from orbital_mission_compiler.schemas import MissionPlan
+
+    with pytest.raises(ValidationError, match="mission_id"):
+        MissionPlan(mission_id="", events=[])
+
+
+# ── 7. Valid edge cases that should NOT be rejected ───────────────────
 
 
 def test_accept_valid_acquisition():


### PR DESCRIPTION
## Summary
Close 3 low-priority negative validation gaps found during P1.2 audit.

## Changes
- `schemas.py`: `orbit` Field(ge=0), `duration_seconds` Field(ge=0), `mission_id` field_validator rejects empty
- `test_schema_negative.py`: 3 new tests

## Small CL scope
2 files, +44/-4 lines.

## Test plan
- [x] 107 tests pass
- [x] 3 evals pass
- [x] lint clean