### PR TITLE
Fix #51: ORCHIDE schema traceability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This is not a flight-ready onboard satellite runtime. It does not implement radi
 git clone https://github.com/thc1006/satellite-mission-compiler.git
 cd satellite-mission-compiler
 pip install -e ".[dev]"
-make test        # 155 tests
+make test        # 230 tests
 make eval        # 3 golden translation checks
 make opa-smoke   # OPA policy evaluation (requires opa CLI)
 make argo-smoke  # Argo manifest lint (requires argo CLI)

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ This is not a flight-ready onboard satellite runtime. It does not implement radi
 git clone https://github.com/thc1006/satellite-mission-compiler.git
 cd satellite-mission-compiler
 pip install -e ".[dev]"
-make test        # 230 tests
-make eval        # 3 golden translation checks
+make test        # run the test suite
+make eval        # run golden translation checks
 make opa-smoke   # OPA policy evaluation (requires opa CLI)
 make argo-smoke  # Argo manifest lint (requires argo CLI)
 ```

--- a/docs/14_traceability_matrix.md
+++ b/docs/14_traceability_matrix.md
@@ -79,18 +79,18 @@ Each field in the Pydantic schema models is mapped to its ORCHIDE source (or mar
 
 Each deny rule in `configs/policies/mission_plan.rego` is mapped to its ORCHIDE source or marked as Author-Imposed. Rules are numbered 1–10 matching the Rego file order.
 
-| Rule # | Deny Message | ORCHIDE Source | Slide / D3.1 Ref | Test Case | Author-Imposed? |
+| Rule # | Deny Message (exact Rego `msg`) | ORCHIDE Source | Slide / D3.1 Ref | Test Case | Author-Imposed? |
 |---|---|---|---|---|---|
 | 1 | `mission_id must not be empty` | Structural requirement for plan identity | D3.1 §3.3.1 | `test_policy.py::test_deny_empty_mission_id` | **Yes** — ORCHIDE does not specify validation rules |
 | 2 | `mission plan must contain at least one event` | Structural requirement | — | `test_policy.py::test_deny_zero_events` | **Yes** — structural guard |
 | 3 | `acquisition event %v must declare at least one service` | ACQ rows have WORKFLOW columns | Slide 9 | `test_policy.py::test_deny_acquisition_no_services` | No — derived from slide 9 table structure |
-| 4 | `GPU step %q should declare fallback_resource_class` | — | — | `test_policy.py::test_deny_gpu_no_fallback` | **Yes** — ground-side reliability for local demo |
-| 5 | `service %q has zero priority` | Priorities are 1-4 in ORCHIDE; 0 is misconfiguration | Slide 9 (PRIORITY columns) | `test_policy.py::test_deny_zero_priority` | No — derived from slide 9 priority semantics |
-| 6 | `step %q claims needs_acceleration but uses cpu` | ukAccel mediates GPU/FPGA only; CPU is host | Slide 18 | `test_policy.py::test_deny_acceleration_on_cpu` | No — derived from slide 18 ukAccel scope |
-| 7 | `download event %v must not declare services` | DOWNLOAD rows have no WORKFLOW columns | Slide 9 | `test_policy.py::test_deny_download_with_services` | No — derived from slide 9 table structure |
-| 8 | `download event %v requires ground_visibility` | DOWNLOAD requires VISI=1 | Slide 9 | `test_policy.py::test_deny_download_without_visibility` | No — derived from slide 9 VISI column |
-| 9 | `service %q has no steps` | Pipeline requires ≥1 stage | Slide 10 | `test_policy.py` (implicit via schema min_length=1) | No — derived from slide 10 pipeline model |
-| 10 | `service %q has unrecognized landscape_type` | TYPE = O (ocean) or L (land) | Slide 9 (TYPE_D1-D4) | `test_policy.py` | No — derived from slide 9 TYPE column |
+| 4 | `GPU step %q should declare fallback_resource_class for local demo reliability` | — | — | `test_policy.py::test_deny_gpu_no_fallback` | **Yes** — ground-side reliability; rule requires `resource_class == "gpu"` AND `needs_acceleration == true` AND no `fallback_resource_class` |
+| 5 | `service %q has zero priority, which is likely a misconfiguration` | Priorities are 1-4 in ORCHIDE; 0 is misconfiguration | Slide 9 (PRIORITY columns) | `test_policy.py::test_deny_zero_priority` | No — derived from slide 9 priority semantics |
+| 6 | `step %q claims needs_acceleration but uses cpu resource class` | ukAccel mediates GPU/FPGA only; CPU is host | Slide 18 | `test_policy.py::test_deny_acceleration_on_cpu` | No — derived from slide 18 ukAccel scope |
+| 7 | `download event %v must not declare services (transmission only)` | DOWNLOAD rows have no WORKFLOW columns | Slide 9 | `test_policy.py::test_deny_download_with_services` | No — derived from slide 9 table structure |
+| 8 | `download event %v requires ground_visibility (station must be visible for transmission)` | DOWNLOAD requires VISI=1 | Slide 9 | `test_policy.py::test_deny_download_without_visibility` | No — derived from slide 9 VISI column |
+| 9 | `service %q has no steps and cannot produce a workflow` | Pipeline requires ≥1 stage | Slide 10 | `test_policy.py` (implicit via schema min_length=1) | No — derived from slide 10 pipeline model |
+| 10 | `service %q has unrecognized landscape_type %q (expected: ocean, land)` | TYPE = O (ocean) or L (land) | Slide 9 (TYPE_D1-D4) | `test_policy.py` | No — derived from slide 9 TYPE column |
 
 ### Policy Layering Note
 
@@ -139,11 +139,13 @@ The following features are explicitly added by this project to fill gaps that OR
 
 | Dimension | Total Items | ORCHIDE-Derived | Author-Imposed | Coverage |
 |---|---|---|---|---|
-| Schema fields (all models) | 28 | 21 | 7 | 100% traced |
+| Schema fields (4 mission-plan models) | 27 | 21 | 6 | 100% traced |
 | Enum values | 11 | 11 | 0 | 100% traced |
 | OPA deny rules | 10 | 7 | 3 | 100% traced |
 | Resource hints keys | 10 | 7 | 3 | 100% traced |
-| **Total** | **59** | **46 (78%)** | **13 (22%)** | **100% traced** |
+| **Total** | **58** | **46 (79%)** | **12 (21%)** | **100% traced** |
+
+Note: this summary counts the four mission-plan schema models (`MissionPlan`, `MissionEvent`, `AIService`, `WorkflowStep`) and excludes the internal `WorkflowIntent` compiler IR model.
 
 ---
 

--- a/docs/14_traceability_matrix.md
+++ b/docs/14_traceability_matrix.md
@@ -1,0 +1,164 @@
+# 14 — ORCHIDE Schema Traceability Matrix
+
+> Formal bidirectional traceability mapping for the ground-side mission plan compiler.
+> Addresses IEEE SMC-IT/SCC 2026 reviewer feedback: R1 Major #6, R2 Major #5, R3 Major #5.
+>
+> **Format**: Aligned with ISO/IEC/IEEE 29148:2018 RTM and ECSS-E-ST-40C Rev.1 bidirectional traceability requirements.
+>
+> **Primary sources**:
+> - KubeCon EU 2026 slides: "Bringing Cloud-Native PaaS to Space" (36 pages)
+> - ORCHIDE D3.1: Overall Solution Architecture and Design (July 2024)
+> - ORCHIDE D2.2: State of the Art (May 2024)
+> - See `docs/00_transcript_grounding.md` for full source attribution.
+
+---
+
+## 1. Schema Field Traceability
+
+Each field in the Pydantic schema models is mapped to its ORCHIDE source (or marked as **Author-Imposed** when the field is a ground-side addition not present in ORCHIDE documentation).
+
+### 1.1 MissionPlan
+
+| Field | ORCHIDE Source | Slide / D3.1 Ref | Implementation | Test Case | Author-Imposed? |
+|---|---|---|---|---|---|
+| `mission_id` | Plan identifier deployed by Satellite Owner | D3.1 §3.3.1 (IF SO_MIS_DP) | `schemas.py:95` | `test_schema.py`, `test_policy.py` | No |
+| `client_id` | — | — | `schemas.py:97` | `test_schema.py` | **Yes** — ground-side attribution for multi-tenant scenarios |
+| `events` | Mission plan table rows | Slide 9 (plan table) | `schemas.py:98` | `test_schema.py`, `test_schema_negative.py` | No |
+
+### 1.2 MissionEvent
+
+| Field | ORCHIDE Source | Slide / D3.1 Ref | Implementation | Test Case | Author-Imposed? |
+|---|---|---|---|---|---|
+| `timestamp` | DATESZ column | Slide 9 | `schemas.py:64` | `test_schema.py` | No |
+| `event_type` | EV column (ACQ / DOWNLOAD) | Slide 9 | `schemas.py:65` | `test_schema.py`, `test_schema_negative.py` | No |
+| `orbit` | ORBIT column | Slide 9 | `schemas.py:66` | `test_schema.py`, `test_ir.py` | No |
+| `duration_seconds` | DT_EV column (transmission window) | Slide 9 | `schemas.py:67` | `test_schema.py`, `test_ir.py` | No |
+| `instrument` | INST column | Slide 9 | `schemas.py:68` | `test_schema.py`, `test_schema_negative.py` | No |
+| `sensor` | — | — | `schemas.py:69` | `test_schema.py` | **Yes** — alias/supplement to instrument for ground-side flexibility |
+| `ground_visibility` | VISI column (1 = visible) | Slide 9 | `schemas.py:70` | `test_schema.py`, `test_policy.py` | No |
+| `region_type` | — | — | `schemas.py:71` | `test_schema.py` | **Yes** — contextual metadata (ocean, land, etc.) for ground-side filtering |
+| `services` | WORKFLOW_D1-D4 columns | Slide 9 | `schemas.py:72` | `test_schema.py`, `test_policy.py` | No |
+
+### 1.3 AIService
+
+| Field | ORCHIDE Source | Slide / D3.1 Ref | Implementation | Test Case | Author-Imposed? |
+|---|---|---|---|---|---|
+| `service_id` | Detector/service identifier (MS, FD, CD) | Slide 9, Slide 10 | `schemas.py:52` | `test_schema.py`, `test_ir.py` | No |
+| `priority` | PRIORITY_D1-D4 columns | Slide 9 | `schemas.py:53-57` | `test_schema.py`, `test_policy.py` | No (scale divergence: ORCHIDE 1-4 vs schema 0-100; rendering layer converts) |
+| `landscape_type` | TYPE_D1-D4 columns (O=ocean, L=land) | Slide 9 | `schemas.py:58` | `test_schema.py`, `test_ir.py`, `test_policy.py` | No |
+| `execution_mode` | "sequential or in parallel" | Slide 10 | `schemas.py:59` | `test_schema.py`, `test_ir.py`, `test_parallel_rendering.py` | No |
+| `steps` | AI service pipeline stages | Slide 10 | `schemas.py:60` | `test_schema.py`, `test_rendering.py` | No |
+
+### 1.4 WorkflowStep
+
+| Field | ORCHIDE Source | Slide / D3.1 Ref | Implementation | Test Case | Author-Imposed? |
+|---|---|---|---|---|---|
+| `name` | Pipeline stage name | Slide 10 | `schemas.py:31` | `test_schema.py`, `test_rendering.py` | No |
+| `image` | OCI container image | Slide 10, D3.1 §5.1 | `schemas.py:32` | `test_schema.py`, `test_rendering.py` | No |
+| `phase` | Pre-processing / AI / Post-processing | Slide 10 | `schemas.py:33` | `test_rendering.py` | No |
+| `resource_class` | Hardware target (CPU/GPU/FPGA) | Slide 14 | `schemas.py:34` | `test_schema.py`, `test_kueue.py` | No |
+| `fallback_resource_class` | — | — | `schemas.py:35` | `test_policy.py` | **Yes** — ground-side reliability for local demo when primary hardware unavailable |
+| `needs_acceleration` | ukAccel accelerator mediation | Slide 18 | `schemas.py:36` | `test_policy.py` | No |
+| `command` | Application entry point | D3.1 §5.1 | `schemas.py:37` | `test_schema.py` | No |
+| `args` | Command arguments | D3.1 §5.1 | `schemas.py:38` | `test_schema.py` | No |
+| `metadata` | — | — | `schemas.py:39` | `test_schema.py` | **Yes** — free-form annotations for ground-side tooling |
+| `preferred_node_selector` | — | — | `schemas.py:40` | `test_schema.py` | **Yes** — Kubernetes node affinity labels for ground-side scheduling |
+
+### 1.5 Enums
+
+| Enum | Values | ORCHIDE Source | Slide / D3.1 Ref |
+|---|---|---|---|
+| `ResourceClass` | `cpu`, `gpu`, `fpga` | Heterogeneous hardware classes | Slide 14 (ARM64 LX2160, Jetson Xavier/Orin, Versal/Ultrascale) |
+| `MissionEventType` | `acquisition`, `download` | EV column categories | Slide 9 (ACQ, DOWNLOAD) |
+| `StepPhase` | `preprocessing`, `ai`, `postprocessing` | 3-stage AI pipeline | Slide 10 (Pre-processing → AI → Post-processing) |
+| `ExecutionMode` | `sequential`, `parallel` | Application launch mode | Slide 10 ("sequentially or in parallel") |
+
+---
+
+## 2. OPA Policy Rule Traceability
+
+Each deny rule in `configs/policies/mission_plan.rego` is mapped to its ORCHIDE source or marked as Author-Imposed. Rules are numbered 1–10 matching the Rego file order.
+
+| Rule # | Deny Message | ORCHIDE Source | Slide / D3.1 Ref | Test Case | Author-Imposed? |
+|---|---|---|---|---|---|
+| 1 | `mission_id must not be empty` | Structural requirement for plan identity | D3.1 §3.3.1 | `test_policy.py::test_deny_empty_mission_id` | **Yes** — ORCHIDE does not specify validation rules |
+| 2 | `mission plan must contain at least one event` | Structural requirement | — | `test_policy.py::test_deny_zero_events` | **Yes** — structural guard |
+| 3 | `acquisition event %v must declare at least one service` | ACQ rows have WORKFLOW columns | Slide 9 | `test_policy.py::test_deny_acquisition_no_services` | No — derived from slide 9 table structure |
+| 4 | `GPU step %q should declare fallback_resource_class` | — | — | `test_policy.py::test_deny_gpu_no_fallback` | **Yes** — ground-side reliability for local demo |
+| 5 | `service %q has zero priority` | Priorities are 1-4 in ORCHIDE; 0 is misconfiguration | Slide 9 (PRIORITY columns) | `test_policy.py::test_deny_zero_priority` | No — derived from slide 9 priority semantics |
+| 6 | `step %q claims needs_acceleration but uses cpu` | ukAccel mediates GPU/FPGA only; CPU is host | Slide 18 | `test_policy.py::test_deny_acceleration_on_cpu` | No — derived from slide 18 ukAccel scope |
+| 7 | `download event %v must not declare services` | DOWNLOAD rows have no WORKFLOW columns | Slide 9 | `test_policy.py::test_deny_download_with_services` | No — derived from slide 9 table structure |
+| 8 | `download event %v requires ground_visibility` | DOWNLOAD requires VISI=1 | Slide 9 | `test_policy.py::test_deny_download_without_visibility` | No — derived from slide 9 VISI column |
+| 9 | `service %q has no steps` | Pipeline requires ≥1 stage | Slide 10 | `test_policy.py` (implicit via schema min_length=1) | No — derived from slide 10 pipeline model |
+| 10 | `service %q has unrecognized landscape_type` | TYPE = O (ocean) or L (land) | Slide 9 (TYPE_D1-D4) | `test_policy.py` | No — derived from slide 9 TYPE column |
+
+### Policy Layering Note
+
+Rules 3, 7, 8, and 9 intentionally overlap with Pydantic schema validators for defense-in-depth. Schema catches structural errors at parse time; OPA catches semantic errors when data bypasses schema validation (e.g., raw JSON sent directly to OPA). See `docs/04_architecture.md` for the full validation layering table.
+
+---
+
+## 3. Resource Hints Traceability
+
+Each key in the `resource_hints` dictionary (built in `compiler.py:compile_plan_to_intents`) is mapped to its derivation source.
+
+| Hint Key | Derivation | Source Field | Slide / D3.1 Ref | Author-Imposed? |
+|---|---|---|---|---|
+| `event_timestamp` | Direct passthrough | `MissionEvent.timestamp` | Slide 9 (DATESZ) | No |
+| `ground_visibility` | Direct passthrough | `MissionEvent.ground_visibility` | Slide 9 (VISI) | No |
+| `region_type` | Direct passthrough | `MissionEvent.region_type` | — | **Yes** — contextual metadata |
+| `orbit` | Direct passthrough | `MissionEvent.orbit` | Slide 9 (ORBIT) | No |
+| `duration_seconds` | Direct passthrough | `MissionEvent.duration_seconds` | Slide 9 (DT_EV) | No |
+| `landscape_type` | Direct passthrough | `AIService.landscape_type` | Slide 9 (TYPE_D1-D4) | No |
+| `execution_mode` | Enum `.value` passthrough | `AIService.execution_mode` | Slide 10 | No |
+| `requires_gpu` | Derived: `bool(steps where resource_class == GPU)` | `WorkflowStep.resource_class` | Slide 14 | **Yes** — derived boolean for downstream schedulers |
+| `requires_fpga` | Derived: `bool(steps where resource_class == FPGA)` | `WorkflowStep.resource_class` | Slide 14 | **Yes** — derived boolean for downstream schedulers |
+| `fallback_enabled` | Derived: `bool(steps where fallback_resource_class != None)` | `WorkflowStep.fallback_resource_class` | — | **Yes** — derived boolean for fallback-aware renderers |
+
+---
+
+## 4. Ground-Side Additions Rationale (Author-Imposed)
+
+The following features are explicitly added by this project to fill gaps that ORCHIDE leaves open (see `docs/00_transcript_grounding.md`, section "What the sources do NOT specify"):
+
+| Addition | Location | Rationale |
+|---|---|---|
+| Pydantic schema validation | `schemas.py` | ORCHIDE does not specify how mission plans are validated before reaching the satellite |
+| OPA/Rego policy framework | `configs/policies/mission_plan.rego`, `policy.py` | ORCHIDE has no policy-as-code; this adds 10 deny rules for semantic validation |
+| Kueue admission control | `compiler.py:render_kueue_job` | ORCHIDE uses a custom priority queue; this adds Kubernetes-native admission via Kueue |
+| CLI tool | `cli.py` | ORCHIDE's translation layer is embedded glue code; this extracts a standalone CLI |
+| MCP server | `mcp/server.py` | ORCHIDE has no AI agent interface; this adds 6 MCP tools for ground-side agents |
+| Fallback resource class | `schemas.py:fallback_resource_class` | ORCHIDE has no fallback strategy; ground-side demo reliability |
+| Timeline conflict detection | `compiler.py:detect_timeline_conflicts` | ORCHIDE has no timeline feasibility check; ground-side planning tool |
+| Resource hints enrichment | `compiler.py` (resource_hints dict) | ORCHIDE does not carry extended event metadata through IR; enriched for downstream schedulers |
+| Golden eval runner | `eval_runner.py`, `evals/golden/` | ORCHIDE has no ground-side evaluation framework; deterministic translation tests |
+
+---
+
+## 5. Coverage Summary
+
+| Dimension | Total Items | ORCHIDE-Derived | Author-Imposed | Coverage |
+|---|---|---|---|---|
+| Schema fields (all models) | 28 | 21 | 7 | 100% traced |
+| Enum values | 11 | 11 | 0 | 100% traced |
+| OPA deny rules | 10 | 7 | 3 | 100% traced |
+| Resource hints keys | 10 | 7 | 3 | 100% traced |
+| **Total** | **59** | **46 (78%)** | **13 (22%)** | **100% traced** |
+
+---
+
+## 6. ORCHIDE Slide / D3.1 Cross-Reference Index
+
+For quick lookup, the following ORCHIDE slides and D3.1 sections are referenced in this traceability matrix:
+
+| Source | Content | Referenced By |
+|---|---|---|
+| Slide 9 | Mission plan table format (DATESZ, ORBIT, EV, INST, TYPE, VISI, WORKFLOW, PRIORITY) | MissionEvent fields, AIService fields, OPA rules 3/5/7/8/10 |
+| Slide 10 | AI service pipeline (Pre-processing → AI → Post-processing, sequential/parallel) | StepPhase, ExecutionMode, AIService.steps, OPA rule 9 |
+| Slide 14 | Heterogeneous hardware (Jetson, Versal, LX2160, Kalray) | ResourceClass, resource_hints requires_gpu/requires_fpga |
+| Slide 18 | ukAccel accelerator mediation (TCP-based, vAccel-derived) | needs_acceleration, OPA rule 6 |
+| Slide 23 | Custom Translation Layer (Mission Plan → Argo workflow) | WorkflowIntent, compile_plan_to_intents, render_argo_workflow |
+| D3.1 §3.2.1.1 | Mission Manager receives and processes mission plan | load_mission_plan |
+| D3.1 §3.2.1.1.2 | Mission Planner determines appropriate service | compile_plan_to_intents (ACQ event filtering) |
+| D3.1 §3.3.1 | Interface IF SO_MIS_DP (Satellite Owner deploys plan) | mission_id identity |
+| D3.1 §5.1 | Application Builder / OCI image deployment | WorkflowStep.image, command, args |

--- a/docs/14_traceability_matrix.md
+++ b/docs/14_traceability_matrix.md
@@ -21,48 +21,48 @@ Each field in the Pydantic schema models is mapped to its ORCHIDE source (or mar
 
 | Field | ORCHIDE Source | Slide / D3.1 Ref | Implementation | Test Case | Author-Imposed? |
 |---|---|---|---|---|---|
-| `mission_id` | Plan identifier deployed by Satellite Owner | D3.1 §3.3.1 (IF SO_MIS_DP) | `schemas.py:95` | `test_schema.py`, `test_policy.py` | No |
-| `client_id` | — | — | `schemas.py:97` | `test_schema.py` | **Yes** — ground-side attribution for multi-tenant scenarios |
-| `events` | Mission plan table rows | Slide 9 (plan table) | `schemas.py:98` | `test_schema.py`, `test_schema_negative.py` | No |
+| `mission_id` | Plan identifier deployed by Satellite Owner | D3.1 §3.3.1 (IF SO_MIS_DP) | `src/orbital_mission_compiler/schemas.py:95` | `test_schema.py`, `test_policy.py` | No |
+| `client_id` | — | — | `src/orbital_mission_compiler/schemas.py:97` | `test_schema.py` | **Yes** — ground-side attribution for multi-tenant scenarios |
+| `events` | Mission plan table rows | Slide 9 (plan table) | `src/orbital_mission_compiler/schemas.py:98` | `test_schema.py`, `test_schema_negative.py` | No |
 
 ### 1.2 MissionEvent
 
 | Field | ORCHIDE Source | Slide / D3.1 Ref | Implementation | Test Case | Author-Imposed? |
 |---|---|---|---|---|---|
-| `timestamp` | DATESZ column | Slide 9 | `schemas.py:64` | `test_schema.py` | No |
-| `event_type` | EV column (ACQ / DOWNLOAD) | Slide 9 | `schemas.py:65` | `test_schema.py`, `test_schema_negative.py` | No |
-| `orbit` | ORBIT column | Slide 9 | `schemas.py:66` | `test_schema.py`, `test_ir.py` | No |
-| `duration_seconds` | DT_EV column (transmission window) | Slide 9 | `schemas.py:67` | `test_schema.py`, `test_ir.py` | No |
-| `instrument` | INST column | Slide 9 | `schemas.py:68` | `test_schema.py`, `test_schema_negative.py` | No |
-| `sensor` | — | — | `schemas.py:69` | `test_schema.py` | **Yes** — alias/supplement to instrument for ground-side flexibility |
-| `ground_visibility` | VISI column (1 = visible) | Slide 9 | `schemas.py:70` | `test_schema.py`, `test_policy.py` | No |
-| `region_type` | — | — | `schemas.py:71` | `test_schema.py` | **Yes** — contextual metadata (ocean, land, etc.) for ground-side filtering |
-| `services` | WORKFLOW_D1-D4 columns | Slide 9 | `schemas.py:72` | `test_schema.py`, `test_policy.py` | No |
+| `timestamp` | DATESZ column | Slide 9 | `src/orbital_mission_compiler/schemas.py:64` | `test_schema.py` | No |
+| `event_type` | EV column (ACQ / DOWNLOAD) | Slide 9 | `src/orbital_mission_compiler/schemas.py:65` | `test_schema.py`, `test_schema_negative.py` | No |
+| `orbit` | ORBIT column | Slide 9 | `src/orbital_mission_compiler/schemas.py:66` | `test_schema.py`, `test_ir.py` | No |
+| `duration_seconds` | DT_EV column (transmission window) | Slide 9 | `src/orbital_mission_compiler/schemas.py:67` | `test_schema.py`, `test_ir.py` | No |
+| `instrument` | INST column | Slide 9 | `src/orbital_mission_compiler/schemas.py:68` | `test_schema.py`, `test_schema_negative.py` | No |
+| `sensor` | — | — | `src/orbital_mission_compiler/schemas.py:69` | `test_schema.py` | **Yes** — alias/supplement to instrument for ground-side flexibility |
+| `ground_visibility` | VISI column (1 = visible) | Slide 9 | `src/orbital_mission_compiler/schemas.py:70` | `test_schema.py`, `test_policy.py` | No |
+| `region_type` | — | — | `src/orbital_mission_compiler/schemas.py:71` | `test_schema.py` | **Yes** — contextual metadata (ocean, land, etc.) for ground-side filtering |
+| `services` | WORKFLOW_D1-D4 columns | Slide 9 | `src/orbital_mission_compiler/schemas.py:72` | `test_schema.py`, `test_policy.py` | No |
 
 ### 1.3 AIService
 
 | Field | ORCHIDE Source | Slide / D3.1 Ref | Implementation | Test Case | Author-Imposed? |
 |---|---|---|---|---|---|
-| `service_id` | Detector/service identifier (MS, FD, CD) | Slide 9, Slide 10 | `schemas.py:52` | `test_schema.py`, `test_ir.py` | No |
-| `priority` | PRIORITY_D1-D4 columns | Slide 9 | `schemas.py:53-57` | `test_schema.py`, `test_policy.py` | No (scale divergence: ORCHIDE 1-4 vs schema 0-100; rendering layer converts) |
-| `landscape_type` | TYPE_D1-D4 columns (O=ocean, L=land) | Slide 9 | `schemas.py:58` | `test_schema.py`, `test_ir.py`, `test_policy.py` | No |
-| `execution_mode` | "sequential or in parallel" | Slide 10 | `schemas.py:59` | `test_schema.py`, `test_ir.py`, `test_parallel_rendering.py` | No |
-| `steps` | AI service pipeline stages | Slide 10 | `schemas.py:60` | `test_schema.py`, `test_rendering.py` | No |
+| `service_id` | Detector/service identifier (MS, FD, CD) | Slide 9, Slide 10 | `src/orbital_mission_compiler/schemas.py:52` | `test_schema.py`, `test_ir.py` | No |
+| `priority` | PRIORITY_D1-D4 columns | Slide 9 | `src/orbital_mission_compiler/schemas.py:53-57` | `test_schema.py`, `test_policy.py` | No (scale divergence: ORCHIDE 1-4 vs schema 0-100; rendering layer converts) |
+| `landscape_type` | TYPE_D1-D4 columns (O=ocean, L=land) | Slide 9 | `src/orbital_mission_compiler/schemas.py:58` | `test_schema.py`, `test_ir.py`, `test_policy.py` | No |
+| `execution_mode` | "sequential or in parallel" | Slide 10 | `src/orbital_mission_compiler/schemas.py:59` | `test_schema.py`, `test_ir.py`, `test_parallel_rendering.py` | No |
+| `steps` | AI service pipeline stages | Slide 10 | `src/orbital_mission_compiler/schemas.py:60` | `test_schema.py`, `test_rendering.py` | No |
 
 ### 1.4 WorkflowStep
 
 | Field | ORCHIDE Source | Slide / D3.1 Ref | Implementation | Test Case | Author-Imposed? |
 |---|---|---|---|---|---|
-| `name` | Pipeline stage name | Slide 10 | `schemas.py:31` | `test_schema.py`, `test_rendering.py` | No |
-| `image` | OCI container image | Slide 10, D3.1 §5.1 | `schemas.py:32` | `test_schema.py`, `test_rendering.py` | No |
-| `phase` | Pre-processing / AI / Post-processing | Slide 10 | `schemas.py:33` | `test_rendering.py` | No |
-| `resource_class` | Hardware target (CPU/GPU/FPGA) | Slide 14 | `schemas.py:34` | `test_schema.py`, `test_kueue.py` | No |
-| `fallback_resource_class` | — | — | `schemas.py:35` | `test_policy.py` | **Yes** — ground-side reliability for local demo when primary hardware unavailable |
-| `needs_acceleration` | ukAccel accelerator mediation | Slide 18 | `schemas.py:36` | `test_policy.py` | No |
-| `command` | Application entry point | D3.1 §5.1 | `schemas.py:37` | `test_schema.py` | No |
-| `args` | Command arguments | D3.1 §5.1 | `schemas.py:38` | `test_schema.py` | No |
-| `metadata` | — | — | `schemas.py:39` | `test_schema.py` | **Yes** — free-form annotations for ground-side tooling |
-| `preferred_node_selector` | — | — | `schemas.py:40` | `test_schema.py` | **Yes** — Kubernetes node affinity labels for ground-side scheduling |
+| `name` | Pipeline stage name | Slide 10 | `src/orbital_mission_compiler/schemas.py:31` | `test_schema.py`, `test_rendering.py` | No |
+| `image` | OCI container image | Slide 10, D3.1 §5.1 | `src/orbital_mission_compiler/schemas.py:32` | `test_schema.py`, `test_rendering.py` | No |
+| `phase` | Pre-processing / AI / Post-processing | Slide 10 | `src/orbital_mission_compiler/schemas.py:33` | `test_rendering.py` | No |
+| `resource_class` | Hardware target (CPU/GPU/FPGA) | Slide 14 | `src/orbital_mission_compiler/schemas.py:34` | `test_schema.py`, `test_kueue.py` | No |
+| `fallback_resource_class` | — | — | `src/orbital_mission_compiler/schemas.py:35` | `test_policy.py` | **Yes** — ground-side reliability for local demo when primary hardware unavailable |
+| `needs_acceleration` | ukAccel accelerator mediation | Slide 18 | `src/orbital_mission_compiler/schemas.py:36` | `test_policy.py` | No |
+| `command` | Application entry point | D3.1 §5.1 | `src/orbital_mission_compiler/schemas.py:37` | `test_schema.py` | No |
+| `args` | Command arguments | D3.1 §5.1 | `src/orbital_mission_compiler/schemas.py:38` | `test_schema.py` | No |
+| `metadata` | — | — | `src/orbital_mission_compiler/schemas.py:39` | `test_schema.py` | **Yes** — free-form annotations for ground-side tooling |
+| `preferred_node_selector` | — | — | `src/orbital_mission_compiler/schemas.py:40` | `test_schema.py` | **Yes** — Kubernetes node affinity labels for ground-side scheduling |
 
 ### 1.5 Enums
 
@@ -100,7 +100,7 @@ Rules 3, 7, 8, and 9 intentionally overlap with Pydantic schema validators for d
 
 ## 3. Resource Hints Traceability
 
-Each key in the `resource_hints` dictionary (built in `compiler.py:compile_plan_to_intents`) is mapped to its derivation source.
+Each key in the `resource_hints` dictionary (built in `src/orbital_mission_compiler/compiler.py:compile_plan_to_intents`) is mapped to its derivation source.
 
 | Hint Key | Derivation | Source Field | Slide / D3.1 Ref | Author-Imposed? |
 |---|---|---|---|---|
@@ -123,15 +123,15 @@ The following features are explicitly added by this project to fill gaps that OR
 
 | Addition | Location | Rationale |
 |---|---|---|
-| Pydantic schema validation | `schemas.py` | ORCHIDE does not specify how mission plans are validated before reaching the satellite |
-| OPA/Rego policy framework | `configs/policies/mission_plan.rego`, `policy.py` | ORCHIDE has no policy-as-code; this adds 10 deny rules for semantic validation |
-| Kueue admission control | `compiler.py:render_kueue_job` | ORCHIDE uses a custom priority queue; this adds Kubernetes-native admission via Kueue |
-| CLI tool | `cli.py` | ORCHIDE's translation layer is embedded glue code; this extracts a standalone CLI |
-| MCP server | `mcp/server.py` | ORCHIDE has no AI agent interface; this adds 6 MCP tools for ground-side agents |
-| Fallback resource class | `schemas.py:fallback_resource_class` | ORCHIDE has no fallback strategy; ground-side demo reliability |
-| Timeline conflict detection | `compiler.py:detect_timeline_conflicts` | ORCHIDE has no timeline feasibility check; ground-side planning tool |
-| Resource hints enrichment | `compiler.py` (resource_hints dict) | ORCHIDE does not carry extended event metadata through IR; enriched for downstream schedulers |
-| Golden eval runner | `eval_runner.py`, `evals/golden/` | ORCHIDE has no ground-side evaluation framework; deterministic translation tests |
+| Pydantic schema validation | `src/orbital_mission_compiler/schemas.py` | ORCHIDE does not specify how mission plans are validated before reaching the satellite |
+| OPA/Rego policy framework | `configs/policies/mission_plan.rego`, `src/orbital_mission_compiler/policy.py` | ORCHIDE has no policy-as-code; this adds 10 deny rules for semantic validation |
+| Kueue admission control | `src/orbital_mission_compiler/compiler.py:render_kueue_job` | ORCHIDE uses a custom priority queue; this adds Kubernetes-native admission via Kueue |
+| CLI tool | `src/orbital_mission_compiler/cli.py` | ORCHIDE's translation layer is embedded glue code; this extracts a standalone CLI |
+| MCP server | `src/orbital_mission_compiler/mcp/server.py` | ORCHIDE has no AI agent interface; this adds 6 MCP tools for ground-side agents |
+| Fallback resource class | `src/orbital_mission_compiler/schemas.py:fallback_resource_class` | ORCHIDE has no fallback strategy; ground-side demo reliability |
+| Timeline conflict detection | `src/orbital_mission_compiler/compiler.py:detect_timeline_conflicts` | ORCHIDE has no timeline feasibility check; ground-side planning tool |
+| Resource hints enrichment | `src/orbital_mission_compiler/compiler.py` (resource_hints dict) | ORCHIDE does not carry extended event metadata through IR; enriched for downstream schedulers |
+| Golden eval runner | `src/orbital_mission_compiler/eval_runner.py`, `evals/golden/` | ORCHIDE has no ground-side evaluation framework; deterministic translation tests |
 
 ---
 

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -11,8 +11,10 @@ REQUIRED = [
     "docs/04_architecture.md",
     "docs/07_installation_matrix.md",
     "docs/12_phase2_local_demo.md",
+    "docs/14_traceability_matrix.md",
     "src/orbital_mission_compiler/compiler.py",
     "tests/test_compiler.py",
+    "tests/test_traceability.py",
     "configs/mission_plans/sample_gpu_cpu_fallback.yaml",
     "manifests/examples/argo-gpu-cpu-fallback.yaml",
 ]

--- a/tests/test_traceability.py
+++ b/tests/test_traceability.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pytest
 
+from orbital_mission_compiler.compiler import compile_plan_to_intents, load_mission_plan
 from orbital_mission_compiler.schemas import (
     AIService,
     ExecutionMode,
@@ -26,6 +27,7 @@ from orbital_mission_compiler.schemas import (
 )
 
 TRACEABILITY_DOC = Path("docs/14_traceability_matrix.md")
+SAMPLE_PLAN = "configs/mission_plans/sample_maritime_surveillance.yaml"
 
 # ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -53,20 +55,27 @@ def _extract_rego_rules(rego_path: str = "configs/policies/mission_plan.rego") -
     return re.findall(r'msg\s*:=\s*(?:sprintf\()?"([^"]+)"', text)
 
 
+# Pre-compute at module level to avoid redundant file reads.
+_REGO_RULES = _extract_rego_rules()
+
+
 def _resource_hints_keys() -> set[str]:
-    """Return the set of resource_hints keys built in compile_plan_to_intents."""
-    return {
-        "event_timestamp",
-        "ground_visibility",
-        "region_type",
-        "orbit",
-        "duration_seconds",
-        "landscape_type",
-        "execution_mode",
-        "requires_gpu",
-        "requires_fpga",
-        "fallback_enabled",
-    }
+    """Derive resource_hints keys from actual compiler output."""
+    plan = load_mission_plan(SAMPLE_PLAN)
+    intents = compile_plan_to_intents(plan)
+    return set(intents[0].resource_hints.keys())
+
+
+def _doc_contains_enum_entry(doc: str, value: str) -> bool:
+    """Return True when an enum value appears as a distinct doc entry."""
+    escaped = re.escape(value.lower())
+    patterns = (
+        rf"`{escaped}`",
+        rf"\|\s*`{escaped}`\s*[,|]",
+        rf"\|\s*{escaped}\s*[,|]",
+    )
+    doc_lower = doc.lower()
+    return any(re.search(p, doc_lower) for p in patterns)
 
 
 # ── Document existence ───────────────────────────────────────────────────
@@ -146,28 +155,28 @@ class TestEnumCompleteness:
     @pytest.mark.parametrize("value", sorted(_enum_member_names(ResourceClass)))
     def test_resource_class_traced(self, value: str):
         doc = _read_doc()
-        assert value in doc.lower(), (
+        assert _doc_contains_enum_entry(doc, value), (
             f"ResourceClass.{value} not found in traceability doc"
         )
 
     @pytest.mark.parametrize("value", sorted(_enum_member_names(StepPhase)))
     def test_step_phase_traced(self, value: str):
         doc = _read_doc()
-        assert value in doc.lower(), (
+        assert _doc_contains_enum_entry(doc, value), (
             f"StepPhase.{value} not found in traceability doc"
         )
 
     @pytest.mark.parametrize("value", sorted(_enum_member_names(ExecutionMode)))
     def test_execution_mode_traced(self, value: str):
         doc = _read_doc()
-        assert value in doc.lower(), (
+        assert _doc_contains_enum_entry(doc, value), (
             f"ExecutionMode.{value} not found in traceability doc"
         )
 
     @pytest.mark.parametrize("value", sorted(_enum_member_names(MissionEventType)))
     def test_event_type_traced(self, value: str):
         doc = _read_doc()
-        assert value in doc.lower(), (
+        assert _doc_contains_enum_entry(doc, value), (
             f"MissionEventType.{value} not found in traceability doc"
         )
 
@@ -179,17 +188,15 @@ class TestOpaPolicyCompleteness:
 
     @pytest.mark.parametrize(
         "rule_msg",
-        _extract_rego_rules(),
-        ids=[f"rule-{i+1}" for i in range(len(_extract_rego_rules()))],
+        _REGO_RULES,
+        ids=[f"rule-{i+1}" for i in range(len(_REGO_RULES))],
     )
     def test_opa_rule_traced(self, rule_msg: str):
         doc = _read_doc()
-        # Check for the rule message or a close keyword from it
-        keywords = [w for w in rule_msg.split() if len(w) > 4][:3]
-        found = any(kw.lower() in doc.lower() for kw in keywords)
-        assert found, (
-            f"OPA rule not found in traceability doc: {rule_msg!r}\n"
-            f"Searched keywords: {keywords}"
+        normalized_doc = re.sub(r"\s+", " ", doc).strip().lower()
+        normalized_msg = re.sub(r"\s+", " ", rule_msg).strip().lower()
+        assert normalized_msg in normalized_doc, (
+            f"OPA rule not found in traceability doc: {rule_msg!r}"
         )
 
 

--- a/tests/test_traceability.py
+++ b/tests/test_traceability.py
@@ -1,0 +1,242 @@
+"""Tests for ORCHIDE schema traceability matrix completeness.
+
+Verifies that docs/14_traceability_matrix.md covers every schema field,
+OPA policy rule, and WorkflowIntent resource hint. Uses Python
+introspection so that any new field/rule added without a traceability
+entry causes an immediate test failure.
+
+Issue #51: ORCHIDE schema traceability appendix.
+Reviewer feedback: R1 Major #6, R2 Major #5, R3 Major #5.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from orbital_mission_compiler.schemas import (
+    AIService,
+    ExecutionMode,
+    MissionEvent,
+    MissionEventType,
+    MissionPlan,
+    ResourceClass,
+    StepPhase,
+    WorkflowStep,
+)
+
+TRACEABILITY_DOC = Path("docs/14_traceability_matrix.md")
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+def _read_doc() -> str:
+    """Read the traceability document, skip if missing."""
+    if not TRACEABILITY_DOC.is_file():
+        pytest.skip(f"{TRACEABILITY_DOC} not yet created")
+    return TRACEABILITY_DOC.read_text(encoding="utf-8")
+
+
+def _model_field_names(model_cls: type) -> set[str]:
+    """Return field names from a Pydantic BaseModel."""
+    return set(model_cls.model_fields.keys())
+
+
+def _enum_member_names(enum_cls: type) -> set[str]:
+    """Return member values from a str Enum."""
+    return {m.value for m in enum_cls}
+
+
+def _extract_rego_rules(rego_path: str = "configs/policies/mission_plan.rego") -> list[str]:
+    """Extract deny rule messages from the Rego file."""
+    text = Path(rego_path).read_text(encoding="utf-8")
+    # Match msg := "..." and msg := sprintf("...", [...])
+    return re.findall(r'msg\s*:=\s*(?:sprintf\()?"([^"]+)"', text)
+
+
+def _resource_hints_keys() -> set[str]:
+    """Return the set of resource_hints keys built in compile_plan_to_intents."""
+    return {
+        "event_timestamp",
+        "ground_visibility",
+        "region_type",
+        "orbit",
+        "duration_seconds",
+        "landscape_type",
+        "execution_mode",
+        "requires_gpu",
+        "requires_fpga",
+        "fallback_enabled",
+    }
+
+
+# ── Document existence ───────────────────────────────────────────────────
+
+class TestTraceabilityDocExists:
+    """The traceability document must exist and have required sections."""
+
+    def test_doc_file_exists(self):
+        assert TRACEABILITY_DOC.is_file(), (
+            f"Traceability document missing: {TRACEABILITY_DOC}"
+        )
+
+    def test_has_schema_field_table(self):
+        doc = _read_doc()
+        assert "Schema Field Traceability" in doc, (
+            "Document must contain a 'Schema Field Traceability' section"
+        )
+
+    def test_has_opa_policy_table(self):
+        doc = _read_doc()
+        assert "OPA Policy Rule Traceability" in doc, (
+            "Document must contain an 'OPA Policy Rule Traceability' section"
+        )
+
+    def test_has_resource_hints_table(self):
+        doc = _read_doc()
+        assert "Resource Hints Traceability" in doc, (
+            "Document must contain a 'Resource Hints Traceability' section"
+        )
+
+    def test_has_ground_side_rationale(self):
+        doc = _read_doc()
+        assert "Ground-Side" in doc or "Author-Imposed" in doc, (
+            "Document must explain ground-side / author-imposed additions"
+        )
+
+
+# ── Schema field completeness ────────────────────────────────────────────
+
+class TestSchemaFieldCompleteness:
+    """Every Pydantic model field must appear in the traceability doc."""
+
+    @pytest.mark.parametrize("field", sorted(_model_field_names(MissionPlan)))
+    def test_mission_plan_field_traced(self, field: str):
+        doc = _read_doc()
+        assert f"`{field}`" in doc or f"| {field} " in doc or f"|{field}|" in doc, (
+            f"MissionPlan.{field} not found in traceability doc"
+        )
+
+    @pytest.mark.parametrize("field", sorted(_model_field_names(MissionEvent)))
+    def test_mission_event_field_traced(self, field: str):
+        doc = _read_doc()
+        assert f"`{field}`" in doc or f"| {field} " in doc or f"|{field}|" in doc, (
+            f"MissionEvent.{field} not found in traceability doc"
+        )
+
+    @pytest.mark.parametrize("field", sorted(_model_field_names(AIService)))
+    def test_ai_service_field_traced(self, field: str):
+        doc = _read_doc()
+        assert f"`{field}`" in doc or f"| {field} " in doc or f"|{field}|" in doc, (
+            f"AIService.{field} not found in traceability doc"
+        )
+
+    @pytest.mark.parametrize("field", sorted(_model_field_names(WorkflowStep)))
+    def test_workflow_step_field_traced(self, field: str):
+        doc = _read_doc()
+        assert f"`{field}`" in doc or f"| {field} " in doc or f"|{field}|" in doc, (
+            f"WorkflowStep.{field} not found in traceability doc"
+        )
+
+
+# ── Enum completeness ────────────────────────────────────────────────────
+
+class TestEnumCompleteness:
+    """Every enum value must appear in the traceability doc."""
+
+    @pytest.mark.parametrize("value", sorted(_enum_member_names(ResourceClass)))
+    def test_resource_class_traced(self, value: str):
+        doc = _read_doc()
+        assert value in doc.lower(), (
+            f"ResourceClass.{value} not found in traceability doc"
+        )
+
+    @pytest.mark.parametrize("value", sorted(_enum_member_names(StepPhase)))
+    def test_step_phase_traced(self, value: str):
+        doc = _read_doc()
+        assert value in doc.lower(), (
+            f"StepPhase.{value} not found in traceability doc"
+        )
+
+    @pytest.mark.parametrize("value", sorted(_enum_member_names(ExecutionMode)))
+    def test_execution_mode_traced(self, value: str):
+        doc = _read_doc()
+        assert value in doc.lower(), (
+            f"ExecutionMode.{value} not found in traceability doc"
+        )
+
+    @pytest.mark.parametrize("value", sorted(_enum_member_names(MissionEventType)))
+    def test_event_type_traced(self, value: str):
+        doc = _read_doc()
+        assert value in doc.lower(), (
+            f"MissionEventType.{value} not found in traceability doc"
+        )
+
+
+# ── OPA policy rule completeness ─────────────────────────────────────────
+
+class TestOpaPolicyCompleteness:
+    """Every OPA deny rule must appear in the traceability doc."""
+
+    @pytest.mark.parametrize(
+        "rule_msg",
+        _extract_rego_rules(),
+        ids=[f"rule-{i+1}" for i in range(len(_extract_rego_rules()))],
+    )
+    def test_opa_rule_traced(self, rule_msg: str):
+        doc = _read_doc()
+        # Check for the rule message or a close keyword from it
+        keywords = [w for w in rule_msg.split() if len(w) > 4][:3]
+        found = any(kw.lower() in doc.lower() for kw in keywords)
+        assert found, (
+            f"OPA rule not found in traceability doc: {rule_msg!r}\n"
+            f"Searched keywords: {keywords}"
+        )
+
+
+# ── Resource hints completeness ──────────────────────────────────────────
+
+class TestResourceHintsCompleteness:
+    """Every resource_hints key must appear in the traceability doc."""
+
+    @pytest.mark.parametrize("hint_key", sorted(_resource_hints_keys()))
+    def test_resource_hint_traced(self, hint_key: str):
+        doc = _read_doc()
+        assert f"`{hint_key}`" in doc or f"| {hint_key} " in doc or f"|{hint_key}|" in doc, (
+            f"resource_hints[{hint_key!r}] not found in traceability doc"
+        )
+
+
+# ── Cross-reference integrity ────────────────────────────────────────────
+
+class TestCrossReferences:
+    """Traceability doc must reference ORCHIDE slides and D3.1 sections."""
+
+    def test_references_slide_9(self):
+        doc = _read_doc()
+        assert "slide 9" in doc.lower() or "Slide 9" in doc, (
+            "Must reference Slide 9 (mission plan table format)"
+        )
+
+    def test_references_slide_10(self):
+        doc = _read_doc()
+        assert "slide 10" in doc.lower() or "Slide 10" in doc, (
+            "Must reference Slide 10 (workflow pipeline)"
+        )
+
+    def test_references_slide_14(self):
+        doc = _read_doc()
+        assert "slide 14" in doc.lower() or "Slide 14" in doc, (
+            "Must reference Slide 14 (heterogeneous hardware)"
+        )
+
+    def test_references_slide_23(self):
+        doc = _read_doc()
+        assert "slide 23" in doc.lower() or "Slide 23" in doc, (
+            "Must reference Slide 23 (custom translation layer)"
+        )
+
+    def test_references_d3_1(self):
+        doc = _read_doc()
+        assert "D3.1" in doc, (
+            "Must reference ORCHIDE D3.1 deliverable"
+        )

--- a/tests/test_traceability.py
+++ b/tests/test_traceability.py
@@ -56,7 +56,12 @@ def _extract_rego_rules(rego_path: str = "configs/policies/mission_plan.rego") -
 
 
 # Pre-compute at module level to avoid redundant file reads.
-_REGO_RULES = _extract_rego_rules()
+# Wrapped in try/except so a missing policy file surfaces as a test
+# failure rather than crashing the entire collection phase.
+try:
+    _REGO_RULES = _extract_rego_rules()
+except OSError:
+    _REGO_RULES = []
 
 
 def _resource_hints_keys() -> set[str]:
@@ -185,6 +190,11 @@ class TestEnumCompleteness:
 
 class TestOpaPolicyCompleteness:
     """Every OPA deny rule must appear in the traceability doc."""
+
+    def test_rego_rules_loaded(self):
+        assert len(_REGO_RULES) > 0, (
+            "No Rego deny rules extracted — check configs/policies/mission_plan.rego exists"
+        )
 
     @pytest.mark.parametrize(
         "rule_msg",


### PR DESCRIPTION
## Summary
- Add `docs/14_traceability_matrix.md` — formal bidirectional traceability mapping aligned with ISO/IEC/IEEE 29148:2018 RTM and ECSS-E-ST-40C Rev.1
- Addresses IEEE SMC-IT/SCC 2026 reviewer feedback: R1 Major #6, R2 Major #5, R3 Major #5
- Add `tests/test_traceability.py` (68 TDD tests) using Python introspection to verify completeness — any future schema/policy change without a doc update will fail tests

### Three traceability tables
1. **Schema fields** (27 fields across 4 models, 4 enums) → ORCHIDE slide / D3.1 section
2. **OPA deny rules** (10 rules) → source attribution (ORCHIDE-derived vs author-imposed)
3. **Resource hints** (10 keys) → derivation path and source field

### Coverage
| Dimension | Total | ORCHIDE-Derived | Author-Imposed |
|---|---|---|---|
| Schema fields | 27 | 21 (78%) | 6 (22%) |
| Enum values | 11 | 11 (100%) | 0 |
| OPA rules | 10 | 7 (70%) | 3 (30%) |
| Resource hints | 10 | 7 (70%) | 3 (30%) |
| **Total** | **58** | **46 (79%)** | **12 (21%)** |

## Test plan
- [x] 68 new traceability tests pass
- [x] 163 existing tests unaffected
- [x] Total: 231 passed, 29 skipped
- [x] verify.py updated to require traceability doc and test
- [x] make eval passes (3 golden checks)