### PR TITLE
Expand mission plan corpus to 12 plans with golden evals (#53)

### DIFF
--- a/configs/mission_plans/sample_download_only.yaml
+++ b/configs/mission_plans/sample_download_only.yaml
@@ -1,0 +1,27 @@
+# Minimal ACQ + DOWNLOAD event plan.
+# Demonstrates ORCHIDE slide 9 DOWNLOAD phase with ground_visibility=true.
+mission_id: mission-download-only
+client_id: download-demo-user
+events:
+  - timestamp: "2029-11-08T05:00:00Z"
+    event_type: acquisition
+    orbit: 1
+    duration_seconds: 2.0
+    instrument: INST_1
+    ground_visibility: false
+    services:
+      - service_id: quicklook
+        priority: 20
+        execution_mode: sequential
+        steps:
+          - name: generate-quicklook
+            image: busybox:1.36
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo generate-quicklook"]
+  - timestamp: "2029-11-08T06:30:00Z"
+    event_type: download
+    orbit: 1
+    duration_seconds: 240.0
+    instrument: X_BAND
+    ground_visibility: true

--- a/configs/mission_plans/sample_fpga_signal.yaml
+++ b/configs/mission_plans/sample_fpga_signal.yaml
@@ -1,0 +1,38 @@
+# FPGA-based signal processing service.
+# Demonstrates ORCHIDE slide 14 FPGA resource class with CPU fallback.
+mission_id: mission-fpga-signal
+client_id: fpga-demo-user
+events:
+  - timestamp: "2029-11-03T06:30:00Z"
+    event_type: acquisition
+    orbit: 1
+    duration_seconds: 3.0
+    instrument: SAR_1
+    ground_visibility: false
+    region_type: land
+    services:
+      - service_id: sar-compression
+        priority: 70
+        landscape_type: land
+        execution_mode: sequential
+        steps:
+          - name: raw-iq-decode
+            image: ghcr.io/example/sar-decode:0.1.0
+            phase: preprocessing
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo raw-iq-decode"]
+          - name: fpga-compress
+            image: ghcr.io/example/fpga-compress:0.1.0
+            phase: ai
+            resource_class: fpga
+            fallback_resource_class: cpu
+            needs_acceleration: true
+            command: ["sh", "-c"]
+            args: ["echo fpga-compress"]
+          - name: package-output
+            image: ghcr.io/example/packager:0.1.0
+            phase: postprocessing
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo package-output"]

--- a/configs/mission_plans/sample_high_priority_gpu.yaml
+++ b/configs/mission_plans/sample_high_priority_gpu.yaml
@@ -1,0 +1,40 @@
+# High-priority GPU service with 3-phase pipeline (preprocessing + AI + postprocessing).
+# Demonstrates ORCHIDE slide 9 priority mapping (95 -> ORCHIDE priority 1).
+mission_id: mission-high-priority-gpu
+client_id: priority-demo-user
+events:
+  - timestamp: "2029-11-07T18:45:00Z"
+    event_type: acquisition
+    orbit: 2
+    duration_seconds: 20.0
+    instrument: INST_1
+    ground_visibility: false
+    region_type: ocean
+    services:
+      - service_id: emergency-detection
+        priority: 95
+        landscape_type: ocean
+        execution_mode: sequential
+        steps:
+          - name: preprocess-imagery
+            image: ghcr.io/example/preprocess:0.1.0
+            phase: preprocessing
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo preprocess-imagery"]
+          - name: ai-classify-emergency
+            image: ghcr.io/example/emergency-classifier:0.1.0
+            phase: ai
+            resource_class: gpu
+            fallback_resource_class: cpu
+            needs_acceleration: true
+            preferred_node_selector:
+              accelerator: nvidia
+            command: ["sh", "-c"]
+            args: ["echo ai-classify-emergency"]
+          - name: generate-alert-package
+            image: ghcr.io/example/alert-packager:0.1.0
+            phase: postprocessing
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo generate-alert-package"]

--- a/configs/mission_plans/sample_minimal_cpu.yaml
+++ b/configs/mission_plans/sample_minimal_cpu.yaml
@@ -1,0 +1,18 @@
+# Minimal valid plan: 1 ACQ event, 1 service, 1 CPU step.
+# Serves as the simplest baseline for schema validation testing.
+mission_id: mission-minimal-cpu
+client_id: minimal-user
+events:
+  - timestamp: "2029-11-06T10:00:00Z"
+    event_type: acquisition
+    instrument: INST_1
+    services:
+      - service_id: thumbnail-gen
+        priority: 10
+        execution_mode: sequential
+        steps:
+          - name: generate-thumbnail
+            image: busybox:1.36
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo generate-thumbnail"]

--- a/configs/mission_plans/sample_multi_instrument.yaml
+++ b/configs/mission_plans/sample_multi_instrument.yaml
@@ -1,0 +1,55 @@
+# Multi-instrument acquisition: 2 ACQ events with different instruments.
+# Demonstrates ORCHIDE slide 9 INST field variation (INST_1, INST_2).
+mission_id: mission-multi-instrument
+client_id: multi-inst-user
+events:
+  - timestamp: "2029-11-01T08:00:00Z"
+    event_type: acquisition
+    orbit: 1
+    duration_seconds: 6.0
+    instrument: INST_1
+    ground_visibility: false
+    region_type: land
+    services:
+      - service_id: vegetation-index
+        priority: 60
+        landscape_type: land
+        execution_mode: sequential
+        steps:
+          - name: calibrate
+            image: ghcr.io/example/calibrate:0.2.0
+            phase: preprocessing
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo calibrate"]
+          - name: compute-ndvi
+            image: ghcr.io/example/ndvi:0.2.0
+            phase: ai
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo compute-ndvi"]
+  - timestamp: "2029-11-01T08:10:00Z"
+    event_type: acquisition
+    orbit: 1
+    duration_seconds: 8.0
+    instrument: INST_2
+    ground_visibility: false
+    region_type: ocean
+    services:
+      - service_id: ocean-color
+        priority: 55
+        landscape_type: ocean
+        execution_mode: sequential
+        steps:
+          - name: radiometric-correction
+            image: ghcr.io/example/radiometric:0.2.0
+            phase: preprocessing
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo radiometric-correction"]
+          - name: chlorophyll-estimation
+            image: ghcr.io/example/chlorophyll:0.2.0
+            phase: ai
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo chlorophyll-estimation"]

--- a/configs/mission_plans/sample_multi_orbit.yaml
+++ b/configs/mission_plans/sample_multi_orbit.yaml
@@ -1,0 +1,86 @@
+# Multi-orbit mission: 3 ACQ events across orbits 1, 2, 3 with download at orbit 3.
+# Demonstrates ORCHIDE slide 9 multi-pass mission planning.
+mission_id: mission-multi-orbit
+client_id: multi-orbit-user
+events:
+  - timestamp: "2029-11-04T00:15:00Z"
+    event_type: acquisition
+    orbit: 1
+    duration_seconds: 5.0
+    instrument: INST_1
+    ground_visibility: false
+    region_type: land
+    services:
+      - service_id: terrain-mapping-pass1
+        priority: 50
+        landscape_type: land
+        execution_mode: sequential
+        steps:
+          - name: orthorectify
+            image: ghcr.io/example/ortho:0.2.0
+            phase: preprocessing
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo orthorectify"]
+          - name: dem-extract
+            image: ghcr.io/example/dem:0.2.0
+            phase: ai
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo dem-extract"]
+  - timestamp: "2029-11-04T01:45:00Z"
+    event_type: acquisition
+    orbit: 2
+    duration_seconds: 5.0
+    instrument: INST_1
+    ground_visibility: false
+    region_type: land
+    services:
+      - service_id: terrain-mapping-pass2
+        priority: 50
+        landscape_type: land
+        execution_mode: sequential
+        steps:
+          - name: orthorectify
+            image: ghcr.io/example/ortho:0.2.0
+            phase: preprocessing
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo orthorectify"]
+          - name: dem-extract
+            image: ghcr.io/example/dem:0.2.0
+            phase: ai
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo dem-extract"]
+  - timestamp: "2029-11-04T03:15:00Z"
+    event_type: acquisition
+    orbit: 3
+    duration_seconds: 5.0
+    instrument: INST_1
+    ground_visibility: false
+    region_type: land
+    services:
+      - service_id: terrain-mapping-pass3
+        priority: 50
+        landscape_type: land
+        execution_mode: sequential
+        steps:
+          - name: orthorectify
+            image: ghcr.io/example/ortho:0.2.0
+            phase: preprocessing
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo orthorectify"]
+          - name: dem-extract
+            image: ghcr.io/example/dem:0.2.0
+            phase: ai
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo dem-extract"]
+  - timestamp: "2029-11-04T04:30:00Z"
+    event_type: download
+    orbit: 3
+    duration_seconds: 300.0
+    instrument: X_BAND
+    ground_visibility: true

--- a/configs/mission_plans/sample_ocean_land_mixed.yaml
+++ b/configs/mission_plans/sample_ocean_land_mixed.yaml
@@ -1,0 +1,61 @@
+# Mixed ocean/land scenario: 1 ACQ event with 2 services targeting different landscapes.
+# Demonstrates ORCHIDE slide 9 landscape_type field (O=ocean, L=land) in a single pass.
+mission_id: mission-ocean-land-mixed
+client_id: mixed-landscape-user
+events:
+  - timestamp: "2029-11-05T14:20:00Z"
+    event_type: acquisition
+    orbit: 1
+    duration_seconds: 12.0
+    instrument: INST_1
+    ground_visibility: false
+    region_type: coastal
+    services:
+      - service_id: coastal-ship-detection
+        priority: 80
+        landscape_type: ocean
+        execution_mode: sequential
+        steps:
+          - name: preprocess-maritime
+            image: ghcr.io/example/preprocess:0.1.0
+            phase: preprocessing
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo preprocess-maritime"]
+          - name: detect-ships
+            image: ghcr.io/example/ship-detector:0.1.0
+            phase: ai
+            resource_class: gpu
+            fallback_resource_class: cpu
+            needs_acceleration: true
+            preferred_node_selector:
+              accelerator: nvidia
+            command: ["sh", "-c"]
+            args: ["echo detect-ships"]
+      - service_id: coastal-fire-detection
+        priority: 85
+        landscape_type: land
+        execution_mode: sequential
+        steps:
+          - name: preprocess-land
+            image: ghcr.io/example/preprocess:0.1.0
+            phase: preprocessing
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo preprocess-land"]
+          - name: detect-fires
+            image: ghcr.io/example/fire-detector:0.1.0
+            phase: ai
+            resource_class: gpu
+            fallback_resource_class: cpu
+            needs_acceleration: true
+            preferred_node_selector:
+              accelerator: nvidia
+            command: ["sh", "-c"]
+            args: ["echo detect-fires"]
+          - name: alert-generation
+            image: ghcr.io/example/alerter:0.1.0
+            phase: postprocessing
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo alert-generation"]

--- a/configs/mission_plans/sample_parallel_services.yaml
+++ b/configs/mission_plans/sample_parallel_services.yaml
@@ -1,0 +1,55 @@
+# Parallel execution mode: 1 ACQ event with 2 services in parallel.
+# Demonstrates ORCHIDE slide 14 concurrent workflow scheduling.
+mission_id: mission-parallel-services
+client_id: parallel-demo-user
+events:
+  - timestamp: "2029-11-02T12:00:00Z"
+    event_type: acquisition
+    orbit: 2
+    duration_seconds: 15.0
+    instrument: INST_1
+    ground_visibility: false
+    region_type: ocean
+    services:
+      - service_id: ship-tracking
+        priority: 85
+        landscape_type: ocean
+        execution_mode: parallel
+        steps:
+          - name: detect-vessels
+            image: ghcr.io/example/vessel-detector:0.3.0
+            phase: ai
+            resource_class: gpu
+            fallback_resource_class: cpu
+            needs_acceleration: true
+            preferred_node_selector:
+              accelerator: nvidia
+            command: ["sh", "-c"]
+            args: ["echo detect-vessels"]
+          - name: classify-vessels
+            image: ghcr.io/example/vessel-classifier:0.3.0
+            phase: ai
+            resource_class: gpu
+            fallback_resource_class: cpu
+            needs_acceleration: true
+            preferred_node_selector:
+              accelerator: nvidia
+            command: ["sh", "-c"]
+            args: ["echo classify-vessels"]
+      - service_id: wave-analysis
+        priority: 40
+        landscape_type: ocean
+        execution_mode: parallel
+        steps:
+          - name: extract-spectra
+            image: ghcr.io/example/spectra:0.3.0
+            phase: preprocessing
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo extract-spectra"]
+          - name: estimate-wave-height
+            image: ghcr.io/example/wave-height:0.3.0
+            phase: ai
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo estimate-wave-height"]

--- a/evals/golden/sample_download_only.expected.json
+++ b/evals/golden/sample_download_only.expected.json
@@ -1,0 +1,25 @@
+[
+  {
+    "service_id": "quicklook",
+    "priority": 20,
+    "workflow_name": "mission-download-only-quicklook-2029-11-08t05-00-00z",
+    "steps": [
+      {
+        "name": "generate-quicklook",
+        "resource_class": "cpu"
+      }
+    ],
+    "resource_hints": {
+      "event_timestamp": "2029-11-08T05:00:00Z",
+      "ground_visibility": false,
+      "region_type": null,
+      "orbit": 1,
+      "duration_seconds": 2.0,
+      "landscape_type": null,
+      "execution_mode": "sequential",
+      "requires_gpu": false,
+      "requires_fpga": false,
+      "fallback_enabled": false
+    }
+  }
+]

--- a/evals/golden/sample_fpga_signal.expected.json
+++ b/evals/golden/sample_fpga_signal.expected.json
@@ -1,0 +1,33 @@
+[
+  {
+    "service_id": "sar-compression",
+    "priority": 70,
+    "workflow_name": "mission-fpga-signal-sar-compression-2029-11-03t06-30-00z",
+    "steps": [
+      {
+        "name": "raw-iq-decode",
+        "resource_class": "cpu"
+      },
+      {
+        "name": "fpga-compress",
+        "resource_class": "fpga"
+      },
+      {
+        "name": "package-output",
+        "resource_class": "cpu"
+      }
+    ],
+    "resource_hints": {
+      "event_timestamp": "2029-11-03T06:30:00Z",
+      "ground_visibility": false,
+      "region_type": "land",
+      "orbit": 1,
+      "duration_seconds": 3.0,
+      "landscape_type": "land",
+      "execution_mode": "sequential",
+      "requires_gpu": false,
+      "requires_fpga": true,
+      "fallback_enabled": true
+    }
+  }
+]

--- a/evals/golden/sample_high_priority_gpu.expected.json
+++ b/evals/golden/sample_high_priority_gpu.expected.json
@@ -1,0 +1,33 @@
+[
+  {
+    "service_id": "emergency-detection",
+    "priority": 95,
+    "workflow_name": "mission-high-priority-gpu-emergency-detection-2029-11-07t18-45-",
+    "steps": [
+      {
+        "name": "preprocess-imagery",
+        "resource_class": "cpu"
+      },
+      {
+        "name": "ai-classify-emergency",
+        "resource_class": "gpu"
+      },
+      {
+        "name": "generate-alert-package",
+        "resource_class": "cpu"
+      }
+    ],
+    "resource_hints": {
+      "event_timestamp": "2029-11-07T18:45:00Z",
+      "ground_visibility": false,
+      "region_type": "ocean",
+      "orbit": 2,
+      "duration_seconds": 20.0,
+      "landscape_type": "ocean",
+      "execution_mode": "sequential",
+      "requires_gpu": true,
+      "requires_fpga": false,
+      "fallback_enabled": true
+    }
+  }
+]

--- a/evals/golden/sample_high_priority_gpu.expected.json
+++ b/evals/golden/sample_high_priority_gpu.expected.json
@@ -2,7 +2,7 @@
   {
     "service_id": "emergency-detection",
     "priority": 95,
-    "workflow_name": "mission-high-priority-gpu-emergency-detection-2029-11-07t18-45-",
+    "workflow_name": "mission-high-priority-gpu-emergency-detection-2029-11-07t18-45",
     "steps": [
       {
         "name": "preprocess-imagery",

--- a/evals/golden/sample_minimal_cpu.expected.json
+++ b/evals/golden/sample_minimal_cpu.expected.json
@@ -1,0 +1,25 @@
+[
+  {
+    "service_id": "thumbnail-gen",
+    "priority": 10,
+    "workflow_name": "mission-minimal-cpu-thumbnail-gen-2029-11-06t10-00-00z",
+    "steps": [
+      {
+        "name": "generate-thumbnail",
+        "resource_class": "cpu"
+      }
+    ],
+    "resource_hints": {
+      "event_timestamp": "2029-11-06T10:00:00Z",
+      "ground_visibility": false,
+      "region_type": null,
+      "orbit": null,
+      "duration_seconds": null,
+      "landscape_type": null,
+      "execution_mode": "sequential",
+      "requires_gpu": false,
+      "requires_fpga": false,
+      "fallback_enabled": false
+    }
+  }
+]

--- a/evals/golden/sample_multi_instrument.expected.json
+++ b/evals/golden/sample_multi_instrument.expected.json
@@ -1,0 +1,56 @@
+[
+  {
+    "service_id": "vegetation-index",
+    "priority": 60,
+    "workflow_name": "mission-multi-instrument-vegetation-index-2029-11-01t08-00-00z",
+    "steps": [
+      {
+        "name": "calibrate",
+        "resource_class": "cpu"
+      },
+      {
+        "name": "compute-ndvi",
+        "resource_class": "cpu"
+      }
+    ],
+    "resource_hints": {
+      "event_timestamp": "2029-11-01T08:00:00Z",
+      "ground_visibility": false,
+      "region_type": "land",
+      "orbit": 1,
+      "duration_seconds": 6.0,
+      "landscape_type": "land",
+      "execution_mode": "sequential",
+      "requires_gpu": false,
+      "requires_fpga": false,
+      "fallback_enabled": false
+    }
+  },
+  {
+    "service_id": "ocean-color",
+    "priority": 55,
+    "workflow_name": "mission-multi-instrument-ocean-color-2029-11-01t08-10-00z",
+    "steps": [
+      {
+        "name": "radiometric-correction",
+        "resource_class": "cpu"
+      },
+      {
+        "name": "chlorophyll-estimation",
+        "resource_class": "cpu"
+      }
+    ],
+    "resource_hints": {
+      "event_timestamp": "2029-11-01T08:10:00Z",
+      "ground_visibility": false,
+      "region_type": "ocean",
+      "orbit": 1,
+      "duration_seconds": 8.0,
+      "landscape_type": "ocean",
+      "execution_mode": "sequential",
+      "requires_gpu": false,
+      "requires_fpga": false,
+      "fallback_enabled": false
+    }
+  }
+]

--- a/evals/golden/sample_multi_orbit.expected.json
+++ b/evals/golden/sample_multi_orbit.expected.json
@@ -1,0 +1,83 @@
+[
+  {
+    "service_id": "terrain-mapping-pass1",
+    "priority": 50,
+    "workflow_name": "mission-multi-orbit-terrain-mapping-pass1-2029-11-04t00-15-00z",
+    "steps": [
+      {
+        "name": "orthorectify",
+        "resource_class": "cpu"
+      },
+      {
+        "name": "dem-extract",
+        "resource_class": "cpu"
+      }
+    ],
+    "resource_hints": {
+      "event_timestamp": "2029-11-04T00:15:00Z",
+      "ground_visibility": false,
+      "region_type": "land",
+      "orbit": 1,
+      "duration_seconds": 5.0,
+      "landscape_type": "land",
+      "execution_mode": "sequential",
+      "requires_gpu": false,
+      "requires_fpga": false,
+      "fallback_enabled": false
+    }
+  },
+  {
+    "service_id": "terrain-mapping-pass2",
+    "priority": 50,
+    "workflow_name": "mission-multi-orbit-terrain-mapping-pass2-2029-11-04t01-45-00z",
+    "steps": [
+      {
+        "name": "orthorectify",
+        "resource_class": "cpu"
+      },
+      {
+        "name": "dem-extract",
+        "resource_class": "cpu"
+      }
+    ],
+    "resource_hints": {
+      "event_timestamp": "2029-11-04T01:45:00Z",
+      "ground_visibility": false,
+      "region_type": "land",
+      "orbit": 2,
+      "duration_seconds": 5.0,
+      "landscape_type": "land",
+      "execution_mode": "sequential",
+      "requires_gpu": false,
+      "requires_fpga": false,
+      "fallback_enabled": false
+    }
+  },
+  {
+    "service_id": "terrain-mapping-pass3",
+    "priority": 50,
+    "workflow_name": "mission-multi-orbit-terrain-mapping-pass3-2029-11-04t03-15-00z",
+    "steps": [
+      {
+        "name": "orthorectify",
+        "resource_class": "cpu"
+      },
+      {
+        "name": "dem-extract",
+        "resource_class": "cpu"
+      }
+    ],
+    "resource_hints": {
+      "event_timestamp": "2029-11-04T03:15:00Z",
+      "ground_visibility": false,
+      "region_type": "land",
+      "orbit": 3,
+      "duration_seconds": 5.0,
+      "landscape_type": "land",
+      "execution_mode": "sequential",
+      "requires_gpu": false,
+      "requires_fpga": false,
+      "fallback_enabled": false
+    }
+  }
+]

--- a/evals/golden/sample_ocean_land_mixed.expected.json
+++ b/evals/golden/sample_ocean_land_mixed.expected.json
@@ -1,0 +1,60 @@
+[
+  {
+    "service_id": "coastal-ship-detection",
+    "priority": 80,
+    "workflow_name": "mission-ocean-land-mixed-coastal-ship-detection-2029-11-05t14-2",
+    "steps": [
+      {
+        "name": "preprocess-maritime",
+        "resource_class": "cpu"
+      },
+      {
+        "name": "detect-ships",
+        "resource_class": "gpu"
+      }
+    ],
+    "resource_hints": {
+      "event_timestamp": "2029-11-05T14:20:00Z",
+      "ground_visibility": false,
+      "region_type": "coastal",
+      "orbit": 1,
+      "duration_seconds": 12.0,
+      "landscape_type": "ocean",
+      "execution_mode": "sequential",
+      "requires_gpu": true,
+      "requires_fpga": false,
+      "fallback_enabled": true
+    }
+  },
+  {
+    "service_id": "coastal-fire-detection",
+    "priority": 85,
+    "workflow_name": "mission-ocean-land-mixed-coastal-fire-detection-2029-11-05t14-2",
+    "steps": [
+      {
+        "name": "preprocess-land",
+        "resource_class": "cpu"
+      },
+      {
+        "name": "detect-fires",
+        "resource_class": "gpu"
+      },
+      {
+        "name": "alert-generation",
+        "resource_class": "cpu"
+      }
+    ],
+    "resource_hints": {
+      "event_timestamp": "2029-11-05T14:20:00Z",
+      "ground_visibility": false,
+      "region_type": "coastal",
+      "orbit": 1,
+      "duration_seconds": 12.0,
+      "landscape_type": "land",
+      "execution_mode": "sequential",
+      "requires_gpu": true,
+      "requires_fpga": false,
+      "fallback_enabled": true
+    }
+  }
+]

--- a/evals/golden/sample_parallel_services.expected.json
+++ b/evals/golden/sample_parallel_services.expected.json
@@ -1,0 +1,56 @@
+[
+  {
+    "service_id": "ship-tracking",
+    "priority": 85,
+    "workflow_name": "mission-parallel-services-ship-tracking-2029-11-02t12-00-00z",
+    "steps": [
+      {
+        "name": "detect-vessels",
+        "resource_class": "gpu"
+      },
+      {
+        "name": "classify-vessels",
+        "resource_class": "gpu"
+      }
+    ],
+    "resource_hints": {
+      "event_timestamp": "2029-11-02T12:00:00Z",
+      "ground_visibility": false,
+      "region_type": "ocean",
+      "orbit": 2,
+      "duration_seconds": 15.0,
+      "landscape_type": "ocean",
+      "execution_mode": "parallel",
+      "requires_gpu": true,
+      "requires_fpga": false,
+      "fallback_enabled": true
+    }
+  },
+  {
+    "service_id": "wave-analysis",
+    "priority": 40,
+    "workflow_name": "mission-parallel-services-wave-analysis-2029-11-02t12-00-00z",
+    "steps": [
+      {
+        "name": "extract-spectra",
+        "resource_class": "cpu"
+      },
+      {
+        "name": "estimate-wave-height",
+        "resource_class": "cpu"
+      }
+    ],
+    "resource_hints": {
+      "event_timestamp": "2029-11-02T12:00:00Z",
+      "ground_visibility": false,
+      "region_type": "ocean",
+      "orbit": 2,
+      "duration_seconds": 15.0,
+      "landscape_type": "ocean",
+      "execution_mode": "parallel",
+      "requires_gpu": false,
+      "requires_fpga": false,
+      "fallback_enabled": false
+    }
+  }
+]

--- a/evals/golden/validation_live_cluster.expected.json
+++ b/evals/golden/validation_live_cluster.expected.json
@@ -1,0 +1,33 @@
+[
+  {
+    "service_id": "ship-detection",
+    "priority": 80,
+    "workflow_name": "validation-live-ship-detection-2026-04-02t23-00-00z",
+    "steps": [
+      {
+        "name": "preprocess",
+        "resource_class": "cpu"
+      },
+      {
+        "name": "detect",
+        "resource_class": "cpu"
+      },
+      {
+        "name": "postprocess",
+        "resource_class": "cpu"
+      }
+    ],
+    "resource_hints": {
+      "event_timestamp": "2026-04-02T23:00:00Z",
+      "ground_visibility": false,
+      "region_type": "ocean",
+      "orbit": 1,
+      "duration_seconds": 10.0,
+      "landscape_type": "ocean",
+      "execution_mode": "sequential",
+      "requires_gpu": false,
+      "requires_fpga": false,
+      "fallback_enabled": false
+    }
+  }
+]

--- a/src/orbital_mission_compiler/compiler.py
+++ b/src/orbital_mission_compiler/compiler.py
@@ -18,7 +18,7 @@ def sanitize_k8s_name(name: str, max_len: int = 63) -> str:
     s = re.sub(r"[^a-z0-9-]", "-", s)
     s = re.sub(r"-+", "-", s)
     s = s.strip("-")
-    return s[:max_len] or "step"
+    return s[:max_len].rstrip("-") or "step"
 
 
 def scale_priority_orchide(priority: int) -> int:

--- a/src/orbital_mission_compiler/eval_runner.py
+++ b/src/orbital_mission_compiler/eval_runner.py
@@ -10,7 +10,7 @@ PLANS_DIR = _REPO_ROOT / "configs" / "mission_plans"
 GOLDEN_DIR = _REPO_ROOT / "evals" / "golden"
 
 
-def _discover_cases() -> tuple[list[tuple[Path, Path]], list[Path]]:
+def discover_cases() -> tuple[list[tuple[Path, Path]], list[Path]]:
     """Auto-discover eval cases: for each golden .expected.json, find matching plan.
 
     Returns (cases, orphans) where orphans are golden files with no matching plan.
@@ -27,7 +27,7 @@ def _discover_cases() -> tuple[list[tuple[Path, Path]], list[Path]]:
     return cases, orphans
 
 
-def _run_case(mission_file: Path, golden_file: Path) -> tuple[bool, str]:
+def run_case(mission_file: Path, golden_file: Path) -> tuple[bool, str]:
     plan = load_mission_plan(mission_file)
     intents = compile_plan_to_intents(plan)
     actual = [
@@ -50,7 +50,7 @@ def _run_case(mission_file: Path, golden_file: Path) -> tuple[bool, str]:
 
 
 def main() -> int:
-    cases, orphans = _discover_cases()
+    cases, orphans = discover_cases()
     if orphans:
         for o in orphans:
             print(f"EVAL ERROR: golden file {o.name} has no matching plan in {PLANS_DIR}")
@@ -60,7 +60,7 @@ def main() -> int:
         return 1
     failed = []
     for mission, golden in cases:
-        ok, msg = _run_case(mission, golden)
+        ok, msg = run_case(mission, golden)
         if ok:
             print(f"EVAL PASSED: {msg}")
         else:

--- a/tests/test_mission_plans_corpus.py
+++ b/tests/test_mission_plans_corpus.py
@@ -6,12 +6,12 @@ to serve as a representative test suite for the compiler pipeline.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
 from orbital_mission_compiler.compiler import load_mission_plan, compile_plan_to_intents
-from orbital_mission_compiler.eval_runner import _discover_cases, _run_case
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 PLANS_DIR = _REPO_ROOT / "configs" / "mission_plans"
@@ -48,15 +48,22 @@ def test_plan_loads_successfully(plan_path: Path) -> None:
 
 @pytest.mark.parametrize("plan_path", _ALL_PLAN_PATHS, ids=_plan_ids())
 def test_plan_compiles_to_intents(plan_path: Path) -> None:
-    """Each plan with acquisition events must produce at least 1 WorkflowIntent."""
+    """Each plan with acquisition+service events must produce WorkflowIntents."""
     plan = load_mission_plan(plan_path)
     intents = compile_plan_to_intents(plan)
-    acq_count = sum(
+    acq_with_services = sum(
         1 for ev in plan.events if ev.event_type.value == "acquisition" and ev.services
     )
-    assert len(intents) >= 1, (
-        f"{plan_path.name}: expected at least 1 intent from {acq_count} acquisition event(s)"
-    )
+    if acq_with_services == 0:
+        assert len(intents) == 0, (
+            f"{plan_path.name}: no acquisition events with services, "
+            f"expected 0 intents but got {len(intents)}"
+        )
+    else:
+        assert len(intents) >= 1, (
+            f"{plan_path.name}: {acq_with_services} acquisition event(s) with services "
+            f"but got 0 intents"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -64,23 +71,63 @@ def test_plan_compiles_to_intents(plan_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _discover_golden_cases() -> tuple[list[tuple[Path, Path]], list[Path]]:
+    """Discover (plan, golden) pairs. Returns (cases, orphans)."""
+    cases = []
+    orphans = []
+    for golden in sorted(GOLDEN_DIR.glob("*.expected.json")):
+        stem = golden.name.removesuffix(".expected.json")
+        plan = PLANS_DIR / f"{stem}.yaml"
+        if plan.exists():
+            cases.append((plan, golden))
+        else:
+            orphans.append(golden)
+    return cases, orphans
+
+
+def _run_golden_case(mission_file: Path, golden_file: Path) -> tuple[bool, str]:
+    """Compare compiler output against golden expected JSON."""
+    plan = load_mission_plan(mission_file)
+    intents = compile_plan_to_intents(plan)
+    actual = [
+        {
+            "service_id": i.service_id,
+            "priority": i.priority,
+            "workflow_name": i.workflow_name,
+            "steps": [
+                {"name": s.name, "resource_class": s.resource_class.value}
+                for s in i.steps
+            ],
+            "resource_hints": i.resource_hints,
+        }
+        for i in intents
+    ]
+    expected = json.loads(golden_file.read_text(encoding="utf-8"))
+    if actual != expected:
+        return False, json.dumps({"expected": expected, "actual": actual}, indent=2)
+    return True, ""
+
+
 def test_all_golden_evals_pass() -> None:
     """All golden eval files must match current compiler output exactly."""
-    cases, orphans = _discover_cases()
+    cases, orphans = _discover_golden_cases()
     assert not orphans, (
         f"Orphan golden files with no matching plan: {[o.name for o in orphans]}"
     )
     assert len(cases) >= 1, "No golden eval cases discovered"
 
+    first_diff: str | None = None
     failures = []
     for mission, golden in cases:
-        ok, msg = _run_case(mission, golden)
+        ok, msg = _run_golden_case(mission, golden)
         if not ok:
             failures.append(mission.name)
+            if first_diff is None:
+                first_diff = msg
 
     assert not failures, (
-        f"Golden eval mismatches for: {failures}. "
-        "Re-generate with: PYTHONPATH=src:. python3 scripts/run_eval.sh"
+        f"Golden eval mismatches for: {failures}\n"
+        f"First mismatch detail:\n{first_diff}"
     )
 
 

--- a/tests/test_mission_plans_corpus.py
+++ b/tests/test_mission_plans_corpus.py
@@ -6,19 +6,20 @@ to serve as a representative test suite for the compiler pipeline.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import pytest
 
 from orbital_mission_compiler.compiler import load_mission_plan, compile_plan_to_intents
+from orbital_mission_compiler.eval_runner import discover_cases, run_case
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 PLANS_DIR = _REPO_ROOT / "configs" / "mission_plans"
 GOLDEN_DIR = _REPO_ROOT / "evals" / "golden"
 
 # ---------------------------------------------------------------------------
-# Discover all plans once (avoid repeated filesystem + YAML parsing per test)
+# Discover all plan file paths once (avoids repeated glob per test;
+# individual tests still load/parse plans as needed).
 # ---------------------------------------------------------------------------
 
 _ALL_PLAN_PATHS = sorted(PLANS_DIR.glob("*.yaml"))
@@ -71,46 +72,9 @@ def test_plan_compiles_to_intents(plan_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _discover_golden_cases() -> tuple[list[tuple[Path, Path]], list[Path]]:
-    """Discover (plan, golden) pairs. Returns (cases, orphans)."""
-    cases = []
-    orphans = []
-    for golden in sorted(GOLDEN_DIR.glob("*.expected.json")):
-        stem = golden.name.removesuffix(".expected.json")
-        plan = PLANS_DIR / f"{stem}.yaml"
-        if plan.exists():
-            cases.append((plan, golden))
-        else:
-            orphans.append(golden)
-    return cases, orphans
-
-
-def _run_golden_case(mission_file: Path, golden_file: Path) -> tuple[bool, str]:
-    """Compare compiler output against golden expected JSON."""
-    plan = load_mission_plan(mission_file)
-    intents = compile_plan_to_intents(plan)
-    actual = [
-        {
-            "service_id": i.service_id,
-            "priority": i.priority,
-            "workflow_name": i.workflow_name,
-            "steps": [
-                {"name": s.name, "resource_class": s.resource_class.value}
-                for s in i.steps
-            ],
-            "resource_hints": i.resource_hints,
-        }
-        for i in intents
-    ]
-    expected = json.loads(golden_file.read_text(encoding="utf-8"))
-    if actual != expected:
-        return False, json.dumps({"expected": expected, "actual": actual}, indent=2)
-    return True, ""
-
-
 def test_all_golden_evals_pass() -> None:
     """All golden eval files must match current compiler output exactly."""
-    cases, orphans = _discover_golden_cases()
+    cases, orphans = discover_cases()
     assert not orphans, (
         f"Orphan golden files with no matching plan: {[o.name for o in orphans]}"
     )
@@ -119,7 +83,7 @@ def test_all_golden_evals_pass() -> None:
     first_diff: str | None = None
     failures = []
     for mission, golden in cases:
-        ok, msg = _run_golden_case(mission, golden)
+        ok, msg = run_case(mission, golden)
         if not ok:
             failures.append(mission.name)
             if first_diff is None:

--- a/tests/test_mission_plans_corpus.py
+++ b/tests/test_mission_plans_corpus.py
@@ -1,0 +1,186 @@
+"""Corpus completeness tests for mission plans.
+
+Verifies that the mission plan corpus has sufficient size and diversity
+to serve as a representative test suite for the compiler pipeline.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from orbital_mission_compiler.compiler import load_mission_plan, compile_plan_to_intents
+from orbital_mission_compiler.eval_runner import _discover_cases, _run_case
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+PLANS_DIR = _REPO_ROOT / "configs" / "mission_plans"
+GOLDEN_DIR = _REPO_ROOT / "evals" / "golden"
+
+# ---------------------------------------------------------------------------
+# Discover all plans once (avoid repeated filesystem + YAML parsing per test)
+# ---------------------------------------------------------------------------
+
+_ALL_PLAN_PATHS = sorted(PLANS_DIR.glob("*.yaml"))
+
+
+def _plan_ids() -> list[str]:
+    return [p.stem for p in _ALL_PLAN_PATHS]
+
+
+# ---------------------------------------------------------------------------
+# 1. Every plan loads and validates successfully
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("plan_path", _ALL_PLAN_PATHS, ids=_plan_ids())
+def test_plan_loads_successfully(plan_path: Path) -> None:
+    """Each YAML plan must parse and pass Pydantic schema validation."""
+    plan = load_mission_plan(plan_path)
+    assert plan.mission_id, f"{plan_path.name}: mission_id must not be empty"
+    assert len(plan.events) >= 1, f"{plan_path.name}: must have at least 1 event"
+
+
+# ---------------------------------------------------------------------------
+# 2. Every plan compiles to at least 1 workflow intent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("plan_path", _ALL_PLAN_PATHS, ids=_plan_ids())
+def test_plan_compiles_to_intents(plan_path: Path) -> None:
+    """Each plan with acquisition events must produce at least 1 WorkflowIntent."""
+    plan = load_mission_plan(plan_path)
+    intents = compile_plan_to_intents(plan)
+    acq_count = sum(
+        1 for ev in plan.events if ev.event_type.value == "acquisition" and ev.services
+    )
+    assert len(intents) >= 1, (
+        f"{plan_path.name}: expected at least 1 intent from {acq_count} acquisition event(s)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Every plan with a golden eval passes the eval runner
+# ---------------------------------------------------------------------------
+
+
+def test_all_golden_evals_pass() -> None:
+    """All golden eval files must match current compiler output exactly."""
+    cases, orphans = _discover_cases()
+    assert not orphans, (
+        f"Orphan golden files with no matching plan: {[o.name for o in orphans]}"
+    )
+    assert len(cases) >= 1, "No golden eval cases discovered"
+
+    failures = []
+    for mission, golden in cases:
+        ok, msg = _run_case(mission, golden)
+        if not ok:
+            failures.append(mission.name)
+
+    assert not failures, (
+        f"Golden eval mismatches for: {failures}. "
+        "Re-generate with: PYTHONPATH=src:. python3 scripts/run_eval.sh"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Corpus has at least 10 plans
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_minimum_size() -> None:
+    """Issue #53 requires 10-20 domain-expert-annotated mission plans."""
+    assert len(_ALL_PLAN_PATHS) >= 10, (
+        f"Corpus has only {len(_ALL_PLAN_PATHS)} plans, need at least 10"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Plans cover diverse resource classes (CPU, GPU, FPGA)
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_covers_resource_classes() -> None:
+    """The corpus must exercise CPU, GPU, and FPGA resource classes."""
+    observed_classes: set[str] = set()
+    for plan_path in _ALL_PLAN_PATHS:
+        plan = load_mission_plan(plan_path)
+        intents = compile_plan_to_intents(plan)
+        for intent in intents:
+            for step in intent.steps:
+                observed_classes.add(step.resource_class.value)
+
+    required = {"cpu", "gpu", "fpga"}
+    missing = required - observed_classes
+    assert not missing, (
+        f"Resource classes not covered by any plan: {missing}. "
+        f"Observed: {observed_classes}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Plans cover both execution modes (sequential, parallel)
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_covers_execution_modes() -> None:
+    """The corpus must exercise both sequential and parallel execution modes."""
+    observed_modes: set[str] = set()
+    for plan_path in _ALL_PLAN_PATHS:
+        plan = load_mission_plan(plan_path)
+        intents = compile_plan_to_intents(plan)
+        for intent in intents:
+            mode = intent.resource_hints.get("execution_mode", "sequential")
+            observed_modes.add(mode)
+
+    required = {"sequential", "parallel"}
+    missing = required - observed_modes
+    assert not missing, (
+        f"Execution modes not covered by any plan: {missing}. "
+        f"Observed: {observed_modes}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. Plans cover both landscape types (ocean, land)
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_covers_landscape_types() -> None:
+    """The corpus should exercise both ocean and land landscape types."""
+    observed_types: set[str] = set()
+    for plan_path in _ALL_PLAN_PATHS:
+        plan = load_mission_plan(plan_path)
+        intents = compile_plan_to_intents(plan)
+        for intent in intents:
+            lt = intent.resource_hints.get("landscape_type")
+            if lt is not None:
+                observed_types.add(lt)
+
+    required = {"ocean", "land"}
+    missing = required - observed_types
+    assert not missing, (
+        f"Landscape types not covered by any plan: {missing}. "
+        f"Observed: {observed_types}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8. Every golden eval file has a corresponding plan
+# ---------------------------------------------------------------------------
+
+
+def test_golden_eval_coverage() -> None:
+    """Every plan in the corpus should have a golden eval file."""
+    plans_with_evals = {
+        g.name.removesuffix(".expected.json")
+        for g in GOLDEN_DIR.glob("*.expected.json")
+    }
+    plans_without_evals = [
+        p.stem for p in _ALL_PLAN_PATHS if p.stem not in plans_with_evals
+    ]
+    assert not plans_without_evals, (
+        f"Plans missing golden evals: {plans_without_evals}. "
+        "Generate with the eval generation script."
+    )


### PR DESCRIPTION
## Summary
- Add 8 new domain-diverse mission plans (total: 12 plans, up from 4)
- Add 9 new golden evals (total: 12, 100% coverage including `validation_live_cluster`)
- Add `tests/test_mission_plans_corpus.py` (30 tests) verifying corpus completeness

### New plans

| Plan | Scenario | Coverage |
|------|----------|----------|
| `sample_multi_instrument.yaml` | 2 ACQ events, INST_1 + INST_2 | Multi-instrument |
| `sample_parallel_services.yaml` | 2 services in parallel mode | `execution_mode: parallel` |
| `sample_fpga_signal.yaml` | FPGA signal processing + CPU fallback | `resource_class: fpga` |
| `sample_multi_orbit.yaml` | 3 ACQ across orbits 1-3 + download | Multi-orbit |
| `sample_ocean_land_mixed.yaml` | Ocean + land services in 1 ACQ | Mixed `landscape_type` |
| `sample_minimal_cpu.yaml` | Simplest valid plan | Baseline |
| `sample_high_priority_gpu.yaml` | Priority 95, 3-phase GPU pipeline | High priority + GPU |
| `sample_download_only.yaml` | Minimal ACQ + download | Download event |

### Corpus coverage verified by tests
- CPU, GPU, FPGA resource classes
- Sequential and parallel execution modes
- Ocean and land landscape types
- Every plan has a matching golden eval

## Test plan
- [x] 30 new corpus tests pass
- [x] 12/12 golden evals pass
- [x] 286 existing tests unaffected
- [x] Total: 316 passed, 41 skipped