### PR TITLE
Fix H-4: eval_runner __file__-based paths

### DIFF
--- a/src/orbital_mission_compiler/eval_runner.py
+++ b/src/orbital_mission_compiler/eval_runner.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 from .compiler import load_mission_plan, compile_plan_to_intents
 
-PLANS_DIR = Path("configs/mission_plans")
-GOLDEN_DIR = Path("evals/golden")
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+PLANS_DIR = _REPO_ROOT / "configs" / "mission_plans"
+GOLDEN_DIR = _REPO_ROOT / "evals" / "golden"
 
 
 def _discover_cases() -> tuple[list[tuple[Path, Path]], list[Path]]:


### PR DESCRIPTION
## Summary
eval_runner PLANS_DIR/GOLDEN_DIR now resolve from `__file__` instead of CWD.

## Decision: A-6 and #9 deferred
Research confirmed these are YAGNI:
- A-6 (ResourceHints model): zero bug history, 11 files impact, no API boundary
- #9 (IR/plan separation): functional, cosmetic refactor

## Small CL scope
1 file, +3/-2 lines.

## Test plan
- [x] 133 tests pass
- [x] 3 evals pass
- [x] lint clean