### PR TITLE
[codex] Add repository Copilot review instructions

### DIFF
--- a/.github/instructions/review.instructions.md
+++ b/.github/instructions/review.instructions.md
@@ -1,0 +1,25 @@
+# Satellite Mission Compiler: Copilot Review Instructions
+
+Focus on actionable, code-level review feedback for this repository.
+
+## Project scope and boundaries
+- This is a ground-side mission plan compiler and policy guardrail toolchain.
+- Do not suggest or imply onboard/flight-readiness claims.
+- Keep recommendations aligned with repository non-goals in `AGENTS.md`.
+
+## Review quality bar
+- Prioritize correctness, security, portability, and maintainability issues.
+- Avoid low-signal style nits unless they hide real defects.
+- Before commenting, verify the concern still exists in the latest PR diff context.
+- Do not repeat comments already addressed by newer commits in the same PR.
+
+## Preferred feedback style
+- Explain concrete risk and expected runtime impact.
+- Propose the smallest practical fix that preserves current behavior.
+- When possible, suggest a test or eval fixture that can prevent regression.
+- For shell scripts, account for POSIX/Bash portability and clear failure diagnostics.
+
+## Repo-specific expectations
+- Favor pinned, reproducible dependency guidance (no floating `latest` suggestions).
+- Respect existing validation gates: `make verify`, `make test`, `make eval`, and `make lint`.
+- Keep feedback consistent with documented architecture and policy intent in `docs/04_architecture.md` and `docs/08_risks_and_unknowns.md`.


### PR DESCRIPTION
## Summary
- add repository-level Copilot review guidance at `.github/instructions/review.instructions.md`
- define review priorities for this repo: correctness/security/portability first, avoid stale or duplicate comments, and suggest minimal actionable fixes
- encode project boundary reminders (ground-side scope, no flight-readiness claims, pinned/reproducible dependency posture)

## Why
Recent PRs showed repeated or outdated Copilot comments and occasional drift from repository scope assumptions. This small PR adds explicit review instructions so future Copilot feedback is higher-signal and aligned with project constraints.

## Validation
- `make verify`
- `make test`
- `make eval`
- `make lint`

## Scope
- Documentation/configuration only (no runtime/compiler behavior change).