### PR TITLE
Fix #45: formalize live cluster validation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON ?= python3
 PACKAGE = orbital_mission_compiler
 export PYTHONPATH := src:.
 
-.PHONY: verify test lint fmt compile-sample render-samples argo-smoke opa-smoke demo-phase2 eval benchmark print-tree
+.PHONY: verify test lint fmt compile-sample render-samples argo-smoke opa-smoke demo-phase2 eval benchmark print-tree k8s-smoke
 
 verify:
 	$(PYTHON) scripts/verify.py
@@ -36,6 +36,9 @@ eval:
 
 benchmark: ## Run scaling benchmark
 	$(PYTHON) scripts/benchmark_scaling.py
+
+k8s-smoke: ## Live cluster validation (requires K8s + Argo + Kueue)
+	bash scripts/validate_live_cluster.sh
 
 print-tree:
 	find . -maxdepth 3 | sort

--- a/scripts/validate_live_cluster.sh
+++ b/scripts/validate_live_cluster.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# validate_live_cluster.sh — End-to-end live cluster validation.
+# Compiles the validation mission plan through the full pipeline,
+# submits to Argo and Kueue, and reports PASS/FAIL per step.
+set -uo pipefail
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+MISSION_FILE="configs/mission_plans/validation_live_cluster.yaml"
+NAMESPACE="orbital-demo"
+QUEUE="orbital-demo-local"
+OUT_DIR="out/live-validation"
+ARGO_OUT="${OUT_DIR}/argo"
+KUEUE_OUT="${OUT_DIR}/kueue"
+
+PASS=0
+FAIL=0
+
+report() {
+  local status="$1"
+  local label="$2"
+  if [ "${status}" = "PASS" ]; then
+    echo "[PASS] ${label}"
+    PASS=$((PASS + 1))
+  else
+    echo "[FAIL] ${label}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ── Step 1: Check prerequisites ────────────────────────────────────────
+
+echo "=== Checking prerequisites ==="
+
+if command -v kubectl >/dev/null 2>&1; then
+  report PASS "kubectl available"
+else
+  report FAIL "kubectl not found"
+fi
+
+if command -v argo >/dev/null 2>&1; then
+  report PASS "argo CLI available"
+else
+  report FAIL "argo CLI not found"
+fi
+
+# ── Step 2: Check controllers ──────────────────────────────────────────
+
+echo ""
+echo "=== Checking cluster controllers ==="
+
+if kubectl get deployment -n argo workflow-controller >/dev/null 2>&1; then
+  ARGO_READY=$(kubectl get deployment -n argo workflow-controller -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+  if [ "${ARGO_READY}" -ge 1 ] 2>/dev/null; then
+    report PASS "Argo Workflow controller running (${ARGO_READY} replica(s))"
+  else
+    report FAIL "Argo Workflow controller not ready"
+  fi
+else
+  report FAIL "Argo Workflow controller not found"
+fi
+
+if kubectl get deployment -n kueue-system kueue-controller-manager >/dev/null 2>&1; then
+  KUEUE_READY=$(kubectl get deployment -n kueue-system kueue-controller-manager -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+  if [ "${KUEUE_READY}" -ge 1 ] 2>/dev/null; then
+    report PASS "Kueue controller running (${KUEUE_READY} replica(s))"
+  else
+    report FAIL "Kueue controller not ready"
+  fi
+else
+  report FAIL "Kueue controller not found"
+fi
+
+# ── Step 3: Compile mission plan ───────────────────────────────────────
+
+echo ""
+echo "=== Compiling validation mission plan ==="
+
+mkdir -p "${OUT_DIR}"
+
+if PYTHONPATH="${PYTHONPATH:-src}" ${PYTHON_BIN} -m orbital_mission_compiler.cli compile \
+    --input "${MISSION_FILE}" \
+    --output "${OUT_DIR}/compiled.yaml" >/dev/null 2>&1; then
+  report PASS "Mission plan compiled"
+else
+  report FAIL "Mission plan compilation failed"
+fi
+
+# ── Step 4: Render and submit Argo Workflow ────────────────────────────
+
+echo ""
+echo "=== Argo Workflow ==="
+
+mkdir -p "${ARGO_OUT}"
+
+if PYTHONPATH="${PYTHONPATH:-src}" ${PYTHON_BIN} -m orbital_mission_compiler.cli render-argo \
+    --input "${MISSION_FILE}" \
+    --output-dir "${ARGO_OUT}" >/dev/null 2>&1; then
+  report PASS "Argo Workflow rendered"
+else
+  report FAIL "Argo Workflow rendering failed"
+fi
+
+if command -v argo >/dev/null 2>&1; then
+  if argo lint "${ARGO_OUT}"/*.yaml >/dev/null 2>&1; then
+    report PASS "Argo lint passed"
+  else
+    report FAIL "Argo lint failed"
+  fi
+fi
+
+ARGO_FILE=$(find "${ARGO_OUT}" -name '*.yaml' -print -quit 2>/dev/null)
+if [ -n "${ARGO_FILE}" ] && command -v argo >/dev/null 2>&1; then
+  echo "Submitting Argo Workflow to cluster ..."
+  WF_NAME=$(argo submit "${ARGO_FILE}" -n "${NAMESPACE}" -o name 2>&1) || true
+  if [ -n "${WF_NAME}" ]; then
+    report PASS "Argo Workflow submitted: ${WF_NAME}"
+
+    echo "Waiting for Argo Workflow completion (up to 120s) ..."
+    if argo wait "${WF_NAME}" -n "${NAMESPACE}" --timeout 120s >/dev/null 2>&1; then
+      WF_STATUS=$(argo get "${WF_NAME}" -n "${NAMESPACE}" -o json 2>/dev/null | ${PYTHON_BIN} -c "import sys,json; print(json.load(sys.stdin).get('status',{}).get('phase','Unknown'))" 2>/dev/null || echo "Unknown")
+      if [ "${WF_STATUS}" = "Succeeded" ]; then
+        report PASS "Argo Workflow completed: ${WF_STATUS}"
+      else
+        report FAIL "Argo Workflow status: ${WF_STATUS}"
+      fi
+    else
+      report FAIL "Argo Workflow did not complete within timeout"
+    fi
+
+    # Cleanup
+    argo delete "${WF_NAME}" -n "${NAMESPACE}" >/dev/null 2>&1 || true
+  else
+    report FAIL "Argo Workflow submission failed"
+  fi
+else
+  echo "Skipping Argo submission (no rendered file or argo CLI unavailable)"
+fi
+
+# ── Step 5: Render and submit Kueue Job ────────────────────────────────
+
+echo ""
+echo "=== Kueue Job ==="
+
+mkdir -p "${KUEUE_OUT}"
+
+if PYTHONPATH="${PYTHONPATH:-src}" ${PYTHON_BIN} -m orbital_mission_compiler.cli render-kueue \
+    --input "${MISSION_FILE}" \
+    --output-dir "${KUEUE_OUT}" \
+    --queue "${QUEUE}" \
+    --namespace "${NAMESPACE}" >/dev/null 2>&1; then
+  report PASS "Kueue Job rendered"
+else
+  report FAIL "Kueue Job rendering failed"
+fi
+
+JOB_FILE=$(find "${KUEUE_OUT}" -name '*-kueue.yaml' -print -quit 2>/dev/null)
+if [ -n "${JOB_FILE}" ] && command -v kubectl >/dev/null 2>&1; then
+  echo "Submitting Kueue Job to cluster ..."
+  JOB_NAME=$(kubectl create -f "${JOB_FILE}" -o jsonpath='{.metadata.name}' 2>&1) || true
+  if [ -n "${JOB_NAME}" ] && [[ ! "${JOB_NAME}" =~ ^error ]]; then
+    report PASS "Kueue Job submitted: ${JOB_NAME}"
+
+    echo "Checking Kueue admission (up to 60s) ..."
+    ADMITTED="false"
+    for _ in $(seq 1 12); do
+      ADMITTED_STATUS=$(kubectl get workloads -n "${NAMESPACE}" -o jsonpath='{.items[*].status.conditions[?(@.type=="Admitted")].status}' 2>/dev/null || true)
+      if echo "${ADMITTED_STATUS}" | grep -q "True"; then
+        ADMITTED="true"
+        break
+      fi
+      sleep 5
+    done
+
+    if [ "${ADMITTED}" = "true" ]; then
+      report PASS "Kueue admission confirmed"
+    else
+      report FAIL "Kueue admission not confirmed within timeout"
+    fi
+
+    echo "Waiting for Job completion (up to 120s) ..."
+    if kubectl wait --for=condition=complete "job/${JOB_NAME}" -n "${NAMESPACE}" --timeout=120s >/dev/null 2>&1; then
+      report PASS "Kueue Job completed"
+    else
+      report FAIL "Kueue Job did not complete within timeout"
+    fi
+
+    # Cleanup
+    kubectl delete "job/${JOB_NAME}" -n "${NAMESPACE}" --ignore-not-found >/dev/null 2>&1 || true
+  else
+    report FAIL "Kueue Job submission failed"
+  fi
+else
+  echo "Skipping Kueue submission (no rendered file or kubectl unavailable)"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Summary ==="
+echo "PASS: ${PASS}  FAIL: ${FAIL}"
+
+if [ "${FAIL}" -gt 0 ]; then
+  echo "RESULT: FAIL"
+  exit 1
+else
+  echo "RESULT: PASS"
+  exit 0
+fi

--- a/scripts/validate_live_cluster.sh
+++ b/scripts/validate_live_cluster.sh
@@ -94,6 +94,7 @@ fi
 echo ""
 echo "=== Argo Workflow ==="
 
+rm -rf "${ARGO_OUT}"
 mkdir -p "${ARGO_OUT}"
 
 if PYTHONPATH="${PYTHONPATH:-src}" ${PYTHON_BIN} -m orbital_mission_compiler.cli render-argo \
@@ -149,6 +150,7 @@ fi
 echo ""
 echo "=== Kueue Job ==="
 
+rm -rf "${KUEUE_OUT}"
 mkdir -p "${KUEUE_OUT}"
 
 if PYTHONPATH="${PYTHONPATH:-src}" ${PYTHON_BIN} -m orbital_mission_compiler.cli render-kueue \

--- a/scripts/validate_live_cluster.sh
+++ b/scripts/validate_live_cluster.sh
@@ -101,7 +101,7 @@ else
 fi
 
 if command -v argo >/dev/null 2>&1; then
-  if argo lint "${ARGO_OUT}"/*.yaml >/dev/null 2>&1; then
+  if shopt -s nullglob; files=("${ARGO_OUT}"/*.yaml); shopt -u nullglob; if [ ${#files[@]} -eq 0 ]; then echo "[FAIL] No YAML files to lint"; FAIL=1; else argo lint "${files[@]}" >/dev/null 2>&1; then
     report PASS "Argo lint passed"
   else
     report FAIL "Argo lint failed"
@@ -111,7 +111,7 @@ fi
 ARGO_FILE=$(find "${ARGO_OUT}" -name '*.yaml' -print -quit 2>/dev/null)
 if [ -n "${ARGO_FILE}" ] && command -v argo >/dev/null 2>&1; then
   echo "Submitting Argo Workflow to cluster ..."
-  WF_NAME=$(argo submit "${ARGO_FILE}" -n "${NAMESPACE}" -o name 2>&1) || true
+  WF_NAME=$(argo submit "${ARGO_FILE}" -n "${NAMESPACE}" -o name ) || { echo "[FAIL] Submit failed"; FAIL=1; }
   if [ -n "${WF_NAME}" ]; then
     report PASS "Argo Workflow submitted: ${WF_NAME}"
 
@@ -156,14 +156,14 @@ fi
 JOB_FILE=$(find "${KUEUE_OUT}" -name '*-kueue.yaml' -print -quit 2>/dev/null)
 if [ -n "${JOB_FILE}" ] && command -v kubectl >/dev/null 2>&1; then
   echo "Submitting Kueue Job to cluster ..."
-  JOB_NAME=$(kubectl create -f "${JOB_FILE}" -o jsonpath='{.metadata.name}' 2>&1) || true
+  JOB_NAME=$(kubectl create -f "${JOB_FILE}" -o jsonpath='{.metadata.name}' ) || { echo "[FAIL] Submit failed"; FAIL=1; }
   if [ -n "${JOB_NAME}" ] && [[ ! "${JOB_NAME}" =~ ^error ]]; then
     report PASS "Kueue Job submitted: ${JOB_NAME}"
 
     echo "Checking Kueue admission (up to 60s) ..."
     ADMITTED="false"
     for _ in $(seq 1 12); do
-      ADMITTED_STATUS=$(kubectl get workloads -n "${NAMESPACE}" -o jsonpath='{.items[*].status.conditions[?(@.type=="Admitted")].status}' 2>/dev/null || true)
+      ADMITTED_STATUS=$(kubectl get workloads -l job-name -n "${NAMESPACE}" -o jsonpath='{.items[*].status.conditions[?(@.type=="Admitted")].status}' 2>/dev/null || true)
       if echo "${ADMITTED_STATUS}" | grep -q "True"; then
         ADMITTED="true"
         break

--- a/scripts/validate_live_cluster.sh
+++ b/scripts/validate_live_cluster.sh
@@ -48,26 +48,30 @@ fi
 echo ""
 echo "=== Checking cluster controllers ==="
 
-if kubectl get deployment -n argo workflow-controller >/dev/null 2>&1; then
-  ARGO_READY=$(kubectl get deployment -n argo workflow-controller -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-  if [ "${ARGO_READY}" -ge 1 ] 2>/dev/null; then
-    report PASS "Argo Workflow controller running (${ARGO_READY} replica(s))"
+if command -v kubectl >/dev/null 2>&1; then
+  if kubectl get deployment -n argo workflow-controller >/dev/null 2>&1; then
+    ARGO_READY=$(kubectl get deployment -n argo workflow-controller -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+    if [ "${ARGO_READY}" -ge 1 ] 2>/dev/null; then
+      report PASS "Argo Workflow controller running (${ARGO_READY} replica(s))"
+    else
+      report FAIL "Argo Workflow controller not ready"
+    fi
   else
-    report FAIL "Argo Workflow controller not ready"
+    report FAIL "Argo Workflow controller not found"
   fi
-else
-  report FAIL "Argo Workflow controller not found"
-fi
 
-if kubectl get deployment -n kueue-system kueue-controller-manager >/dev/null 2>&1; then
-  KUEUE_READY=$(kubectl get deployment -n kueue-system kueue-controller-manager -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-  if [ "${KUEUE_READY}" -ge 1 ] 2>/dev/null; then
-    report PASS "Kueue controller running (${KUEUE_READY} replica(s))"
+  if kubectl get deployment -n kueue-system kueue-controller-manager >/dev/null 2>&1; then
+    KUEUE_READY=$(kubectl get deployment -n kueue-system kueue-controller-manager -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+    if [ "${KUEUE_READY}" -ge 1 ] 2>/dev/null; then
+      report PASS "Kueue controller running (${KUEUE_READY} replica(s))"
+    else
+      report FAIL "Kueue controller not ready"
+    fi
   else
-    report FAIL "Kueue controller not ready"
+    report FAIL "Kueue controller not found"
   fi
 else
-  report FAIL "Kueue controller not found"
+  echo "Skipping controller checks (kubectl not available)"
 fi
 
 # ── Step 3: Compile mission plan ───────────────────────────────────────
@@ -101,7 +105,12 @@ else
 fi
 
 if command -v argo >/dev/null 2>&1; then
-  if shopt -s nullglob; files=("${ARGO_OUT}"/*.yaml); shopt -u nullglob; if [ ${#files[@]} -eq 0 ]; then echo "[FAIL] No YAML files to lint"; FAIL=1; else argo lint "${files[@]}" >/dev/null 2>&1; then
+  shopt -s nullglob
+  files=("${ARGO_OUT}"/*.yaml)
+  shopt -u nullglob
+  if [ ${#files[@]} -eq 0 ]; then
+    report FAIL "No YAML files to lint"
+  elif argo lint "${files[@]}" >/dev/null 2>&1; then
     report PASS "Argo lint passed"
   else
     report FAIL "Argo lint failed"
@@ -111,8 +120,7 @@ fi
 ARGO_FILE=$(find "${ARGO_OUT}" -name '*.yaml' -print -quit 2>/dev/null)
 if [ -n "${ARGO_FILE}" ] && command -v argo >/dev/null 2>&1; then
   echo "Submitting Argo Workflow to cluster ..."
-  WF_NAME=$(argo submit "${ARGO_FILE}" -n "${NAMESPACE}" -o name ) || { echo "[FAIL] Submit failed"; FAIL=1; }
-  if [ -n "${WF_NAME}" ]; then
+  if WF_NAME=$(argo submit "${ARGO_FILE}" -n "${NAMESPACE}" -o name 2>/dev/null); then
     report PASS "Argo Workflow submitted: ${WF_NAME}"
 
     echo "Waiting for Argo Workflow completion (up to 120s) ..."
@@ -156,14 +164,13 @@ fi
 JOB_FILE=$(find "${KUEUE_OUT}" -name '*-kueue.yaml' -print -quit 2>/dev/null)
 if [ -n "${JOB_FILE}" ] && command -v kubectl >/dev/null 2>&1; then
   echo "Submitting Kueue Job to cluster ..."
-  JOB_NAME=$(kubectl create -f "${JOB_FILE}" -o jsonpath='{.metadata.name}' ) || { echo "[FAIL] Submit failed"; FAIL=1; }
-  if [ -n "${JOB_NAME}" ] && [[ ! "${JOB_NAME}" =~ ^error ]]; then
+  if JOB_NAME=$(kubectl create -f "${JOB_FILE}" -o jsonpath='{.metadata.name}' 2>/dev/null); then
     report PASS "Kueue Job submitted: ${JOB_NAME}"
 
     echo "Checking Kueue admission (up to 60s) ..."
     ADMITTED="false"
     for _ in $(seq 1 12); do
-      ADMITTED_STATUS=$(kubectl get workloads -l job-name -n "${NAMESPACE}" -o jsonpath='{.items[*].status.conditions[?(@.type=="Admitted")].status}' 2>/dev/null || true)
+      ADMITTED_STATUS=$(kubectl get workloads -l "job-name=${JOB_NAME}" -n "${NAMESPACE}" -o jsonpath='{.items[*].status.conditions[?(@.type=="Admitted")].status}' 2>/dev/null || true)
       if echo "${ADMITTED_STATUS}" | grep -q "True"; then
         ADMITTED="true"
         break

--- a/tests/test_live_validation.py
+++ b/tests/test_live_validation.py
@@ -1,0 +1,156 @@
+"""Tests for live cluster validation mission plan.
+
+Validates that the validation_live_cluster.yaml plan loads, compiles,
+and renders valid Argo/Kueue YAML. Optionally runs argo lint if the
+CLI is available. Does NOT submit to a live cluster.
+"""
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from orbital_mission_compiler.compiler import (
+    compile_plan_to_intents,
+    load_mission_plan,
+    render_argo_workflow,
+    render_kueue_job,
+    write_individual_workflows,
+)
+
+VALIDATION_PLAN = "configs/mission_plans/validation_live_cluster.yaml"
+
+ARGO_CLI_AVAILABLE = shutil.which("argo") is not None
+
+
+class TestValidationPlanLoad:
+    """Test that the validation mission plan loads and parses correctly."""
+
+    def test_plan_file_exists(self):
+        assert Path(VALIDATION_PLAN).is_file(), (
+            f"Validation plan not found: {VALIDATION_PLAN}"
+        )
+
+    def test_plan_loads_successfully(self):
+        plan = load_mission_plan(VALIDATION_PLAN)
+        assert plan.mission_id == "validation-live"
+        assert plan.client_id == "paper-validation"
+
+    def test_plan_has_acquisition_event(self):
+        plan = load_mission_plan(VALIDATION_PLAN)
+        acq_events = [e for e in plan.events if e.event_type.value == "acquisition"]
+        assert len(acq_events) >= 1, "Validation plan must have at least one acquisition event"
+
+    def test_plan_uses_cpu_only(self):
+        """Validation plan should use CPU-only to avoid GPU dependency."""
+        plan = load_mission_plan(VALIDATION_PLAN)
+        for event in plan.events:
+            for svc in event.services:
+                for step in svc.steps:
+                    assert step.resource_class.value == "cpu", (
+                        f"Step {step.name!r} uses {step.resource_class.value}, "
+                        "expected cpu for validation plan"
+                    )
+
+
+class TestValidationPlanCompile:
+    """Test that the validation plan compiles to valid workflow intents."""
+
+    def test_compiles_to_intents(self):
+        plan = load_mission_plan(VALIDATION_PLAN)
+        intents = compile_plan_to_intents(plan)
+        assert len(intents) >= 1, "Must produce at least one workflow intent"
+
+    def test_intent_metadata(self):
+        plan = load_mission_plan(VALIDATION_PLAN)
+        intents = compile_plan_to_intents(plan)
+        intent = intents[0]
+        assert intent.mission_id == "validation-live"
+        assert intent.service_id == "ship-detection"
+        assert intent.resource_hints["requires_gpu"] is False
+
+
+class TestValidationArgoRendering:
+    """Test that rendered Argo Workflow YAML is structurally valid."""
+
+    def test_renders_argo_workflow(self):
+        plan = load_mission_plan(VALIDATION_PLAN)
+        intents = compile_plan_to_intents(plan)
+        wf = render_argo_workflow(intents[0])
+        assert wf["apiVersion"] == "argoproj.io/v1alpha1"
+        assert wf["kind"] == "Workflow"
+        assert "spec" in wf
+        assert "entrypoint" in wf["spec"]
+
+    def test_argo_workflow_has_three_steps(self):
+        plan = load_mission_plan(VALIDATION_PLAN)
+        intents = compile_plan_to_intents(plan)
+        wf = render_argo_workflow(intents[0])
+        # main DAG template + 3 step templates = 4 templates total
+        templates = wf["spec"]["templates"]
+        step_templates = [t for t in templates if t["name"] != "main"]
+        assert len(step_templates) == 3, (
+            f"Expected 3 step templates, got {len(step_templates)}"
+        )
+
+    def test_argo_workflow_uses_busybox(self):
+        plan = load_mission_plan(VALIDATION_PLAN)
+        intents = compile_plan_to_intents(plan)
+        wf = render_argo_workflow(intents[0])
+        for tmpl in wf["spec"]["templates"]:
+            if "container" in tmpl:
+                assert tmpl["container"]["image"].startswith("busybox:"), (
+                    f"Validation plan should use busybox, got {tmpl['container']['image']}"
+                )
+
+    def test_write_individual_workflows(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            written = write_individual_workflows(VALIDATION_PLAN, tmpdir)
+            assert len(written) >= 1
+            for path in written:
+                assert path.exists()
+                obj = yaml.safe_load(path.read_text(encoding="utf-8"))
+                assert obj["kind"] == "Workflow"
+
+    @pytest.mark.skipif(
+        not ARGO_CLI_AVAILABLE,
+        reason="argo CLI not available",
+    )
+    def test_argo_lint_passes(self):
+        """Rendered Argo YAML passes official argo lint."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            written = write_individual_workflows(VALIDATION_PLAN, tmpdir)
+            for path in written:
+                result = subprocess.run(
+                    ["argo", "lint", str(path)],
+                    capture_output=True,
+                    text=True,
+                )
+                assert result.returncode == 0, (
+                    f"argo lint failed for {path.name}:\n{result.stderr}"
+                )
+
+
+class TestValidationKueueRendering:
+    """Test that rendered Kueue Job YAML is structurally valid."""
+
+    def test_renders_kueue_job(self):
+        plan = load_mission_plan(VALIDATION_PLAN)
+        intents = compile_plan_to_intents(plan)
+        job = render_kueue_job(intents[0])
+        assert job["apiVersion"] == "batch/v1"
+        assert job["kind"] == "Job"
+
+    def test_kueue_job_no_gpu_resources(self):
+        """CPU-only plan should not request GPU resources."""
+        plan = load_mission_plan(VALIDATION_PLAN)
+        intents = compile_plan_to_intents(plan)
+        job = render_kueue_job(intents[0])
+        pod_spec = job["spec"]["template"]["spec"]
+        assert "nodeSelector" not in pod_spec
+        assert "tolerations" not in pod_spec
+        resources = pod_spec["containers"][0].get("resources", {})
+        assert "nvidia.com/gpu" not in resources.get("requests", {})

--- a/tests/test_live_validation.py
+++ b/tests/test_live_validation.py
@@ -131,7 +131,9 @@ class TestValidationArgoRendering:
                     timeout=30,
                 )
                 assert result.returncode == 0, (
-                    f"argo lint failed for {path.name}:\n{result.stderr}"
+                    f"argo lint failed for {path.name}:\n"
+                    f"stdout:\n{result.stdout}\n"
+                    f"stderr:\n{result.stderr}"
                 )
 
 

--- a/tests/test_live_validation.py
+++ b/tests/test_live_validation.py
@@ -128,6 +128,7 @@ class TestValidationArgoRendering:
                     ["argo", "lint", str(path)],
                     capture_output=True,
                     text=True,
+                    timeout=30,
                 )
                 assert result.returncode == 0, (
                     f"argo lint failed for {path.name}:\n{result.stderr}"


### PR DESCRIPTION
## Summary
- Add `scripts/validate_live_cluster.sh` for end-to-end K8s smoke testing
- Checks Argo controller + Kueue controller availability
- Compiles, submits Argo Workflow, checks Kueue admission
- Add `make k8s-smoke` target
- Add 13 tests for validation plan compilation and rendering

## Test plan
- [x] Validation plan loads and has correct structure
- [x] Compiles to intents with correct metadata
- [x] Rendered Argo YAML has valid structure with 3 step templates
- [x] Rendered Kueue Job has valid structure without GPU resources
- [x] argo lint passes (skipped if CLI unavailable)
- [x] All 184 tests pass, 3 skipped

Closes #45