### PR TITLE
Critical: fix Makefile PYTHONPATH (make test was broken)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PYTHON ?= python3
 PACKAGE = orbital_mission_compiler
+export PYTHONPATH := src:.
 
 .PHONY: verify test lint fmt compile-sample render-samples argo-smoke opa-smoke demo-phase2 eval print-tree
 


### PR DESCRIPTION
## Summary
`make test` failed with 13 ModuleNotFoundError collection errors.
README Quick Start was broken for anyone cloning the repo.

Fix: add `export PYTHONPATH := src:.` to Makefile.

## Found by
Full-review Phase 3B documentation audit.

## Test plan
- [x] `make test` → 133 passed, 3 skipped
- [x] `make eval` → 3/3 passed
- [x] `make lint` → all checks passed