### PR TITLE
BP-1 to BP-5: modern typing, set_defaults, coverage gate, ruff target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Unit tests with coverage
         run: |
-          python3 -m pytest -q --cov=orbital_mission_compiler --cov-report=term-missing
+          python3 -m pytest -q --cov=orbital_mission_compiler --cov-report=term-missing --cov-fail-under=70
 
       - name: Golden evals
         run: python3 -m orbital_mission_compiler.eval_runner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ where = ["src"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py311"
+target-version = "py310"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/orbital_mission_compiler/cli.py
+++ b/src/orbital_mission_compiler/cli.py
@@ -24,24 +24,29 @@ def build_parser() -> argparse.ArgumentParser:
     compile_p = sub.add_parser("compile", help="Compile mission plan to workflow payload")
     compile_p.add_argument("--input", required=True)
     compile_p.add_argument("--output", required=True)
+    compile_p.set_defaults(func=cmd_compile)
 
     render_p = sub.add_parser("render-argo", help="Render individual Argo Workflow manifests")
     render_p.add_argument("--input", required=True)
     render_p.add_argument("--output-dir", required=True)
+    render_p.set_defaults(func=cmd_render_argo)
 
     inspect_p = sub.add_parser("inspect", help="Inspect compiled workflow intents")
     inspect_p.add_argument("--input", required=True)
+    inspect_p.set_defaults(func=cmd_inspect)
 
     kueue_p = sub.add_parser("render-kueue", help="Render Kueue-compatible Job manifests")
     kueue_p.add_argument("--input", required=True)
     kueue_p.add_argument("--output-dir", required=True)
     kueue_p.add_argument("--queue", default="orbital-demo-local")
     kueue_p.add_argument("--namespace", default="orbital-demo")
+    kueue_p.set_defaults(func=cmd_render_kueue)
 
     policy_p = sub.add_parser("policy", help="Evaluate policy pack with OPA if available")
     policy_p.add_argument("--input", required=True)
     policy_p.add_argument("--bundle", default="configs/policies")
     policy_p.add_argument("--decision", default="data.orbitalmission")
+    policy_p.set_defaults(func=cmd_policy)
 
     return parser
 
@@ -89,18 +94,7 @@ def cmd_policy(args):
 def main():
     parser = build_parser()
     args = parser.parse_args()
-    if args.command == "compile":
-        cmd_compile(args)
-    elif args.command == "render-argo":
-        cmd_render_argo(args)
-    elif args.command == "inspect":
-        cmd_inspect(args)
-    elif args.command == "render-kueue":
-        cmd_render_kueue(args)
-    elif args.command == "policy":
-        cmd_policy(args)
-    else:
-        parser.error("unknown command")
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/src/orbital_mission_compiler/compiler.py
+++ b/src/orbital_mission_compiler/compiler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 import yaml
 
@@ -26,8 +26,8 @@ def load_mission_plan(path: str | Path) -> MissionPlan:
     return MissionPlan.model_validate(raw)
 
 
-def compile_plan_to_intents(plan: MissionPlan) -> List[WorkflowIntent]:
-    intents: List[WorkflowIntent] = []
+def compile_plan_to_intents(plan: MissionPlan) -> list[WorkflowIntent]:
+    intents: list[WorkflowIntent] = []
     skipped = 0
     for event in plan.events:
         if event.event_type.value != "acquisition":
@@ -73,7 +73,7 @@ def compile_plan_to_intents(plan: MissionPlan) -> List[WorkflowIntent]:
     return intents
 
 
-def _preferred_affinity(step: WorkflowStep) -> Dict[str, Any] | None:
+def _preferred_affinity(step: WorkflowStep) -> dict[str, Any] | None:
     if not step.preferred_node_selector:
         return None
     expressions = [
@@ -92,19 +92,19 @@ def _preferred_affinity(step: WorkflowStep) -> Dict[str, Any] | None:
     }
 
 
-def render_argo_workflow(intent: WorkflowIntent) -> Dict[str, Any]:
+def render_argo_workflow(intent: WorkflowIntent) -> dict[str, Any]:
     templates = []
     dag_tasks = []
     for idx, step in enumerate(intent.steps):
         template_name = f"step-{idx}-{sanitize_k8s_name(step.name)}"
-        annotations: Dict[str, str] = {
+        annotations: dict[str, str] = {
             "resource-class": step.resource_class.value,
             "needs-acceleration": str(step.needs_acceleration).lower(),
         }
         if step.phase is not None:
             annotations["phase"] = step.phase.value
 
-        template: Dict[str, Any] = {
+        template: dict[str, Any] = {
             "name": template_name,
             "container": {
                 "image": step.image,
@@ -136,7 +136,7 @@ def render_argo_workflow(intent: WorkflowIntent) -> Dict[str, Any]:
         templates.append(template)
 
         safe_name = sanitize_k8s_name(step.name)
-        dag_task: Dict[str, Any] = {"name": safe_name, "template": template_name}
+        dag_task: dict[str, Any] = {"name": safe_name, "template": template_name}
         dag_tasks.append(dag_task)
 
     # Apply DAG dependencies based on execution_mode.
@@ -150,7 +150,7 @@ def render_argo_workflow(intent: WorkflowIntent) -> Dict[str, Any]:
         for i in range(1, len(dag_tasks)):
             dag_tasks[i]["depends"] = dag_tasks[i - 1]["name"]
 
-    wf_annotations: Dict[str, str] = {
+    wf_annotations: dict[str, str] = {
         "orbital/priority": str(intent.priority),
         "orbital/execution-mode": execution_mode,
         "orbital/requires-gpu": str(intent.resource_hints.get("requires_gpu", False)).lower(),
@@ -182,14 +182,14 @@ def render_kueue_job(
     intent: WorkflowIntent,
     queue_name: str = "orbital-demo-local",
     namespace: str = "orbital-demo",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     requires_gpu = intent.resource_hints.get("requires_gpu", False)
 
     # Pick the primary compute step (GPU step if present, else first step).
     gpu_steps = [s for s in intent.steps if s.resource_class == ResourceClass.GPU]
     primary = gpu_steps[0] if gpu_steps else intent.steps[0]
 
-    container: Dict[str, Any] = {
+    container: dict[str, Any] = {
         "name": sanitize_k8s_name(primary.name),
         "image": primary.image,
         "command": primary.command or ["sh", "-c"],
@@ -205,7 +205,7 @@ def render_kueue_job(
         container["resources"]["requests"]["nvidia.com/gpu"] = "1"
         container["resources"]["limits"] = {"nvidia.com/gpu": "1"}
 
-    pod_spec: Dict[str, Any] = {
+    pod_spec: dict[str, Any] = {
         "restartPolicy": "Never",
         "containers": [container],
     }
@@ -215,13 +215,13 @@ def render_kueue_job(
             {"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"}
         ]
 
-    job_annotations: Dict[str, str] = {
+    job_annotations: dict[str, str] = {
         "orbital/priority": str(intent.priority),
         "orbital/requires-gpu": str(requires_gpu).lower(),
         "orbital/fallback-enabled": str(intent.resource_hints.get("fallback_enabled", False)).lower(),
     }
 
-    job: Dict[str, Any] = {
+    job: dict[str, Any] = {
         "apiVersion": "batch/v1",
         "kind": "Job",
         "metadata": {
@@ -244,7 +244,7 @@ def render_kueue_job(
     return job
 
 
-def render_workflows_for_file(input_path: str | Path) -> List[Dict[str, Any]]:
+def render_workflows_for_file(input_path: str | Path) -> list[dict[str, Any]]:
     plan = load_mission_plan(input_path)
     intents = compile_plan_to_intents(plan)
     return [render_argo_workflow(intent) for intent in intents]
@@ -262,7 +262,7 @@ def write_individual_workflows(input_path: str | Path, output_dir: str | Path) -
     return written
 
 
-def compile_file(input_path: str | Path, output_path: str | Path) -> Dict[str, Any]:
+def compile_file(input_path: str | Path, output_path: str | Path) -> dict[str, Any]:
     plan = load_mission_plan(input_path)
     intents = compile_plan_to_intents(plan)
     payload = {

--- a/src/orbital_mission_compiler/policy.py
+++ b/src/orbital_mission_compiler/policy.py
@@ -4,7 +4,7 @@ import json
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any
 
 
 def opa_available() -> bool:
@@ -14,7 +14,7 @@ def opa_available() -> bool:
 OPA_TIMEOUT_SECONDS = 30
 
 
-def eval_policy(bundle_dir: str | Path, input_payload: Dict[str, Any], decision: str) -> Tuple[int, str]:
+def eval_policy(bundle_dir: str | Path, input_payload: dict[str, Any], decision: str) -> tuple[int, str]:
     if not opa_available():
         return 2, "opa CLI not found; skipping policy evaluation"
 

--- a/src/orbital_mission_compiler/schemas.py
+++ b/src/orbital_mission_compiler/schemas.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import List, Optional, Dict, Any
+from typing import Any
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 
@@ -30,14 +30,14 @@ class ExecutionMode(str, Enum):
 class WorkflowStep(BaseModel):
     name: str
     image: str
-    phase: Optional[StepPhase] = None
+    phase: StepPhase | None = None
     resource_class: ResourceClass = ResourceClass.CPU
-    fallback_resource_class: Optional[ResourceClass] = None
+    fallback_resource_class: ResourceClass | None = None
     needs_acceleration: bool = False
-    command: List[str] = Field(default_factory=list)
-    args: List[str] = Field(default_factory=list)
-    metadata: Dict[str, Any] = Field(default_factory=dict)
-    preferred_node_selector: Dict[str, str] = Field(default_factory=dict)
+    command: list[str] = Field(default_factory=list)
+    args: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    preferred_node_selector: dict[str, str] = Field(default_factory=dict)
 
 
 class AIService(BaseModel):
@@ -55,21 +55,21 @@ class AIService(BaseModel):
         le=100,
         description="0-100 scale; ORCHIDE uses 1-4 (see rendering layer for conversion)",
     )
-    landscape_type: Optional[str] = None
+    landscape_type: str | None = None
     execution_mode: ExecutionMode = ExecutionMode.SEQUENTIAL
-    steps: List[WorkflowStep] = Field(min_length=1)
+    steps: list[WorkflowStep] = Field(min_length=1)
 
 
 class MissionEvent(BaseModel):
     timestamp: str
     event_type: MissionEventType
-    orbit: Optional[int] = Field(default=None, ge=0)
-    duration_seconds: Optional[float] = Field(default=None, ge=0)
-    instrument: Optional[str] = None
-    sensor: Optional[str] = None
+    orbit: int | None = Field(default=None, ge=0)
+    duration_seconds: float | None = Field(default=None, ge=0)
+    instrument: str | None = None
+    sensor: str | None = None
     ground_visibility: bool = False
-    region_type: Optional[str] = None
-    services: List[AIService] = Field(default_factory=list)
+    region_type: str | None = None
+    services: list[AIService] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def check_event_constraints(self) -> "MissionEvent":
@@ -94,8 +94,8 @@ class MissionEvent(BaseModel):
 
 class MissionPlan(BaseModel):
     mission_id: str
-    client_id: Optional[str] = None
-    events: List[MissionEvent] = Field(min_length=1)
+    client_id: str | None = None
+    events: list[MissionEvent] = Field(min_length=1)
 
     @field_validator("mission_id")
     @classmethod
@@ -110,5 +110,5 @@ class WorkflowIntent(BaseModel):
     service_id: str
     priority: int
     workflow_name: str
-    steps: List[WorkflowStep]
-    resource_hints: Dict[str, Any] = Field(default_factory=dict)
+    steps: list[WorkflowStep]
+    resource_hints: dict[str, Any] = Field(default_factory=dict)


### PR DESCRIPTION
## Summary
Fix all 5 Phase 4 best practices findings.

| BP | Fix |
|---|---|
| BP-1 | CI `--cov-fail-under=70` |
| BP-3 | `List/Dict/Optional` → `list/dict/X\|None` in schemas, compiler, policy |
| BP-4 | `cli.py main()` uses `args.func(args)` instead of if/elif |
| BP-5 | ruff `target-version` py311 → py310 (matches requires-python) |

BP-2 (Dockerfile digest) already has comment — no further action.

## Test plan
- [x] 142 tests pass
- [x] 3 evals pass
- [x] lint clean