### PR TITLE
Add expanded multi-system comparison table (#53)

### DIFF
--- a/docs/16_comparison_table.md
+++ b/docs/16_comparison_table.md
@@ -42,7 +42,7 @@
 |---|---|---|---|---|---|
 | **Hardware Abstraction** | ResourceClass enum (CPU/GPU/FPGA) + DRA ResourceClaimTemplate + legacy extended resources | Hardware-specific: Jetson, Versal, LX2160, Kalray via ukAccel | Cloud VMs (no accelerator abstraction) | Standard K8s nodes | Cloud VMs |
 | **Extensibility Model** | Library + CLI + MCP tools; pip-installable | Embedded glue code in Mission Manager | 160+ microservice repos | Custom kube-apiserver patches | Argo + CWL runner |
-| **AI Agent Interface** | MCP server (6 tools: validate, compile, render, explain, diff, conflicts) | None | None | None | None |
+| **AI Agent Interface** | MCP server (6 tools: validate_plan, compile_plan, render_argo, explain_policy, diff_plans, check_timeline_conflicts) | None | None | None | None |
 
 ### 2.4 Operational Scope
 
@@ -61,7 +61,7 @@ This compiler occupies a unique niche as the only system that combines:
 
 1. **Schema + Policy dual-layer validation** — no other compared system has policy-as-code for mission plans
 2. **Step-level artifact granularity** — phase annotations, resource class, fallback per container (vs workflow-level in others)
-3. **Kueue admission with DRA** — Kubernetes-native queue-based scheduling with `resource.k8s.io/v1` ResourceClaimTemplates
+3. **Kueue admission with DRA** — Kubernetes-native queue-based scheduling with `resource.k8s.io/v1` `ResourceClaimTemplate` objects
 4. **MCP agent interface** — the only space-related system exposing compilation tools to AI agents
 5. **CCSDS 522.0-B alignment** — Plan Elaboration terminology mapped; no other system documents this
 

--- a/docs/16_comparison_table.md
+++ b/docs/16_comparison_table.md
@@ -1,0 +1,77 @@
+# 16 — Expanded Comparison Table
+
+> Multi-dimensional comparison of this compiler against related systems.
+> Addresses IEEE SMC-IT/SCC 2026 reviewer feedback: expand Table I with
+> problem layer, artifact granularity, and scheduling scope dimensions.
+
+---
+
+## 1. Systems Compared
+
+| System | Role | Source |
+|---|---|---|
+| **This compiler** | Ground-side mission plan compiler | This repo |
+| **ORCHIDE** | Onboard satellite PaaS (K3s + Argo) | KubeCon EU 2026, D3.1 |
+| **EOEPCA+** | ESA EO exploitation platform | eoepca.org (160+ repos) |
+| **KubeSpace** | LEO satellite K8s control plane | arXiv:2601.21383, Fudan 2026 |
+| **DLR Sentinel+Argo** | Copernicus image processing pipeline | DLR eLib, 2021 |
+
+---
+
+## 2. Multi-Dimensional Comparison
+
+### 2.1 Reviewer-Requested Dimensions
+
+| Dimension | This Compiler | ORCHIDE | EOEPCA+ | KubeSpace | DLR Sentinel+Argo |
+|---|---|---|---|---|---|
+| **Problem Layer** | Plan validation + compilation (ground) | Workflow execution (onboard) | Data exploitation (ground) | Cluster management (LEO) | Image processing (ground) |
+| **Artifact Granularity** | Step-level: individual container specs with phase annotations, resource classes, and fallback | Workflow-level: Argo DAG from priority queue | Service-level: OGC Application Package | Pod-level: scheduling decisions | Workflow-level: CWL → Argo |
+| **Scheduling Scope** | Single-workflow admission via Kueue (queue-name, priority, DRA) | Multi-workflow preemption via custom priority queue | No scheduling (user-submitted jobs) | Constellation-wide pod placement across LEO nodes | Single-workflow submission |
+
+### 2.2 Validation & Policy
+
+| Dimension | This Compiler | ORCHIDE | EOEPCA+ | KubeSpace | DLR Sentinel+Argo |
+|---|---|---|---|---|---|
+| **Validation Approach** | Schema (Pydantic) + Policy-as-code (OPA/Rego), 12 error categories | None documented | OGC schema validation | None (cluster-level only) | None (assumes valid CWL) |
+| **Policy Framework** | OPA/Rego: 10 deny rules, ORCHIDE slide-traceable | None | None | None | None |
+| **Defense-in-Depth** | 5 rules overlap between schema + policy layers | N/A | N/A | N/A | N/A |
+
+### 2.3 Hardware & Extensibility
+
+| Dimension | This Compiler | ORCHIDE | EOEPCA+ | KubeSpace | DLR Sentinel+Argo |
+|---|---|---|---|---|---|
+| **Hardware Abstraction** | ResourceClass enum (CPU/GPU/FPGA) + DRA ResourceClaimTemplate + legacy extended resources | Hardware-specific: Jetson, Versal, LX2160, Kalray via ukAccel | Cloud VMs (no accelerator abstraction) | Standard K8s nodes | Cloud VMs |
+| **Extensibility Model** | Library + CLI + MCP tools; pip-installable | Embedded glue code in Mission Manager | 160+ microservice repos | Custom kube-apiserver patches | Argo + CWL runner |
+| **AI Agent Interface** | MCP server (6 tools: validate, compile, render, explain, diff, conflicts) | None | None | None | None |
+
+### 2.4 Operational Scope
+
+| Dimension | This Compiler | ORCHIDE | EOEPCA+ | KubeSpace | DLR Sentinel+Argo |
+|---|---|---|---|---|---|
+| **Execution Environment** | Ground-side development/CI | Onboard satellite (ARM64) | Ground cloud (x86/ARM) | LEO satellite constellation | Ground cloud (x86) |
+| **ORCHIDE Relationship** | Ground-side complement (pre-deployment) | Self-contained platform | Independent | Independent | Independent |
+| **CCSDS Alignment** | Plan Elaboration (522.0-B terminology mapped) | Not documented | Partial (OGC standards) | None | None |
+| **Open Source** | Yes (EUPL-1.2) | Announced, pending (ends 2026/05) | Yes (Apache-2.0) | Yes | Yes |
+
+---
+
+## 3. Key Differentiators Summary
+
+This compiler occupies a unique niche as the only system that combines:
+
+1. **Schema + Policy dual-layer validation** — no other compared system has policy-as-code for mission plans
+2. **Step-level artifact granularity** — phase annotations, resource class, fallback per container (vs workflow-level in others)
+3. **Kueue admission with DRA** — Kubernetes-native queue-based scheduling with `resource.k8s.io/v1` ResourceClaimTemplates
+4. **MCP agent interface** — the only space-related system exposing compilation tools to AI agents
+5. **CCSDS 522.0-B alignment** — Plan Elaboration terminology mapped; no other system documents this
+
+---
+
+## 4. Limitations (Honest Assessment)
+
+| Limitation | This Compiler | Systems That Do Better |
+|---|---|---|
+| No onboard execution | Ground-only; depends on ORCHIDE for satellite runtime | ORCHIDE (full onboard PaaS) |
+| Single-satellite scope | No constellation-level scheduling | KubeSpace (LEO constellation) |
+| No data exploitation | Produces workflow YAML, not data products | EOEPCA+ (full EO pipeline) |
+| Research prototype | TRL ~3 (lab validation) | ORCHIDE (TRL6), EOEPCA+ (production) |

--- a/docs/16_comparison_table.md
+++ b/docs/16_comparison_table.md
@@ -1,6 +1,6 @@
 # 16 — Expanded Comparison Table
 
-> Multi-dimensional comparison of this compiler against related systems.
+> 5 systems × 13 dimensions comparison of this compiler against related systems.
 > Addresses IEEE SMC-IT/SCC 2026 reviewer feedback: expand Table I with
 > problem layer, artifact granularity, and scheduling scope dimensions.
 
@@ -32,7 +32,7 @@
 
 | Dimension | This Compiler | ORCHIDE | EOEPCA+ | KubeSpace | DLR Sentinel+Argo |
 |---|---|---|---|---|---|
-| **Validation Approach** | Schema (Pydantic) + Policy-as-code (OPA/Rego), 12 error categories | None documented | OGC schema validation | None (cluster-level only) | None (assumes valid CWL) |
+| **Validation Approach** | Schema (Pydantic) + Policy-as-code (OPA/Rego), 12 invalid error categories | None documented | OGC schema validation | None (cluster-level only) | None (assumes valid CWL) |
 | **Policy Framework** | OPA/Rego: 10 deny rules, ORCHIDE slide-traceable | None | None | None | None |
 | **Defense-in-Depth** | 5 rules overlap between schema + policy layers | N/A | N/A | N/A | N/A |
 

--- a/tests/test_table_expansion.py
+++ b/tests/test_table_expansion.py
@@ -26,7 +26,7 @@ class TestDocumentStructure:
 
     def test_has_multi_system_table(self):
         doc = _read_doc()
-        assert "ORCHIDE" in doc and "EOEPCA" in doc, (
+        assert "ORCHIDE" in doc and "EOEPCA+" in doc, (
             "Must compare against ORCHIDE and EOEPCA+"
         )
 
@@ -47,7 +47,7 @@ class TestReviewerRequestedDimensions:
 
 
 class TestAdditionalDimensions:
-    """Additional comparison dimensions with exact labels."""
+    """All 10 additional dimensions with exact labels."""
 
     @pytest.mark.parametrize("dimension", [
         "Validation Approach",
@@ -57,6 +57,7 @@ class TestAdditionalDimensions:
         "Extensibility Model",
         "AI Agent Interface",
         "Execution Environment",
+        "ORCHIDE Relationship",
         "CCSDS Alignment",
         "Open Source",
     ])
@@ -72,7 +73,7 @@ class TestComparedSystems:
 
     @pytest.mark.parametrize("system", [
         "ORCHIDE",
-        "EOEPCA",
+        "EOEPCA+",
         "KubeSpace",
         "DLR Sentinel+Argo",
         "This compiler",

--- a/tests/test_table_expansion.py
+++ b/tests/test_table_expansion.py
@@ -47,27 +47,35 @@ class TestReviewerRequestedDimensions:
 
 
 class TestAdditionalDimensions:
-    """Additional comparison dimensions for completeness."""
+    """Additional comparison dimensions with exact labels."""
 
     @pytest.mark.parametrize("dimension", [
-        "Validation",
+        "Validation Approach",
+        "Policy Framework",
+        "Defense-in-Depth",
         "Hardware Abstraction",
-        "Extensibility",
+        "Extensibility Model",
+        "AI Agent Interface",
+        "Execution Environment",
+        "CCSDS Alignment",
+        "Open Source",
     ])
     def test_dimension_present(self, dimension: str):
         doc = _read_doc()
-        assert dimension.lower() in doc.lower(), (
+        assert dimension in doc, (
             f"Comparison dimension missing: {dimension}"
         )
 
 
 class TestComparedSystems:
-    """Must compare against key related systems."""
+    """All 5 compared systems must be present."""
 
     @pytest.mark.parametrize("system", [
         "ORCHIDE",
         "EOEPCA",
         "KubeSpace",
+        "DLR Sentinel+Argo",
+        "This compiler",
     ])
     def test_system_compared(self, system: str):
         doc = _read_doc()

--- a/tests/test_table_expansion.py
+++ b/tests/test_table_expansion.py
@@ -1,0 +1,74 @@
+"""Tests for expanded comparison table completeness.
+
+Verifies that docs/16_comparison_table.md covers all reviewer-requested
+dimensions and related systems.
+
+Issue #53: Expand Table I comparison dimensions.
+"""
+
+from pathlib import Path
+
+import pytest
+
+TABLE_DOC = Path("docs/16_comparison_table.md")
+
+
+def _read_doc() -> str:
+    if not TABLE_DOC.is_file():
+        pytest.skip(f"{TABLE_DOC} not yet created")
+    return TABLE_DOC.read_text(encoding="utf-8")
+
+
+class TestDocumentStructure:
+
+    def test_doc_exists(self):
+        assert TABLE_DOC.is_file(), f"Comparison table missing: {TABLE_DOC}"
+
+    def test_has_multi_system_table(self):
+        doc = _read_doc()
+        assert "ORCHIDE" in doc and "EOEPCA" in doc, (
+            "Must compare against ORCHIDE and EOEPCA+"
+        )
+
+
+class TestReviewerRequestedDimensions:
+    """Reviewer asked for: problem layer, artifact granularity, scheduling scope."""
+
+    @pytest.mark.parametrize("dimension", [
+        "Problem Layer",
+        "Artifact Granularity",
+        "Scheduling Scope",
+    ])
+    def test_reviewer_dimension_present(self, dimension: str):
+        doc = _read_doc()
+        assert dimension.lower() in doc.lower(), (
+            f"Reviewer-requested dimension missing: {dimension}"
+        )
+
+
+class TestAdditionalDimensions:
+    """Additional comparison dimensions for completeness."""
+
+    @pytest.mark.parametrize("dimension", [
+        "Validation",
+        "Hardware Abstraction",
+        "Extensibility",
+    ])
+    def test_dimension_present(self, dimension: str):
+        doc = _read_doc()
+        assert dimension.lower() in doc.lower(), (
+            f"Comparison dimension missing: {dimension}"
+        )
+
+
+class TestComparedSystems:
+    """Must compare against key related systems."""
+
+    @pytest.mark.parametrize("system", [
+        "ORCHIDE",
+        "EOEPCA",
+        "KubeSpace",
+    ])
+    def test_system_compared(self, system: str):
+        doc = _read_doc()
+        assert system in doc, f"System not compared: {system}"


### PR DESCRIPTION
## Summary
- New `docs/16_comparison_table.md` — 5 systems × 13 dimensions comparison
- Addresses reviewer feedback: expand Table I with problem layer, artifact granularity, scheduling scope

### Compared systems
ORCHIDE, EOEPCA+, KubeSpace (Fudan 2026), DLR Sentinel+Argo

### 13 comparison dimensions (grouped)
1. **Reviewer-requested**: Problem Layer, Artifact Granularity, Scheduling Scope
2. **Validation & Policy**: Validation Approach, Policy Framework, Defense-in-Depth
3. **Hardware & Extensibility**: Hardware Abstraction, Extensibility Model, AI Agent Interface
4. **Operational**: Execution Environment, ORCHIDE Relationship, CCSDS Alignment, Open Source

### Honest limitations section
TRL ~3, no onboard execution, single-satellite scope, no data exploitation

## Test plan
- [x] 20 doc-completeness tests pass (13 dimensions + 5 systems + 2 structure)
- [x] Existing tests unaffected