### PR TITLE
Add JSON output and CLI args to benchmark script (#53)

### DIFF
--- a/scripts/benchmark_scaling.py
+++ b/scripts/benchmark_scaling.py
@@ -286,6 +286,7 @@ def write_json_output(
             "sizes": sizes,
             "iterations": iterations,
             "policy_skipped": policy_skipped,
+            "timing_unit": "seconds",
         },
         "results": results,
     }
@@ -329,7 +330,9 @@ def main(argv: list[str] | None = None) -> None:
     has_policy = not skip_policy
     print_results(results, has_policy=has_policy)
 
-    if args.output:
+    if args.output is not None:
+        if not args.output.strip():
+            parser.error("--output path must not be empty")
         try:
             write_json_output(
                 path=args.output,

--- a/scripts/benchmark_scaling.py
+++ b/scripts/benchmark_scaling.py
@@ -209,7 +209,7 @@ def parse_sizes(sizes_str: str) -> list[int]:
     """
     parts = [s.strip() for s in sizes_str.split(",") if s.strip()]
     if not parts:
-        raise argparse.ArgumentTypeError("--sizes must contain at least one positive integer")
+        raise argparse.ArgumentTypeError("must contain at least one positive integer")
     result: list[int] = []
     for part in parts:
         try:

--- a/scripts/benchmark_scaling.py
+++ b/scripts/benchmark_scaling.py
@@ -7,13 +7,20 @@ compile, argo_render, kueue_render.
 
 Usage:
     PYTHONPATH=src:. python3 scripts/benchmark_scaling.py
+    PYTHONPATH=src:. python3 scripts/benchmark_scaling.py --sizes 10,50 --iterations 5
+    PYTHONPATH=src:. python3 scripts/benchmark_scaling.py --output results.json
+    PYTHONPATH=src:. python3 scripts/benchmark_scaling.py --skip-policy
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import statistics
+import sys
 import time
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from orbital_mission_compiler.benchmark import generate_synthetic_plan
@@ -188,20 +195,153 @@ def print_results(results: list[dict[str, Any]], has_policy: bool = True) -> Non
             )
 
 
-def main() -> None:
-    """Entry point for the benchmark script."""
-    has_opa = opa_available()
-    skip_policy = not has_opa
+def parse_sizes(sizes_str: str) -> list[int]:
+    """Parse a comma-separated string of plan sizes into a list of positive ints.
 
-    if skip_policy:
+    Args:
+        sizes_str: Comma-separated sizes, e.g. "10,50,100".
+
+    Returns:
+        List of positive integers.
+
+    Raises:
+        argparse.ArgumentTypeError: If any value is not a positive integer.
+    """
+    parts = [s.strip() for s in sizes_str.split(",") if s.strip()]
+    if not parts:
+        raise argparse.ArgumentTypeError("--sizes must contain at least one positive integer")
+    result: list[int] = []
+    for part in parts:
+        try:
+            val = int(part)
+        except ValueError:
+            raise argparse.ArgumentTypeError(
+                f"Invalid size value: {part!r} (must be a positive integer)"
+            )
+        if val <= 0:
+            raise argparse.ArgumentTypeError(
+                f"Invalid size value: {val} (must be a positive integer)"
+            )
+        result.append(val)
+    return result
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser for the benchmark script."""
+    parser = argparse.ArgumentParser(
+        description="Scaling benchmark for the satellite mission compiler pipeline.",
+    )
+    parser.add_argument(
+        "--sizes",
+        type=parse_sizes,
+        default=None,
+        help=(
+            "Comma-separated plan sizes to benchmark "
+            f"(default: {','.join(str(s) for s in PLAN_SIZES)})"
+        ),
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=ITERATIONS,
+        help=f"Number of timing iterations per size (default: {ITERATIONS})",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Path to write JSON results file (omit for stdout-only)",
+    )
+    parser.add_argument(
+        "--skip-policy",
+        action="store_true",
+        default=False,
+        help="Skip OPA policy evaluation phase",
+    )
+    return parser
+
+
+def write_json_output(
+    path: str,
+    results: list[dict[str, Any]],
+    sizes: list[int],
+    iterations: int,
+    policy_skipped: bool,
+) -> None:
+    """Write benchmark results to a JSON file.
+
+    Args:
+        path: File path to write.
+        results: List of per-size result dicts from run_benchmark().
+        sizes: The plan sizes used.
+        iterations: Number of iterations per size.
+        policy_skipped: Whether policy evaluation was skipped.
+
+    Raises:
+        OSError: If the output path is not writable.
+    """
+    output = {
+        "metadata": {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "sizes": sizes,
+            "iterations": iterations,
+            "policy_skipped": policy_skipped,
+        },
+        "results": results,
+    }
+    out_path = Path(path)
+    # Ensure parent directory exists or raise a clear error
+    parent = out_path.parent
+    if not parent.exists():
+        raise OSError(f"Output directory does not exist: {parent}")
+    out_path.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the benchmark script.
+
+    Args:
+        argv: Command-line arguments. Defaults to sys.argv[1:].
+    """
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    sizes = args.sizes if args.sizes is not None else list(PLAN_SIZES)
+
+    if args.iterations < 1:
+        parser.error("--iterations must be at least 1")
+
+    has_opa = opa_available()
+    skip_policy = args.skip_policy or not has_opa
+
+    if not has_opa and not args.skip_policy:
         print("WARNING: OPA CLI not found; skipping policy evaluation phase.")
         print()
 
-    print(f"Scaling benchmark: sizes={PLAN_SIZES}, iterations={ITERATIONS}")
+    if args.skip_policy and not has_opa:
+        print("NOTE: --skip-policy set and OPA CLI not found; policy phase skipped.")
+        print()
+
+    print(f"Scaling benchmark: sizes={sizes}, iterations={args.iterations}")
     print()
 
-    results = run_benchmark(skip_policy=skip_policy)
-    print_results(results, has_policy=has_opa)
+    results = run_benchmark(sizes=sizes, iterations=args.iterations, skip_policy=skip_policy)
+    has_policy = not skip_policy
+    print_results(results, has_policy=has_policy)
+
+    if args.output:
+        try:
+            write_json_output(
+                path=args.output,
+                results=results,
+                sizes=sizes,
+                iterations=args.iterations,
+                policy_skipped=skip_policy,
+            )
+            print(f"\nResults written to {args.output}")
+        except OSError as exc:
+            print(f"\nERROR: Could not write output file: {exc}", file=sys.stderr)
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -1,0 +1,179 @@
+"""Tests for benchmark_scaling.py CLI argument parsing and JSON output.
+
+Validates the argparse interface, JSON output structure, --skip-policy
+flag, and custom --sizes handling. Uses minimal sizes and iterations
+to keep tests fast.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# The benchmark script lives in scripts/ and is not a package module.
+# Import its functions by manipulating sys.path.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from benchmark_scaling import (  # noqa: E402
+    PLAN_SIZES,
+    build_parser,
+    main,
+    parse_sizes,
+)
+
+from orbital_mission_compiler.policy import opa_available  # noqa: E402
+
+
+class TestParseSizes:
+    """Tests for the parse_sizes helper."""
+
+    def test_default_sizes_match_module_constant(self):
+        """build_parser default (None) should cause main() to use PLAN_SIZES."""
+        parser = build_parser()
+        args = parser.parse_args([])
+        assert args.sizes is None
+        # When None, main() falls back to PLAN_SIZES
+        assert PLAN_SIZES == [10, 50, 100, 500, 1000]
+
+    def test_parse_single_size(self):
+        """A single integer should produce a one-element list."""
+        assert parse_sizes("10") == [10]
+
+    def test_parse_multiple_sizes(self):
+        """Comma-separated values should produce a matching list."""
+        assert parse_sizes("10,50,100") == [10, 50, 100]
+
+    def test_parse_sizes_strips_whitespace(self):
+        """Whitespace around values should be ignored."""
+        assert parse_sizes(" 10 , 50 ") == [10, 50]
+
+    def test_parse_sizes_rejects_non_integer(self):
+        """Non-integer values should raise ArgumentTypeError."""
+        import argparse
+
+        with pytest.raises(argparse.ArgumentTypeError, match="Invalid size value"):
+            parse_sizes("10,abc")
+
+    def test_parse_sizes_rejects_zero(self):
+        """Zero should be rejected as a size."""
+        import argparse
+
+        with pytest.raises(argparse.ArgumentTypeError, match="must be a positive integer"):
+            parse_sizes("0")
+
+    def test_parse_sizes_rejects_negative(self):
+        """Negative values should be rejected."""
+        import argparse
+
+        with pytest.raises(argparse.ArgumentTypeError, match="must be a positive integer"):
+            parse_sizes("-5")
+
+    def test_parse_sizes_rejects_empty(self):
+        """An empty string should be rejected."""
+        import argparse
+
+        with pytest.raises(argparse.ArgumentTypeError, match="at least one positive integer"):
+            parse_sizes("")
+
+
+class TestBenchmarkJsonOutput:
+    """Tests for JSON output via --output flag."""
+
+    def test_json_output_structure(self, tmp_path: Path):
+        """Running with --output should produce a well-formed JSON file."""
+        out_file = tmp_path / "bench.json"
+        main(["--sizes", "10", "--iterations", "1", "--skip-policy", "--output", str(out_file)])
+
+        assert out_file.exists()
+        data = json.loads(out_file.read_text(encoding="utf-8"))
+
+        # Top-level structure
+        assert "metadata" in data
+        assert "results" in data
+
+        # Metadata fields
+        meta = data["metadata"]
+        assert meta["sizes"] == [10]
+        assert meta["iterations"] == 1
+        assert meta["policy_skipped"] is True
+        assert "timestamp" in meta
+
+        # Results structure
+        assert len(data["results"]) == 1
+        row = data["results"][0]
+        assert row["n_events"] == 10
+        assert row["iterations"] == 1
+        for phase in ("parse_mean", "parse_std", "compile_mean", "compile_std",
+                       "argo_mean", "argo_std", "kueue_mean", "kueue_std"):
+            assert phase in row
+            assert isinstance(row[phase], (int, float))
+
+    def test_json_output_unwritable_path(self, tmp_path: Path):
+        """An unwritable output path should exit with error."""
+        bad_path = "/nonexistent_dir_xyz/bench.json"
+        with pytest.raises(SystemExit):
+            main(["--sizes", "10", "--iterations", "1", "--skip-policy", "--output", bad_path])
+
+    def test_no_json_when_output_omitted(self, tmp_path: Path, capsys):
+        """Without --output, no JSON file should be created."""
+        main(["--sizes", "10", "--iterations", "1", "--skip-policy"])
+        captured = capsys.readouterr()
+        # Should have table output but no "Results written" line
+        assert "Scaling benchmark" in captured.out
+        assert "Results written" not in captured.out
+
+
+class TestSkipPolicyFlag:
+    """Tests for the --skip-policy flag."""
+
+    def test_skip_policy_excludes_policy_fields(self, tmp_path: Path):
+        """With --skip-policy, results should not contain policy_mean/policy_std."""
+        out_file = tmp_path / "bench.json"
+        main(["--sizes", "10", "--iterations", "1", "--skip-policy", "--output", str(out_file)])
+
+        data = json.loads(out_file.read_text(encoding="utf-8"))
+        assert data["metadata"]["policy_skipped"] is True
+        row = data["results"][0]
+        assert "policy_mean" not in row
+        assert "policy_std" not in row
+
+    @pytest.mark.skipif(not opa_available(), reason="OPA CLI not installed")
+    def test_with_policy_includes_policy_fields(self, tmp_path: Path):
+        """Without --skip-policy (and OPA available), results should contain policy fields."""
+        out_file = tmp_path / "bench.json"
+        main(["--sizes", "10", "--iterations", "1", "--output", str(out_file)])
+
+        data = json.loads(out_file.read_text(encoding="utf-8"))
+        assert data["metadata"]["policy_skipped"] is False
+        row = data["results"][0]
+        assert "policy_mean" in row
+        assert "policy_std" in row
+
+
+class TestCustomSizes:
+    """Tests for custom --sizes values."""
+
+    def test_two_sizes_produce_two_results(self, tmp_path: Path):
+        """--sizes '10,50' should produce exactly 2 result entries."""
+        out_file = tmp_path / "bench.json"
+        main(["--sizes", "10,50", "--iterations", "1", "--skip-policy", "--output", str(out_file)])
+
+        data = json.loads(out_file.read_text(encoding="utf-8"))
+        assert len(data["results"]) == 2
+        assert data["results"][0]["n_events"] == 10
+        assert data["results"][1]["n_events"] == 50
+        assert data["metadata"]["sizes"] == [10, 50]
+
+    def test_single_size_produces_one_result(self, tmp_path: Path):
+        """--sizes '10' should produce exactly 1 result entry."""
+        out_file = tmp_path / "bench.json"
+        main(["--sizes", "10", "--iterations", "1", "--skip-policy", "--output", str(out_file)])
+
+        data = json.loads(out_file.read_text(encoding="utf-8"))
+        assert len(data["results"]) == 1
+        assert data["results"][0]["n_events"] == 10

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -116,13 +116,13 @@ class TestBenchmarkJsonOutput:
             assert phase in row
             assert isinstance(row[phase], (int, float))
 
-    def test_json_output_unwritable_path(self, tmp_path: Path):
-        """An unwritable output path should exit with error."""
+    def test_json_output_nonexistent_parent(self, tmp_path: Path):
+        """A path with missing parent directory should exit with error."""
         bad_path = tmp_path / "does_not_exist" / "bench.json"
         with pytest.raises(SystemExit):
             main(["--sizes", "10", "--iterations", "1", "--skip-policy", "--output", str(bad_path)])
 
-    def test_no_json_when_output_omitted(self, tmp_path: Path, capsys):
+    def test_no_json_when_output_omitted(self, capsys):
         """Without --output, no JSON file should be created."""
         main(["--sizes", "10", "--iterations", "1", "--skip-policy"])
         captured = capsys.readouterr()

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -37,8 +37,10 @@ class TestParseSizes:
         parser = build_parser()
         args = parser.parse_args([])
         assert args.sizes is None
-        # When None, main() falls back to PLAN_SIZES
-        assert PLAN_SIZES == [10, 50, 100, 500, 1000]
+        # When None, main() falls back to PLAN_SIZES — verify structural invariants
+        assert isinstance(PLAN_SIZES, list)
+        assert PLAN_SIZES
+        assert all(isinstance(s, int) and s > 0 for s in PLAN_SIZES)
 
     def test_parse_single_size(self):
         """A single integer should produce a one-element list."""
@@ -115,9 +117,9 @@ class TestBenchmarkJsonOutput:
 
     def test_json_output_unwritable_path(self, tmp_path: Path):
         """An unwritable output path should exit with error."""
-        bad_path = "/nonexistent_dir_xyz/bench.json"
+        bad_path = tmp_path / "does_not_exist" / "bench.json"
         with pytest.raises(SystemExit):
-            main(["--sizes", "10", "--iterations", "1", "--skip-policy", "--output", bad_path])
+            main(["--sizes", "10", "--iterations", "1", "--skip-policy", "--output", str(bad_path)])
 
     def test_no_json_when_output_omitted(self, tmp_path: Path, capsys):
         """Without --output, no JSON file should be created."""

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -7,26 +7,26 @@ to keep tests fast.
 
 from __future__ import annotations
 
+import importlib.util
 import json
-import sys
 from pathlib import Path
 
 import pytest
 
+from orbital_mission_compiler.policy import opa_available
+
 # The benchmark script lives in scripts/ and is not a package module.
-# Import its functions by manipulating sys.path.
-_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent / "scripts")
-if _SCRIPTS_DIR not in sys.path:
-    sys.path.insert(0, _SCRIPTS_DIR)
+# Load via importlib to avoid mutating sys.path for the whole test run.
+_SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "benchmark_scaling.py"
+_spec = importlib.util.spec_from_file_location("benchmark_scaling", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
 
-from benchmark_scaling import (  # noqa: E402
-    PLAN_SIZES,
-    build_parser,
-    main,
-    parse_sizes,
-)
-
-from orbital_mission_compiler.policy import opa_available  # noqa: E402
+PLAN_SIZES = _mod.PLAN_SIZES
+build_parser = _mod.build_parser
+main = _mod.main
+parse_sizes = _mod.parse_sizes
 
 
 class TestParseSizes:
@@ -103,6 +103,7 @@ class TestBenchmarkJsonOutput:
         assert meta["sizes"] == [10]
         assert meta["iterations"] == 1
         assert meta["policy_skipped"] is True
+        assert meta["timing_unit"] == "seconds"
         assert "timestamp" in meta
 
         # Results structure


### PR DESCRIPTION
## Summary
- Add `--sizes`, `--iterations`, `--output`, `--skip-policy` CLI flags to `scripts/benchmark_scaling.py`
- JSON output includes metadata (timestamp, sizes, iterations) and per-size timing statistics for all pipeline phases
- Backward compatible: `make benchmark` (no args) works identically to before

### New CLI flags
```bash
python scripts/benchmark_scaling.py --sizes 10,50,100 --iterations 5 --output results.json
python scripts/benchmark_scaling.py --skip-policy  # skip OPA phase
```

### JSON output structure
```json
{
  "metadata": {"timestamp": "...", "sizes": [...], "iterations": N, "policy_skipped": bool},
  "results": [{"n_events": N, "parse_mean": ..., "parse_std": ..., ...}]
}
```

## Test plan
- [x] 15 new CLI tests (14 passed, 1 OPA-dependent skipped)
- [x] 286 existing tests unaffected
- [x] `make benchmark` backward compat verified
- [x] JSON output manually verified