### PR TITLE
Add ablation study: schema-only vs policy-only vs combined (#53)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON ?= python3
 PACKAGE = orbital_mission_compiler
 export PYTHONPATH := src:.
 
-.PHONY: verify test lint fmt compile-sample render-samples argo-smoke opa-smoke demo-phase2 eval benchmark print-tree k8s-smoke
+.PHONY: verify test lint fmt compile-sample render-samples argo-smoke opa-smoke demo-phase2 eval benchmark print-tree k8s-smoke ablation
 
 verify:
 	$(PYTHON) scripts/verify.py
@@ -36,6 +36,9 @@ eval:
 
 benchmark: ## Run scaling benchmark
 	$(PYTHON) scripts/benchmark_scaling.py
+
+ablation: ## Run ablation study (requires OPA CLI)
+	$(PYTHON) scripts/ablation_study.py
 
 k8s-smoke: ## Live cluster validation (requires K8s + Argo + Kueue)
 	bash scripts/validate_live_cluster.sh

--- a/configs/policies/mission_plan.rego
+++ b/configs/policies/mission_plan.rego
@@ -27,9 +27,13 @@ deny contains msg if {
   step := input.events[i].services[j].steps[k]
   step.resource_class == "gpu"
   step.needs_acceleration == true
-  not step.fallback_resource_class
+  _missing_fallback(step)
   msg := sprintf("GPU step %q should declare fallback_resource_class for local demo reliability", [step.name])
 }
+
+# Handle both undefined (raw input) and null (schema-normalized input).
+_missing_fallback(step) if not step.fallback_resource_class
+_missing_fallback(step) if step.fallback_resource_class == null
 
 # Rule 5: service priority must not be zero (slide 9: priorities are 1-4)
 deny contains msg if {

--- a/scripts/ablation_study.py
+++ b/scripts/ablation_study.py
@@ -1,0 +1,31 @@
+"""Run the ablation study and print results.
+
+Usage:
+    python scripts/ablation_study.py
+    make ablation
+"""
+
+from orbital_mission_compiler.ablation import (
+    format_results_table,
+    run_ablation_study,
+)
+from orbital_mission_compiler.policy import opa_available
+
+
+def main() -> None:
+    if not opa_available():
+        print("ERROR: OPA CLI not found. Install OPA to run the ablation study.")
+        print("  curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static")
+        raise SystemExit(1)
+
+    print("Running ablation study: schema-only vs policy-only vs combined...")
+    print()
+    results = run_ablation_study()
+    table = format_results_table(results)
+    print(table)
+    print()
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ablation_study.py
+++ b/scripts/ablation_study.py
@@ -15,7 +15,8 @@ from orbital_mission_compiler.policy import opa_available
 def main() -> None:
     if not opa_available():
         print("ERROR: OPA CLI not found. Install OPA to run the ablation study.")
-        print("  curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static")
+        print("  See: https://www.openpolicyagent.org/docs/latest/#1-download-opa")
+        print("  Verify the downloaded binary checksum before running it.")
         raise SystemExit(1)
 
     print("Running ablation study: schema-only vs policy-only vs combined...")

--- a/src/orbital_mission_compiler/ablation.py
+++ b/src/orbital_mission_compiler/ablation.py
@@ -336,19 +336,28 @@ def run_ablation_study() -> dict[ValidationArm, dict[ErrorCategory, float]]:
 
         for case in cases:
             raw = case["plan"]
-            s_det, _ = run_schema_validation(raw)
+
+            # Validate once — reuse model for both schema arm and
+            # combined arm normalization (avoids redundant parsing).
+            try:
+                model = MissionPlan.model_validate(raw)
+                s_det = False
+            except (ValidationError, ValueError):
+                model = None
+                s_det = True
 
             # Policy-only arm: raw dict (no schema normalization).
             p_det, _ = run_policy_validation(raw)
 
             # Combined arm: if schema passes, normalize through
-            # MissionPlan.model_dump(mode='json') before policy eval,
-            # matching the real CLI/MCP pipeline.
+            # model_dump(mode='json') before policy eval, matching
+            # the real CLI/MCP pipeline.
             if s_det:
                 c_det = True
             else:
-                normalized = MissionPlan.model_validate(raw).model_dump(mode="json")
-                c_policy_det, _ = run_policy_validation(normalized)
+                c_policy_det, _ = run_policy_validation(
+                    model.model_dump(mode="json")
+                )
                 c_det = c_policy_det
 
             if s_det:

--- a/src/orbital_mission_compiler/ablation.py
+++ b/src/orbital_mission_compiler/ablation.py
@@ -1,0 +1,403 @@
+"""Ablation study framework: schema-only vs policy-only vs combined validation.
+
+Generates a mutation corpus of invalid mission plans, runs each through
+three validation arms, and reports per-category detection rates.
+
+Issue #53: Camera-ready ablation study.
+"""
+
+from __future__ import annotations
+
+import json
+from enum import Enum
+from typing import Any
+
+from pydantic import ValidationError
+
+from .policy import eval_policy, opa_available
+from .schemas import MissionPlan
+
+
+class ErrorCategory(str, Enum):
+    """Error categories for the mutation corpus."""
+
+    VALID = "valid"
+    # Schema-only (Pydantic catches, OPA does not)
+    ACQ_NO_INSTRUMENT = "acq_no_instrument"
+    DOWNLOAD_NO_DURATION = "download_no_duration"
+    # Policy-only (OPA catches, Pydantic does not)
+    ACQ_NO_SERVICES = "acq_no_services"
+    GPU_NO_FALLBACK = "gpu_no_fallback"
+    ZERO_PRIORITY = "zero_priority"
+    CPU_ACCELERATION = "cpu_acceleration"
+    INVALID_LANDSCAPE = "invalid_landscape"
+    # Both layers (defense-in-depth overlap)
+    EMPTY_MISSION_ID = "empty_mission_id"
+    EMPTY_EVENTS = "empty_events"
+    DOWNLOAD_WITH_SERVICES = "download_with_services"
+    DOWNLOAD_NO_VISIBILITY = "download_no_visibility"
+    SERVICE_NO_STEPS = "service_no_steps"
+
+
+class ValidationArm(str, Enum):
+    SCHEMA = "schema"
+    POLICY = "policy"
+    COMBINED = "combined"
+
+
+# ── Mutation corpus ──────────────────────────────────────────────────────
+
+_VALID_STEP = {
+    "name": "detect",
+    "image": "busybox:1.36",
+    "resource_class": "cpu",
+    "command": ["sh", "-c"],
+    "args": ["echo ok"],
+}
+
+_VALID_GPU_STEP = {
+    "name": "gpu-detect",
+    "image": "nvcr.io/nvidia/pytorch:24.01-py3",
+    "resource_class": "gpu",
+    "needs_acceleration": True,
+    "fallback_resource_class": "cpu",
+}
+
+_VALID_SERVICE = {
+    "service_id": "ship-detection",
+    "priority": 50,
+    "landscape_type": "ocean",
+    "execution_mode": "sequential",
+    "steps": [_VALID_STEP],
+}
+
+_VALID_ACQ_EVENT = {
+    "timestamp": "2026-04-15T10:00:00Z",
+    "event_type": "acquisition",
+    "orbit": 1,
+    "instrument": "MSI",
+    "ground_visibility": False,
+    "services": [_VALID_SERVICE],
+}
+
+_VALID_DOWNLOAD_EVENT = {
+    "timestamp": "2026-04-15T11:00:00Z",
+    "event_type": "download",
+    "orbit": 2,
+    "duration_seconds": 300.0,
+    "ground_visibility": True,
+}
+
+
+def _base_plan() -> dict[str, Any]:
+    """Return a structurally valid mission plan dict."""
+    return {
+        "mission_id": "ablation-test",
+        "events": [_deep_copy(_VALID_ACQ_EVENT)],
+    }
+
+
+def _deep_copy(obj: Any) -> Any:
+    """Simple deep copy for JSON-serializable dicts/lists."""
+    return json.loads(json.dumps(obj))
+
+
+def generate_mutation_corpus() -> list[dict[str, Any]]:
+    """Generate a corpus of valid and invalid mission plans for ablation study."""
+    corpus: list[dict[str, Any]] = []
+
+    # ── Valid plans ──────────────────────────────────────────────────
+    corpus.append({
+        "plan": _base_plan(),
+        "category": ErrorCategory.VALID,
+        "expected_layer": "none",
+        "description": "Valid single-ACQ plan with CPU service",
+    })
+
+    plan_with_download = _base_plan()
+    plan_with_download["events"].append(_deep_copy(_VALID_DOWNLOAD_EVENT))
+    corpus.append({
+        "plan": plan_with_download,
+        "category": ErrorCategory.VALID,
+        "expected_layer": "none",
+        "description": "Valid plan with ACQ + DOWNLOAD events",
+    })
+
+    # ── Schema-only errors ───────────────────────────────────────────
+
+    # ACQ without instrument
+    p = _base_plan()
+    del p["events"][0]["instrument"]
+    corpus.append({
+        "plan": p,
+        "category": ErrorCategory.ACQ_NO_INSTRUMENT,
+        "expected_layer": "schema",
+        "description": "Acquisition event missing instrument (slide 9: INST)",
+    })
+
+    # DOWNLOAD without duration
+    p = _base_plan()
+    p["events"] = [{"timestamp": "2026-04-15T11:00:00Z", "event_type": "download",
+                     "orbit": 2, "ground_visibility": True}]
+    corpus.append({
+        "plan": p,
+        "category": ErrorCategory.DOWNLOAD_NO_DURATION,
+        "expected_layer": "schema",
+        "description": "Download event missing duration_seconds (slide 9: DT_EV)",
+    })
+
+    # ── Policy-only errors ───────────────────────────────────────────
+
+    # ACQ with zero services
+    p = _base_plan()
+    p["events"][0]["services"] = []
+    corpus.append({
+        "plan": p,
+        "category": ErrorCategory.ACQ_NO_SERVICES,
+        "expected_layer": "policy",
+        "description": "Acquisition event with no services (slide 9: WORKFLOW required)",
+    })
+
+    # GPU step without fallback
+    p = _base_plan()
+    gpu_step = _deep_copy(_VALID_GPU_STEP)
+    del gpu_step["fallback_resource_class"]
+    p["events"][0]["services"][0]["steps"] = [gpu_step]
+    corpus.append({
+        "plan": p,
+        "category": ErrorCategory.GPU_NO_FALLBACK,
+        "expected_layer": "policy",
+        "description": "GPU+acceleration step without fallback_resource_class",
+    })
+
+    # Zero priority
+    p = _base_plan()
+    p["events"][0]["services"][0]["priority"] = 0
+    corpus.append({
+        "plan": p,
+        "category": ErrorCategory.ZERO_PRIORITY,
+        "expected_layer": "policy",
+        "description": "Service priority=0 (misconfiguration; ORCHIDE uses 1-4)",
+    })
+
+    # CPU + needs_acceleration
+    p = _base_plan()
+    p["events"][0]["services"][0]["steps"] = [{
+        "name": "cpu-accel",
+        "image": "busybox:1.36",
+        "resource_class": "cpu",
+        "needs_acceleration": True,
+    }]
+    corpus.append({
+        "plan": p,
+        "category": ErrorCategory.CPU_ACCELERATION,
+        "expected_layer": "policy",
+        "description": "CPU step with needs_acceleration=true (contradiction)",
+    })
+
+    # Invalid landscape_type
+    p = _base_plan()
+    p["events"][0]["services"][0]["landscape_type"] = "desert"
+    corpus.append({
+        "plan": p,
+        "category": ErrorCategory.INVALID_LANDSCAPE,
+        "expected_layer": "policy",
+        "description": "Unrecognized landscape_type 'desert' (slide 9: O/L only)",
+    })
+
+    # ── Both-layer errors (defense-in-depth) ─────────────────────────
+
+    # Empty mission_id
+    p = _base_plan()
+    p["mission_id"] = ""
+    corpus.append({
+        "plan": p,
+        "category": ErrorCategory.EMPTY_MISSION_ID,
+        "expected_layer": "both",
+        "description": "Empty mission_id",
+    })
+
+    # Empty events
+    p = _base_plan()
+    p["events"] = []
+    corpus.append({
+        "plan": p,
+        "category": ErrorCategory.EMPTY_EVENTS,
+        "expected_layer": "both",
+        "description": "Mission plan with zero events",
+    })
+
+    # DOWNLOAD with services
+    p = _base_plan()
+    p["events"] = [{
+        "timestamp": "2026-04-15T11:00:00Z",
+        "event_type": "download",
+        "orbit": 2,
+        "duration_seconds": 300.0,
+        "ground_visibility": True,
+        "services": [_deep_copy(_VALID_SERVICE)],
+    }]
+    corpus.append({
+        "plan": p,
+        "category": ErrorCategory.DOWNLOAD_WITH_SERVICES,
+        "expected_layer": "both",
+        "description": "Download event carrying AI services (slide 9: DOWNLOAD has no WORKFLOW)",
+    })
+
+    # DOWNLOAD without visibility
+    p = _base_plan()
+    p["events"] = [{
+        "timestamp": "2026-04-15T11:00:00Z",
+        "event_type": "download",
+        "orbit": 2,
+        "duration_seconds": 300.0,
+        "ground_visibility": False,
+    }]
+    corpus.append({
+        "plan": p,
+        "category": ErrorCategory.DOWNLOAD_NO_VISIBILITY,
+        "expected_layer": "both",
+        "description": "Download event without ground visibility (slide 9: VISI=1)",
+    })
+
+    # Service with no steps
+    p = _base_plan()
+    p["events"][0]["services"][0]["steps"] = []
+    corpus.append({
+        "plan": p,
+        "category": ErrorCategory.SERVICE_NO_STEPS,
+        "expected_layer": "both",
+        "description": "Service with zero steps",
+    })
+
+    return corpus
+
+
+# ── Validation arms ──────────────────────────────────────────────────────
+
+POLICY_BUNDLE = "configs/policies"
+POLICY_DECISION = "data.orbitalmission"
+
+
+def run_schema_validation(plan_dict: dict[str, Any]) -> tuple[bool, str]:
+    """Run Pydantic schema validation only. Returns (detected, error_message)."""
+    try:
+        MissionPlan.model_validate(plan_dict)
+        return False, ""
+    except (ValidationError, ValueError) as exc:
+        return True, str(exc)
+
+
+def run_policy_validation(plan_dict: dict[str, Any]) -> tuple[bool, list[str]]:
+    """Run OPA policy validation only (skips schema). Returns (detected, deny_messages)."""
+    if not opa_available():
+        return False, ["opa CLI not available"]
+    rc, output = eval_policy(POLICY_BUNDLE, plan_dict, POLICY_DECISION)
+    if rc != 0:
+        return False, [f"OPA error (rc={rc}): {output}"]
+    try:
+        parsed = json.loads(output)
+        result = parsed["result"][0]["expressions"][0]["value"]
+        deny = result.get("deny", [])
+        return len(deny) > 0, deny
+    except (json.JSONDecodeError, KeyError, IndexError):
+        return False, [f"Unparseable OPA output: {output[:200]}"]
+
+
+# ── Ablation runner ──────────────────────────────────────────────────────
+
+
+def run_ablation_study() -> dict[ValidationArm, dict[ErrorCategory, float]]:
+    """Run the full three-arm ablation study.
+
+    Returns detection rates per (arm, category). For valid plans the rate
+    represents false positives (should be 0.0).
+    """
+    corpus = generate_mutation_corpus()
+
+    # Group by category
+    by_category: dict[ErrorCategory, list[dict]] = {}
+    for case in corpus:
+        by_category.setdefault(case["category"], []).append(case)
+
+    results: dict[ValidationArm, dict[ErrorCategory, float]] = {
+        arm: {} for arm in ValidationArm
+    }
+
+    for cat, cases in by_category.items():
+        n = len(cases)
+        schema_hits = 0
+        policy_hits = 0
+        combined_hits = 0
+
+        for case in cases:
+            s_det, _ = run_schema_validation(case["plan"])
+            p_det, _ = run_policy_validation(case["plan"])
+
+            if s_det:
+                schema_hits += 1
+            if p_det:
+                policy_hits += 1
+            if s_det or p_det:
+                combined_hits += 1
+
+        results[ValidationArm.SCHEMA][cat] = schema_hits / n
+        results[ValidationArm.POLICY][cat] = policy_hits / n
+        results[ValidationArm.COMBINED][cat] = combined_hits / n
+
+    return results
+
+
+# ── Results formatting ───────────────────────────────────────────────────
+
+
+def format_results_table(
+    results: dict[ValidationArm, dict[ErrorCategory, float]],
+) -> str:
+    """Format ablation results as a markdown table suitable for the paper."""
+    lines = [
+        "| Error Category | Layer | Schema | Policy | Combined |",
+        "|---|---|---|---|---|",
+    ]
+
+    layer_map = {
+        ErrorCategory.ACQ_NO_INSTRUMENT: "Schema-only",
+        ErrorCategory.DOWNLOAD_NO_DURATION: "Schema-only",
+        ErrorCategory.ACQ_NO_SERVICES: "Policy-only",
+        ErrorCategory.GPU_NO_FALLBACK: "Policy-only",
+        ErrorCategory.ZERO_PRIORITY: "Policy-only",
+        ErrorCategory.CPU_ACCELERATION: "Policy-only",
+        ErrorCategory.INVALID_LANDSCAPE: "Policy-only",
+        ErrorCategory.EMPTY_MISSION_ID: "Both",
+        ErrorCategory.EMPTY_EVENTS: "Both",
+        ErrorCategory.DOWNLOAD_WITH_SERVICES: "Both",
+        ErrorCategory.DOWNLOAD_NO_VISIBILITY: "Both",
+        ErrorCategory.SERVICE_NO_STEPS: "Both",
+    }
+
+    def _pct(v: float) -> str:
+        return f"{v * 100:.0f}%"
+
+    for cat in ErrorCategory:
+        if cat == ErrorCategory.VALID:
+            continue
+        s = results[ValidationArm.SCHEMA].get(cat, 0.0)
+        p = results[ValidationArm.POLICY].get(cat, 0.0)
+        c = results[ValidationArm.COMBINED].get(cat, 0.0)
+        layer = layer_map.get(cat, "?")
+        lines.append(f"| {cat.value} | {layer} | {_pct(s)} | {_pct(p)} | {_pct(c)} |")
+
+    # Summary row
+    cats = [c for c in ErrorCategory if c != ErrorCategory.VALID]
+    s_avg = sum(results[ValidationArm.SCHEMA].get(c, 0.0) for c in cats) / len(cats)
+    p_avg = sum(results[ValidationArm.POLICY].get(c, 0.0) for c in cats) / len(cats)
+    c_avg = sum(results[ValidationArm.COMBINED].get(c, 0.0) for c in cats) / len(cats)
+    lines.append(f"| **Average detection** | — | **{_pct(s_avg)}** | **{_pct(p_avg)}** | **{_pct(c_avg)}** |")
+
+    # False positive row
+    s_fp = results[ValidationArm.SCHEMA].get(ErrorCategory.VALID, 0.0)
+    p_fp = results[ValidationArm.POLICY].get(ErrorCategory.VALID, 0.0)
+    c_fp = results[ValidationArm.COMBINED].get(ErrorCategory.VALID, 0.0)
+    lines.append(f"| **False positive rate** | — | **{_pct(s_fp)}** | **{_pct(p_fp)}** | **{_pct(c_fp)}** |")
+
+    return "\n".join(lines)

--- a/src/orbital_mission_compiler/ablation.py
+++ b/src/orbital_mission_compiler/ablation.py
@@ -289,19 +289,23 @@ def run_schema_validation(plan_dict: dict[str, Any]) -> tuple[bool, str]:
 
 
 def run_policy_validation(plan_dict: dict[str, Any]) -> tuple[bool, list[str]]:
-    """Run OPA policy validation only (skips schema). Returns (detected, deny_messages)."""
+    """Run OPA policy validation only (skips schema). Returns (detected, deny_messages).
+
+    Raises RuntimeError on OPA failures so the ablation study cannot
+    silently produce incorrect results.
+    """
     if not opa_available():
-        return False, ["opa CLI not available"]
+        raise RuntimeError("OPA CLI not available")
     rc, output = eval_policy(POLICY_BUNDLE, plan_dict, POLICY_DECISION)
     if rc != 0:
-        return False, [f"OPA error (rc={rc}): {output}"]
+        raise RuntimeError(f"OPA error (rc={rc}): {output}")
     try:
         parsed = json.loads(output)
         result = parsed["result"][0]["expressions"][0]["value"]
         deny = result.get("deny", [])
         return len(deny) > 0, deny
-    except (json.JSONDecodeError, KeyError, IndexError):
-        return False, [f"Unparseable OPA output: {output[:200]}"]
+    except (json.JSONDecodeError, KeyError, IndexError) as exc:
+        raise RuntimeError(f"Unparseable OPA output: {output[:200]}") from exc
 
 
 # ── Ablation runner ──────────────────────────────────────────────────────
@@ -331,14 +335,27 @@ def run_ablation_study() -> dict[ValidationArm, dict[ErrorCategory, float]]:
         combined_hits = 0
 
         for case in cases:
-            s_det, _ = run_schema_validation(case["plan"])
-            p_det, _ = run_policy_validation(case["plan"])
+            raw = case["plan"]
+            s_det, _ = run_schema_validation(raw)
+
+            # Policy-only arm: raw dict (no schema normalization).
+            p_det, _ = run_policy_validation(raw)
+
+            # Combined arm: if schema passes, normalize through
+            # MissionPlan.model_dump(mode='json') before policy eval,
+            # matching the real CLI/MCP pipeline.
+            if s_det:
+                c_det = True
+            else:
+                normalized = MissionPlan.model_validate(raw).model_dump(mode="json")
+                c_policy_det, _ = run_policy_validation(normalized)
+                c_det = c_policy_det
 
             if s_det:
                 schema_hits += 1
             if p_det:
                 policy_hits += 1
-            if s_det or p_det:
+            if c_det:
                 combined_hits += 1
 
         results[ValidationArm.SCHEMA][cat] = schema_hits / n

--- a/tests/test_ablation.py
+++ b/tests/test_ablation.py
@@ -23,6 +23,13 @@ from orbital_mission_compiler.policy import opa_available
 OPA_AVAILABLE = opa_available()
 
 
+def _pick(corpus: list[dict], cat: ErrorCategory) -> dict:
+    """Pick the first corpus case for a category, with a clear error on miss."""
+    case = next((c for c in corpus if c["category"] == cat), None)
+    assert case is not None, f"Corpus missing category: {cat.value}"
+    return case
+
+
 # ── Corpus completeness ──────────────────────────────────────────────────
 
 
@@ -61,30 +68,24 @@ class TestSchemaValidation:
 
     def test_detects_empty_mission_id(self):
         corpus = generate_mutation_corpus()
-        case = [c for c in corpus if c["category"] == ErrorCategory.EMPTY_MISSION_ID][0]
-        detected, _ = run_schema_validation(case["plan"])
+        detected, _ = run_schema_validation(_pick(corpus, ErrorCategory.EMPTY_MISSION_ID)["plan"])
         assert detected
 
     def test_misses_zero_priority(self):
         """Schema allows priority=0; only policy catches this."""
         corpus = generate_mutation_corpus()
-        zero_prio = [c for c in corpus if c["category"] == ErrorCategory.ZERO_PRIORITY]
-        assert len(zero_prio) >= 1
-        detected, _ = run_schema_validation(zero_prio[0]["plan"])
+        detected, _ = run_schema_validation(_pick(corpus, ErrorCategory.ZERO_PRIORITY)["plan"])
         assert not detected, "Schema should NOT catch zero priority"
 
     def test_misses_cpu_acceleration(self):
         """Schema has no cross-field constraint for CPU+acceleration."""
         corpus = generate_mutation_corpus()
-        cpu_accel = [c for c in corpus if c["category"] == ErrorCategory.CPU_ACCELERATION]
-        assert len(cpu_accel) >= 1
-        detected, _ = run_schema_validation(cpu_accel[0]["plan"])
+        detected, _ = run_schema_validation(_pick(corpus, ErrorCategory.CPU_ACCELERATION)["plan"])
         assert not detected, "Schema should NOT catch CPU+acceleration contradiction"
 
     def test_valid_plan_passes(self):
         corpus = generate_mutation_corpus()
-        valid = [c for c in corpus if c["category"] == ErrorCategory.VALID][0]
-        detected, _ = run_schema_validation(valid["plan"])
+        detected, _ = run_schema_validation(_pick(corpus, ErrorCategory.VALID)["plan"])
         assert not detected, "Valid plan should pass schema validation"
 
 
@@ -97,27 +98,23 @@ class TestPolicyValidation:
 
     def test_detects_zero_priority(self):
         corpus = generate_mutation_corpus()
-        zero_prio = [c for c in corpus if c["category"] == ErrorCategory.ZERO_PRIORITY][0]
-        detected, _ = run_policy_validation(zero_prio["plan"])
+        detected, _ = run_policy_validation(_pick(corpus, ErrorCategory.ZERO_PRIORITY)["plan"])
         assert detected
 
     def test_detects_cpu_acceleration(self):
         corpus = generate_mutation_corpus()
-        cpu_accel = [c for c in corpus if c["category"] == ErrorCategory.CPU_ACCELERATION][0]
-        detected, _ = run_policy_validation(cpu_accel["plan"])
+        detected, _ = run_policy_validation(_pick(corpus, ErrorCategory.CPU_ACCELERATION)["plan"])
         assert detected
 
     def test_misses_acq_without_instrument(self):
         """Policy has no rule requiring instrument on acquisition events."""
         corpus = generate_mutation_corpus()
-        no_inst = [c for c in corpus if c["category"] == ErrorCategory.ACQ_NO_INSTRUMENT][0]
-        detected, _ = run_policy_validation(no_inst["plan"])
+        detected, _ = run_policy_validation(_pick(corpus, ErrorCategory.ACQ_NO_INSTRUMENT)["plan"])
         assert not detected, "Policy should NOT catch missing instrument"
 
     def test_valid_plan_passes(self):
         corpus = generate_mutation_corpus()
-        valid = [c for c in corpus if c["category"] == ErrorCategory.VALID][0]
-        detected, _ = run_policy_validation(valid["plan"])
+        detected, _ = run_policy_validation(_pick(corpus, ErrorCategory.VALID)["plan"])
         assert not detected, "Valid plan should pass policy validation"
 
 

--- a/tests/test_ablation.py
+++ b/tests/test_ablation.py
@@ -60,8 +60,9 @@ class TestSchemaValidation:
     """Schema-only validation catches structural errors."""
 
     def test_detects_empty_mission_id(self):
-        plan = {"mission_id": "", "events": []}
-        detected, _ = run_schema_validation(plan)
+        corpus = generate_mutation_corpus()
+        case = [c for c in corpus if c["category"] == ErrorCategory.EMPTY_MISSION_ID][0]
+        detected, _ = run_schema_validation(case["plan"])
         assert detected
 
     def test_misses_zero_priority(self):
@@ -148,6 +149,17 @@ class TestCombinedValidation:
             )
 
 
+# ── Shared fixture (runs ablation once per module) ───────────────────────
+
+
+@pytest.fixture(scope="module")
+def ablation_results():
+    """Run the ablation study once and share across all tests in this module."""
+    if not OPA_AVAILABLE:
+        pytest.skip("OPA CLI not available")
+    return run_ablation_study()
+
+
 # ── Full ablation run ────────────────────────────────────────────────────
 
 
@@ -155,31 +167,28 @@ class TestCombinedValidation:
 class TestAblationResults:
     """run_ablation_study produces well-structured results."""
 
-    def test_results_have_all_arms(self):
-        results = run_ablation_study()
+    def test_results_have_all_arms(self, ablation_results):
         for arm in ValidationArm:
-            assert arm in results, f"Results missing arm: {arm.value}"
+            assert arm in ablation_results, f"Results missing arm: {arm.value}"
 
-    def test_results_have_all_categories(self):
-        results = run_ablation_study()
+    def test_results_have_all_categories(self, ablation_results):
         for arm in ValidationArm:
             for cat in ErrorCategory:
-                assert cat in results[arm], (
+                assert cat in ablation_results[arm], (
                     f"Results[{arm.value}] missing category: {cat.value}"
                 )
 
-    def test_combined_has_perfect_detection(self):
-        results = run_ablation_study()
+    def test_combined_has_perfect_detection(self, ablation_results):
         for cat in ErrorCategory:
             if cat == ErrorCategory.VALID:
-                assert results[ValidationArm.COMBINED][cat] == 0.0, (
+                assert ablation_results[ValidationArm.COMBINED][cat] == 0.0, (
                     f"Combined should have 0% detection on valid plans, "
-                    f"got {results[ValidationArm.COMBINED][cat]}"
+                    f"got {ablation_results[ValidationArm.COMBINED][cat]}"
                 )
             else:
-                assert results[ValidationArm.COMBINED][cat] == 1.0, (
+                assert ablation_results[ValidationArm.COMBINED][cat] == 1.0, (
                     f"Combined should catch all {cat.value}, "
-                    f"got {results[ValidationArm.COMBINED][cat]}"
+                    f"got {ablation_results[ValidationArm.COMBINED][cat]}"
                 )
 
 
@@ -190,21 +199,18 @@ class TestAblationResults:
 class TestResultsFormatting:
     """format_results_table outputs a usable markdown table."""
 
-    def test_table_is_string(self):
-        results = run_ablation_study()
-        table = format_results_table(results)
+    def test_table_is_string(self, ablation_results):
+        table = format_results_table(ablation_results)
         assert isinstance(table, str)
 
-    def test_table_has_header_row(self):
-        results = run_ablation_study()
-        table = format_results_table(results)
+    def test_table_has_header_row(self, ablation_results):
+        table = format_results_table(ablation_results)
         assert "Schema" in table
         assert "Policy" in table
         assert "Combined" in table
 
-    def test_table_has_all_categories(self):
-        results = run_ablation_study()
-        table = format_results_table(results)
+    def test_table_has_all_categories(self, ablation_results):
+        table = format_results_table(ablation_results)
         for cat in ErrorCategory:
             if cat != ErrorCategory.VALID:
                 assert cat.value in table, f"Table missing category row: {cat.value}"

--- a/tests/test_ablation.py
+++ b/tests/test_ablation.py
@@ -19,6 +19,7 @@ from orbital_mission_compiler.ablation import (
     format_results_table,
 )
 from orbital_mission_compiler.policy import opa_available
+from orbital_mission_compiler.schemas import MissionPlan
 
 OPA_AVAILABLE = opa_available()
 
@@ -126,22 +127,36 @@ class TestCombinedValidation:
     """Combined schema+policy catches all error categories."""
 
     def test_combined_catches_all_invalid(self):
+        """Mirror the actual combined arm: normalize through schema before policy."""
         corpus = generate_mutation_corpus()
         invalid = [c for c in corpus if c["category"] != ErrorCategory.VALID]
         for case in invalid:
-            schema_hit, _ = run_schema_validation(case["plan"])
-            policy_hit, _ = run_policy_validation(case["plan"])
-            assert schema_hit or policy_hit, (
+            raw = case["plan"]
+            schema_hit, _ = run_schema_validation(raw)
+            if schema_hit:
+                combined_hit = True
+            else:
+                normalized = MissionPlan.model_validate(raw).model_dump(mode="json")
+                policy_hit, _ = run_policy_validation(normalized)
+                combined_hit = policy_hit
+            assert combined_hit, (
                 f"Combined missed {case['category'].value}: {case['description']}"
             )
 
     def test_no_false_positives_on_valid(self):
+        """Mirror the actual combined arm: normalize through schema before policy."""
         corpus = generate_mutation_corpus()
         valid = [c for c in corpus if c["category"] == ErrorCategory.VALID]
         for case in valid:
-            schema_hit, _ = run_schema_validation(case["plan"])
-            policy_hit, _ = run_policy_validation(case["plan"])
-            assert not schema_hit and not policy_hit, (
+            raw = case["plan"]
+            schema_hit, _ = run_schema_validation(raw)
+            if schema_hit:
+                combined_hit = True
+            else:
+                normalized = MissionPlan.model_validate(raw).model_dump(mode="json")
+                policy_hit, _ = run_policy_validation(normalized)
+                combined_hit = policy_hit
+            assert not combined_hit, (
                 f"False positive on valid plan: {case['description']}"
             )
 

--- a/tests/test_ablation.py
+++ b/tests/test_ablation.py
@@ -1,0 +1,210 @@
+"""Tests for ablation study framework.
+
+Validates that the mutation corpus covers all error categories and that
+schema-only, policy-only, and combined validation produce the expected
+detection patterns.
+
+Issue #53: Camera-ready ablation study.
+"""
+
+import pytest
+
+from orbital_mission_compiler.ablation import (
+    ErrorCategory,
+    ValidationArm,
+    generate_mutation_corpus,
+    run_schema_validation,
+    run_policy_validation,
+    run_ablation_study,
+    format_results_table,
+)
+from orbital_mission_compiler.policy import opa_available
+
+OPA_AVAILABLE = opa_available()
+
+
+# ── Corpus completeness ──────────────────────────────────────────────────
+
+
+class TestMutationCorpus:
+    """The mutation corpus must cover all error categories."""
+
+    def test_corpus_is_non_empty(self):
+        corpus = generate_mutation_corpus()
+        assert len(corpus) > 0
+
+    def test_corpus_covers_all_error_categories(self):
+        corpus = generate_mutation_corpus()
+        categories = {case["category"] for case in corpus}
+        for cat in ErrorCategory:
+            assert cat in categories, f"Corpus missing category: {cat.value}"
+
+    def test_corpus_has_valid_plans(self):
+        corpus = generate_mutation_corpus()
+        valid = [c for c in corpus if c["category"] == ErrorCategory.VALID]
+        assert len(valid) >= 2, "Corpus must include at least 2 valid plans"
+
+    def test_each_case_has_required_fields(self):
+        corpus = generate_mutation_corpus()
+        for case in corpus:
+            assert "plan" in case, "Each case must have a 'plan' dict"
+            assert "category" in case, "Each case must have a 'category'"
+            assert "expected_layer" in case, "Each case must have an 'expected_layer'"
+            assert "description" in case, "Each case must have a 'description'"
+
+
+# ── Schema-only validation ───────────────────────────────────────────────
+
+
+class TestSchemaValidation:
+    """Schema-only validation catches structural errors."""
+
+    def test_detects_empty_mission_id(self):
+        plan = {"mission_id": "", "events": []}
+        detected, _ = run_schema_validation(plan)
+        assert detected
+
+    def test_misses_zero_priority(self):
+        """Schema allows priority=0; only policy catches this."""
+        corpus = generate_mutation_corpus()
+        zero_prio = [c for c in corpus if c["category"] == ErrorCategory.ZERO_PRIORITY]
+        assert len(zero_prio) >= 1
+        detected, _ = run_schema_validation(zero_prio[0]["plan"])
+        assert not detected, "Schema should NOT catch zero priority"
+
+    def test_misses_cpu_acceleration(self):
+        """Schema has no cross-field constraint for CPU+acceleration."""
+        corpus = generate_mutation_corpus()
+        cpu_accel = [c for c in corpus if c["category"] == ErrorCategory.CPU_ACCELERATION]
+        assert len(cpu_accel) >= 1
+        detected, _ = run_schema_validation(cpu_accel[0]["plan"])
+        assert not detected, "Schema should NOT catch CPU+acceleration contradiction"
+
+    def test_valid_plan_passes(self):
+        corpus = generate_mutation_corpus()
+        valid = [c for c in corpus if c["category"] == ErrorCategory.VALID][0]
+        detected, _ = run_schema_validation(valid["plan"])
+        assert not detected, "Valid plan should pass schema validation"
+
+
+# ── Policy-only validation ───────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not OPA_AVAILABLE, reason="OPA CLI not available")
+class TestPolicyValidation:
+    """Policy-only validation catches semantic errors."""
+
+    def test_detects_zero_priority(self):
+        corpus = generate_mutation_corpus()
+        zero_prio = [c for c in corpus if c["category"] == ErrorCategory.ZERO_PRIORITY][0]
+        detected, _ = run_policy_validation(zero_prio["plan"])
+        assert detected
+
+    def test_detects_cpu_acceleration(self):
+        corpus = generate_mutation_corpus()
+        cpu_accel = [c for c in corpus if c["category"] == ErrorCategory.CPU_ACCELERATION][0]
+        detected, _ = run_policy_validation(cpu_accel["plan"])
+        assert detected
+
+    def test_misses_acq_without_instrument(self):
+        """Policy has no rule requiring instrument on acquisition events."""
+        corpus = generate_mutation_corpus()
+        no_inst = [c for c in corpus if c["category"] == ErrorCategory.ACQ_NO_INSTRUMENT][0]
+        detected, _ = run_policy_validation(no_inst["plan"])
+        assert not detected, "Policy should NOT catch missing instrument"
+
+    def test_valid_plan_passes(self):
+        corpus = generate_mutation_corpus()
+        valid = [c for c in corpus if c["category"] == ErrorCategory.VALID][0]
+        detected, _ = run_policy_validation(valid["plan"])
+        assert not detected, "Valid plan should pass policy validation"
+
+
+# ── Combined validation ──────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not OPA_AVAILABLE, reason="OPA CLI not available")
+class TestCombinedValidation:
+    """Combined schema+policy catches all error categories."""
+
+    def test_combined_catches_all_invalid(self):
+        corpus = generate_mutation_corpus()
+        invalid = [c for c in corpus if c["category"] != ErrorCategory.VALID]
+        for case in invalid:
+            schema_hit, _ = run_schema_validation(case["plan"])
+            policy_hit, _ = run_policy_validation(case["plan"])
+            assert schema_hit or policy_hit, (
+                f"Combined missed {case['category'].value}: {case['description']}"
+            )
+
+    def test_no_false_positives_on_valid(self):
+        corpus = generate_mutation_corpus()
+        valid = [c for c in corpus if c["category"] == ErrorCategory.VALID]
+        for case in valid:
+            schema_hit, _ = run_schema_validation(case["plan"])
+            policy_hit, _ = run_policy_validation(case["plan"])
+            assert not schema_hit and not policy_hit, (
+                f"False positive on valid plan: {case['description']}"
+            )
+
+
+# ── Full ablation run ────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not OPA_AVAILABLE, reason="OPA CLI not available")
+class TestAblationResults:
+    """run_ablation_study produces well-structured results."""
+
+    def test_results_have_all_arms(self):
+        results = run_ablation_study()
+        for arm in ValidationArm:
+            assert arm in results, f"Results missing arm: {arm.value}"
+
+    def test_results_have_all_categories(self):
+        results = run_ablation_study()
+        for arm in ValidationArm:
+            for cat in ErrorCategory:
+                assert cat in results[arm], (
+                    f"Results[{arm.value}] missing category: {cat.value}"
+                )
+
+    def test_combined_has_perfect_detection(self):
+        results = run_ablation_study()
+        for cat in ErrorCategory:
+            if cat == ErrorCategory.VALID:
+                assert results[ValidationArm.COMBINED][cat] == 0.0, (
+                    f"Combined should have 0% detection on valid plans, "
+                    f"got {results[ValidationArm.COMBINED][cat]}"
+                )
+            else:
+                assert results[ValidationArm.COMBINED][cat] == 1.0, (
+                    f"Combined should catch all {cat.value}, "
+                    f"got {results[ValidationArm.COMBINED][cat]}"
+                )
+
+
+# ── Results formatting ───────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not OPA_AVAILABLE, reason="OPA CLI not available")
+class TestResultsFormatting:
+    """format_results_table outputs a usable markdown table."""
+
+    def test_table_is_string(self):
+        results = run_ablation_study()
+        table = format_results_table(results)
+        assert isinstance(table, str)
+
+    def test_table_has_header_row(self):
+        results = run_ablation_study()
+        table = format_results_table(results)
+        assert "Schema" in table
+        assert "Policy" in table
+        assert "Combined" in table
+
+    def test_table_has_all_categories(self):
+        results = run_ablation_study()
+        table = format_results_table(results)
+        for cat in ErrorCategory:
+            if cat != ErrorCategory.VALID:
+                assert cat.value in table, f"Table missing category row: {cat.value}"


### PR DESCRIPTION
## Summary
Mutation-based three-arm ablation study comparing schema-only, policy-only, and combined validation. Addresses IEEE SMC-IT/SCC 2026 reviewer feedback on evaluation methodology.

### Results

| Error Category | Layer | Schema | Policy | Combined |
|---|---|---|---|---|
| acq_no_instrument | Schema-only | 100% | 0% | 100% |
| download_no_duration | Schema-only | 100% | 0% | 100% |
| acq_no_services | Policy-only | 0% | 100% | 100% |
| gpu_no_fallback | Policy-only | 0% | 100% | 100% |
| zero_priority | Policy-only | 0% | 100% | 100% |
| cpu_acceleration | Policy-only | 0% | 100% | 100% |
| invalid_landscape | Policy-only | 0% | 100% | 100% |
| empty_mission_id | Both | 100% | 100% | 100% |
| empty_events | Both | 100% | 100% | 100% |
| download_with_services | Both | 100% | 100% | 100% |
| download_no_visibility | Both | 100% | 100% | 100% |
| service_no_steps | Both | 100% | 100% | 100% |
| **Average detection** | — | **58%** | **83%** | **100%** |
| **False positive rate** | — | **0%** | **0%** | **0%** |

### Key findings
- Schema alone misses 5 semantic errors (42% gap)
- Policy alone misses 2 structural errors (17% gap)
- Combined achieves 100% detection with 0% false positives
- 5 rules have defense-in-depth overlap (both layers catch them)

## Test plan
- [x] 20 new ablation tests pass (8 without OPA, 12 with OPA)
- [x] 261 existing tests unaffected
- [x] Total: 295 passed with OPA, 281 passed without OPA
- [x] `make ablation` produces the results table