### PR TITLE
Security S-H1: MCP path traversal protection (CWE-22)

### DIFF
--- a/src/orbital_mission_compiler/mcp/server.py
+++ b/src/orbital_mission_compiler/mcp/server.py
@@ -22,7 +22,7 @@ _ALLOWED_BUNDLES = (_REPO_ROOT / "configs" / "policies").resolve()
 
 
 def _is_within(child: Path, parent: Path) -> bool:
-    """Check if child path is strictly within parent directory."""
+    """Check if child path is within or equal to parent directory."""
     try:
         child.relative_to(parent)
         return True
@@ -31,11 +31,13 @@ def _is_within(child: Path, parent: Path) -> bool:
 
 
 def _validate_plan_path(path: str) -> Path:
-    """Validate plan path is within configs/mission_plans/. CWE-22 prevention."""
+    """Validate plan path is a filename within configs/mission_plans/. CWE-22 prevention."""
     candidate = Path(path)
     if candidate.is_absolute() or ".." in candidate.parts:
         raise ValueError(f"Path outside allowed directory: {path}")
-    # Only accept filenames — resolve against allowed dir
+    # Only accept bare filenames — reject paths with directory components
+    if candidate != Path(candidate.name):
+        raise ValueError(f"Path outside allowed directory: {path}")
     resolved = (_ALLOWED_PLANS / candidate.name).resolve()
     if not _is_within(resolved, _ALLOWED_PLANS):
         raise ValueError(f"Path outside allowed directory: {path}")
@@ -46,7 +48,12 @@ def _validate_plan_path(path: str) -> Path:
 
 def _validate_bundle_path(bundle: str) -> Path:
     """Validate bundle path is within configs/policies/. CWE-22 prevention."""
-    resolved = Path(bundle).resolve()
+    candidate = Path(bundle)
+    # Resolve relative paths against _REPO_ROOT (CWD-independent)
+    if not candidate.is_absolute():
+        resolved = (_REPO_ROOT / candidate).resolve()
+    else:
+        resolved = candidate.resolve()
     if not _is_within(resolved, _ALLOWED_BUNDLES):
         raise ValueError(f"Bundle path outside allowed directory: {bundle}")
     return resolved

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -26,7 +26,7 @@ def test_validate_path_accepts_valid():
     """Valid plan paths should pass."""
     from orbital_mission_compiler.mcp.server import _validate_plan_path
 
-    result = _validate_plan_path("configs/mission_plans/sample_maritime_surveillance.yaml")
+    result = _validate_plan_path("sample_maritime_surveillance.yaml")
     assert result.exists()
 
 


### PR DESCRIPTION
## Summary
All 4 MCP tools now validate file paths before access.

- `_validate_plan_path`: rejects absolute paths, `..` traversal, paths outside configs/mission_plans/
- `_validate_bundle_path`: rejects bundle dirs outside configs/policies/
- Also: `except Exception` → `except ImportError` for FastMCP import

## Test plan
- [x] 5 new security tests (traversal, absolute, valid, bundle reject, bundle accept)
- [x] 138 total tests pass
- [x] lint clean

Closes relevant part of security audit finding S-H1.