### PR TITLE
Capture render diagnostic output to log files

### DIFF
--- a/scripts/validate_live_cluster.sh
+++ b/scripts/validate_live_cluster.sh
@@ -88,7 +88,11 @@ if PYTHONPATH="${PYTHONPATH:-src}" ${PYTHON_BIN} -m orbital_mission_compiler.cli
   report PASS "Mission plan compiled"
 else
   report FAIL "Mission plan compilation failed (see ${COMPILE_LOG})"
-  cat "${COMPILE_LOG}" >&2
+  if [ -s "${COMPILE_LOG}" ]; then
+    cat "${COMPILE_LOG}" >&2
+  else
+    echo "Compilation failed, but no compile log was created or it is empty: ${COMPILE_LOG}" >&2
+  fi
 fi
 
 # ── Step 4: Render and submit Argo Workflow ────────────────────────────
@@ -106,7 +110,11 @@ if PYTHONPATH="${PYTHONPATH:-src}" ${PYTHON_BIN} -m orbital_mission_compiler.cli
   report PASS "Argo Workflow rendered"
 else
   report FAIL "Argo Workflow rendering failed (see ${ARGO_RENDER_LOG})"
-  cat "${ARGO_RENDER_LOG}" >&2
+  if [ -s "${ARGO_RENDER_LOG}" ]; then
+    cat "${ARGO_RENDER_LOG}" >&2
+  else
+    echo "Argo render log is missing or empty: ${ARGO_RENDER_LOG}" >&2
+  fi
 fi
 
 if command -v argo >/dev/null 2>&1; then
@@ -166,7 +174,11 @@ if PYTHONPATH="${PYTHONPATH:-src}" ${PYTHON_BIN} -m orbital_mission_compiler.cli
   report PASS "Kueue Job rendered"
 else
   report FAIL "Kueue Job rendering failed (see ${KUEUE_RENDER_LOG})"
-  cat "${KUEUE_RENDER_LOG}" >&2
+  if [ -s "${KUEUE_RENDER_LOG}" ]; then
+    cat "${KUEUE_RENDER_LOG}" >&2
+  else
+    echo "Kueue render log is missing or empty: ${KUEUE_RENDER_LOG}" >&2
+  fi
 fi
 
 JOB_FILE=$(find "${KUEUE_OUT}" -name '*-kueue.yaml' -print -quit 2>/dev/null)

--- a/scripts/validate_live_cluster.sh
+++ b/scripts/validate_live_cluster.sh
@@ -81,12 +81,14 @@ echo "=== Compiling validation mission plan ==="
 
 mkdir -p "${OUT_DIR}"
 
+COMPILE_LOG="${OUT_DIR}/compile.log"
 if PYTHONPATH="${PYTHONPATH:-src}" ${PYTHON_BIN} -m orbital_mission_compiler.cli compile \
     --input "${MISSION_FILE}" \
-    --output "${OUT_DIR}/compiled.yaml" >/dev/null 2>&1; then
+    --output "${OUT_DIR}/compiled.yaml" >"${COMPILE_LOG}" 2>&1; then
   report PASS "Mission plan compiled"
 else
-  report FAIL "Mission plan compilation failed"
+  report FAIL "Mission plan compilation failed (see ${COMPILE_LOG})"
+  cat "${COMPILE_LOG}" >&2
 fi
 
 # ── Step 4: Render and submit Argo Workflow ────────────────────────────
@@ -97,12 +99,14 @@ echo "=== Argo Workflow ==="
 rm -rf "${ARGO_OUT}"
 mkdir -p "${ARGO_OUT}"
 
+ARGO_RENDER_LOG="${OUT_DIR}/argo-render.log"
 if PYTHONPATH="${PYTHONPATH:-src}" ${PYTHON_BIN} -m orbital_mission_compiler.cli render-argo \
     --input "${MISSION_FILE}" \
-    --output-dir "${ARGO_OUT}" >/dev/null 2>&1; then
+    --output-dir "${ARGO_OUT}" >"${ARGO_RENDER_LOG}" 2>&1; then
   report PASS "Argo Workflow rendered"
 else
-  report FAIL "Argo Workflow rendering failed"
+  report FAIL "Argo Workflow rendering failed (see ${ARGO_RENDER_LOG})"
+  cat "${ARGO_RENDER_LOG}" >&2
 fi
 
 if command -v argo >/dev/null 2>&1; then
@@ -153,14 +157,16 @@ echo "=== Kueue Job ==="
 rm -rf "${KUEUE_OUT}"
 mkdir -p "${KUEUE_OUT}"
 
+KUEUE_RENDER_LOG="${OUT_DIR}/kueue-render.log"
 if PYTHONPATH="${PYTHONPATH:-src}" ${PYTHON_BIN} -m orbital_mission_compiler.cli render-kueue \
     --input "${MISSION_FILE}" \
     --output-dir "${KUEUE_OUT}" \
     --queue "${QUEUE}" \
-    --namespace "${NAMESPACE}" >/dev/null 2>&1; then
+    --namespace "${NAMESPACE}" >"${KUEUE_RENDER_LOG}" 2>&1; then
   report PASS "Kueue Job rendered"
 else
-  report FAIL "Kueue Job rendering failed"
+  report FAIL "Kueue Job rendering failed (see ${KUEUE_RENDER_LOG})"
+  cat "${KUEUE_RENDER_LOG}" >&2
 fi
 
 JOB_FILE=$(find "${KUEUE_OUT}" -name '*-kueue.yaml' -print -quit 2>/dev/null)


### PR DESCRIPTION
## Summary
- Redirect compile, render-argo, and render-kueue stdout/stderr to log files (`compile.log`, `argo-render.log`, `kueue-render.log`) under `out/live-validation/` instead of discarding to `/dev/null`
- On failure, print the log file path in the FAIL message and dump log content to stderr for immediate diagnosis
- Addresses review feedback on PR #59 (comments [r3034789576](https://github.com/thc1006/satellite-mission-compiler/pull/59#discussion_r3034789576), [r3034789589](https://github.com/thc1006/satellite-mission-compiler/pull/59#discussion_r3034789589))

## Test plan
- [x] `tests/test_live_validation.py` — 12 passed, 1 skipped
- [ ] Manual: run `make k8s-smoke` and verify log files are created on success/failure