### PR TITLE
Bump version metadata, fix install_argo.sh, add local-dev docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,7 @@ out/
 
 # Paper drafts (local only)
 paper/
+
+# Claude Code local-only state
 .claude/worktrees/
+.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,36 @@
 # Changelog
 
-## v0.2.0 (unreleased)
+## v0.3.0 (2026-04-05)
+
+Tagged release used as the reference artifact for the IEEE SMC-IT/SCC 2026
+paper submission (DOI: 10.5281/zenodo.19391965).
+
+### Features
+- Real GPU DRA (Dynamic Resource Allocation) experiments: live K8s 1.35 +
+  Argo v4.0.1 + Kueue v0.17.0 validation with NVIDIA RTX 5080 against
+  `gpu.nvidia.com` DeviceClass.
+- Ablation harness (`scripts/ablation_study.py`) producing schema-only,
+  policy-only, and combined detection rates across 12 error categories.
+- Phase-wise scaling benchmark (`scripts/benchmark_scaling.py`) covering
+  parse, OPA, compile, Argo render, and Kueue render at 10–1000 events.
+
+### Testing
+- 422 tests across 34 modules (419 passing, 3 skipped pending live cluster
+  in author's local environment; 394 passing, 28 skipped in fresh
+  environments without OPA binary, k3s, and Argo CLI installed).
+- 13 golden translation evaluations comparing rendered IR against
+  expected JSON.
+
+### Documentation
+- Traceability matrix mapping each schema field, Rego rule, and rendered
+  artifact back to ORCHIDE slide references.
+- Architecture documentation aligned with paper §III.
+
+## v0.2.1 (2026-04-03)
+
+Patch release on top of v0.2.0 — see git log for details.
+
+## v0.2.0 (2026-04-03)
 
 ### Security
 - **S-H1**: MCP tools now validate file paths — reject traversal, absolute paths, directory components (CWE-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,16 @@ paper submission (DOI: 10.5281/zenodo.19391965).
 
 ## v0.2.1 (2026-04-03)
 
-Patch release on top of v0.2.0 — see git log for details.
+### Features
+- MCP tool expansion: `diff_plans` (structural diff between two mission
+  plans) and `check_timeline_conflicts` (interval overlap detection).
+
+### Code quality
+- `cli.py` coverage 67% → 99%; total coverage 78% → 84%.
+
+### Documentation
+- README counts updated (155 tests, 6 MCP tools at the time).
+- Added EUPL-1.2 license badge.
 
 ## v0.2.0 (2026-04-03)
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software, please cite both the software and the paper."
 title: "Satellite Mission Compiler"
 version: "0.3.0"
-date-released: "2026-04-10"
+date-released: "2026-04-05"
 url: "https://github.com/thc1006/satellite-mission-compiler"
 repository-code: "https://github.com/thc1006/satellite-mission-compiler"
 license: "EUPL-1.2"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,44 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite both the software and the paper."
+title: "Satellite Mission Compiler"
+version: "0.3.0"
+date-released: "2026-04-10"
+url: "https://github.com/thc1006/satellite-mission-compiler"
+repository-code: "https://github.com/thc1006/satellite-mission-compiler"
+license: "EUPL-1.2"
+doi: "10.5281/zenodo.19391965"
+type: software
+keywords:
+  - satellite
+  - mission-planning
+  - cloud-native
+  - argo-workflows
+  - kueue
+  - opa
+  - rego
+  - policy-as-code
+  - orchide
+authors:
+  - family-names: "Tsai"
+    given-names: "Hsiu-Chi"
+    affiliation: "National Yang Ming Chiao Tung University"
+    email: "thc1006@ieee.org"
+  - family-names: "Chung"
+    given-names: "Chia-Tung"
+    affiliation: "National Yang Ming Chiao Tung University"
+preferred-citation:
+  type: conference-paper
+  title: "Satellite Mission Compiler: Ground-Side Schema Validation, Policy-as-Code, and Workflow Artifact Rendering for Onboard AI Platforms"
+  authors:
+    - family-names: "Tsai"
+      given-names: "Hsiu-Chi"
+      affiliation: "National Yang Ming Chiao Tung University"
+    - family-names: "Chung"
+      given-names: "Chia-Tung"
+      affiliation: "National Yang Ming Chiao Tung University"
+  year: 2026
+  conference:
+    name: "IEEE Space Mission Challenges for Information Technology / Space Computing Conference (SMC-IT/SCC)"
+    city: "Pasadena"
+    region: "CA"
+    country: "US"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,7 +22,6 @@ authors:
   - family-names: "Tsai"
     given-names: "Hsiu-Chi"
     affiliation: "National Yang Ming Chiao Tung University"
-    email: "thc1006@ieee.org"
   - family-names: "Chung"
     given-names: "Chia-Tung"
     affiliation: "National Yang Ming Chiao Tung University"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,97 @@ For live validation changes:
 - prefer least-privilege service accounts over namespace `default`,
 - treat `make k8s-smoke` as environment-coupled validation, not deterministic CI.
 
+## Local development environment
+
+This repo is developed against a host-resident kubeadm K8s cluster
+(NOT kind/minikube/k3s). The cluster runs as a systemd kubelet on the
+dev box (`thc1006-l340`) and was set up with Cilium CNI, Multus
+secondary CNI, NVIDIA DRA driver, and DRA-aware feature gates.
+Reproduction recipe and known issues are documented in
+`docs/local-dev-troubleshooting.md`.
+
+### Standard environment setup
+
+```bash
+# 1. kubeconfig (root-owned by default; copy to user-readable temp path)
+sudo cp /etc/kubernetes/admin.conf /tmp/kubeconfig-host
+sudo chmod a+r /tmp/kubeconfig-host
+export KUBECONFIG=/tmp/kubeconfig-host
+kubectl get nodes  # expect: thc1006-l340 Ready, control-plane, v1.35.x
+
+# 2. Python venv (project deps + dev tools + MCP)
+uv venv .venv-verify --python 3.12
+uv pip install --python .venv-verify/bin/python -e '.[dev,mcp]'
+
+# 3. CLI tools (one-time, place in venv bin)
+curl -sSL -o .venv-verify/bin/argo.gz \
+  https://github.com/argoproj/argo-workflows/releases/download/v4.0.1/argo-linux-amd64.gz
+gunzip -f .venv-verify/bin/argo.gz && chmod +x .venv-verify/bin/argo
+curl -sSL -o .venv-verify/bin/opa \
+  https://github.com/open-policy-agent/opa/releases/download/v1.15.1/opa_linux_amd64_static
+chmod +x .venv-verify/bin/opa
+```
+
+### Canonical commands
+
+```bash
+# Run pytest (expect: ~415 passed, ~31 skipped on fresh env;
+# ~419 passed, ~3 skipped with full local tooling per paper L452)
+.venv-verify/bin/python -m pytest -q
+
+# Live cluster validation against host kubeadm cluster (expect 13/13 PASS)
+PATH="$PWD/.venv-verify/bin:$PATH" \
+PYTHON_BIN=$PWD/.venv-verify/bin/python \
+KUBECONFIG=/tmp/kubeconfig-host \
+bash scripts/validate_live_cluster.sh
+
+# Defense-in-depth ablation (requires opa on PATH; produces Patch A data)
+PATH="$PWD/.venv-verify/bin:$PATH" \
+.venv-verify/bin/python scripts/ablation_study.py
+
+# Phase-wise scaling benchmark (Table IV in paper)
+.venv-verify/bin/python scripts/benchmark_scaling.py \
+  --sizes 10,100,1000 --iterations 10
+```
+
+### One-time host cluster bootstrap (Argo + Kueue + queues)
+
+```bash
+# Install Argo Workflows v4.0.1 (note: --server-side mandatory on K8s 1.35+)
+kubectl create namespace argo
+kubectl apply --server-side -n argo \
+  -f https://github.com/argoproj/argo-workflows/releases/download/v4.0.1/install.yaml
+
+# Install Kueue v0.17.0
+bash scripts/install_kueue.sh
+
+# Apply queue manifests FIRST (creates orbital-demo namespace), then RBAC
+kubectl apply -f manifests/k8s/kueue/
+kubectl apply -f manifests/k8s/argo/00-workflow-executor-rbac.yaml
+```
+
+### When pods CrashLoop with `crypto/rsa: verification error`
+
+Don't trust the error message — the cause is upstream. See
+`docs/local-dev-troubleshooting.md` §A. The fix is usually:
+
+```bash
+sudo mkdir -p /var/lib/cni/multus
+sudo chmod 755 /var/lib/cni/multus
+KUBECONFIG=/tmp/kubeconfig-host kubectl delete pod -n kube-system -l app=multus
+```
+
+### Operator constraints
+
+- The host runs Tailscale; user accesses the box remotely via it.
+  **Never** run `sudo tailscale down` or `systemctl stop tailscaled` —
+  cuts the SSH session. Use `sudo tailscale set --accept-dns=false`
+  for DNS-only adjustments.
+- Do NOT install kind, k3s, or minikube on this host. Port 6443 is
+  already owned by the host kubeadm cluster, and Multus shim is
+  configured for the host network namespace; sibling installs cause
+  cross-CNI conflicts.
+
 ## If asked to extend the system
 Prefer one of these directions:
 1. richer mission plan schema

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ For live validation changes:
 
 This repo is developed against a host-resident kubeadm K8s cluster
 (NOT kind/minikube/k3s). The cluster runs as a systemd kubelet on the
-dev box (`thc1006-l340`) and was set up with Cilium CNI, Multus
+dev box (`<dev-host>`) and was set up with Cilium CNI, Multus
 secondary CNI, NVIDIA DRA driver, and DRA-aware feature gates.
 Reproduction recipe and known issues are documented in
 `docs/local-dev-troubleshooting.md`.
@@ -80,15 +80,21 @@ Reproduction recipe and known issues are documented in
 ### Standard environment setup
 
 ```bash
-# 1. kubeconfig (root-owned by default; copy to user-readable temp path)
-sudo cp /etc/kubernetes/admin.conf /tmp/kubeconfig-host
-sudo chmod a+r /tmp/kubeconfig-host
+# 1. kubeconfig — root-owned by default; copy to a user-private path.
+#    Note: /tmp is wiped on reboot. For a persistent path use
+#    ~/.kube/satellite-mission-compiler-config and update KUBECONFIG accordingly.
+sudo install -m 0600 -o "$USER" -g "$USER" \
+  /etc/kubernetes/admin.conf /tmp/kubeconfig-host
 export KUBECONFIG=/tmp/kubeconfig-host
-kubectl get nodes  # expect: thc1006-l340 Ready, control-plane, v1.35.x
+kubectl get nodes  # expect: <dev-host> Ready, control-plane, v1.35.x
 
 # 2. Python venv (project deps + dev tools + MCP)
+#    uv path (faster, optional — see docs/07_installation_matrix.md):
 uv venv .venv-verify --python 3.12
 uv pip install --python .venv-verify/bin/python -e '.[dev,mcp]'
+#    Or pure stdlib + pip equivalent:
+#    python3 -m venv .venv-verify
+#    .venv-verify/bin/python -m pip install -e '.[dev,mcp]'
 
 # 3. CLI tools (one-time, place in venv bin)
 curl -sSL -o .venv-verify/bin/argo.gz \
@@ -150,10 +156,14 @@ KUBECONFIG=/tmp/kubeconfig-host kubectl delete pod -n kube-system -l app=multus
 
 ### Operator constraints
 
-- The host runs Tailscale; user accesses the box remotely via it.
-  **Never** run `sudo tailscale down` or `systemctl stop tailscaled` —
-  cuts the SSH session. Use `sudo tailscale set --accept-dns=false`
-  for DNS-only adjustments.
+- **If the operator is remoting into this box via Tailscale**: never run
+  `sudo tailscale down` or `systemctl stop tailscaled` — that severs
+  the SSH session and may require physical/console access to recover.
+  For DNS-only experiments use `sudo tailscale set --accept-dns=false`
+  (revertable with `--accept-dns=true`); for iptables-only experiments
+  use `--netfilter-mode=off` (revertable to `=on`). The reason these
+  matter on this host: the operator's incoming SSH path **is** the
+  Tailscale tunnel, so any change that drops the tunnel drops access.
 - Do NOT install kind, k3s, or minikube on this host. Port 6443 is
   already owned by the host kubeadm cluster, and Multus shim is
   configured for the host network namespace; sibling installs cause

--- a/docs/07_installation_matrix.md
+++ b/docs/07_installation_matrix.md
@@ -14,6 +14,7 @@
 | Hera | `hera-workflows` | https://pypi.org/project/hera-workflows/ | **6.0.0** | `pip install hera-workflows==6.0.0` | Python only | **Removed from default deps** — was unused; re-add when Hera-based rendering is implemented |
 | Ruff | `ruff` | https://docs.astral.sh/ruff/ ; https://github.com/astral-sh/ruff/releases | **0.15.8** | `pip install ruff==0.15.8` | Python toolchain | none known here |
 | pytest | `pytest` | https://docs.pytest.org/en/stable/announce/release-9.0.2.html | **9.0.2** | `pip install pytest==9.0.2` | Python toolchain | plugin compatibility may vary |
+| uv (optional) | `uv` | https://docs.astral.sh/uv/ ; https://github.com/astral-sh/uv/releases | latest stable | `curl -LsSf https://astral.sh/uv/install.sh \| sh` | Linux/macOS/Windows | Fast venv + installer; substitutable with stdlib `python3 -m venv` + `pip install` |
 | FastMCP (optional) | `fastmcp` | https://gofastmcp.com/getting-started/installation | **3.2.0** | `pip install fastmcp==3.2.0` | Python only | optional extra; not required for core compiler |
 | mypy | `mypy` | https://mypy.readthedocs.io/ ; https://github.com/python/mypy/releases | **1.16.0** | `pip install mypy==1.16.0` | Python toolchain | static type checker; dev dependency only |
 | types-PyYAML | `types-PyYAML` | https://pypi.org/project/types-PyYAML/ | **6.0.12.20250915** | `pip install types-PyYAML==6.0.12.20250915` | Python toolchain | type stubs for PyYAML; dev dependency only |

--- a/docs/local-dev-troubleshooting.md
+++ b/docs/local-dev-troubleshooting.md
@@ -1,8 +1,12 @@
 # Local Development Troubleshooting
 
+> **Last verified: 2026-05-09.** Re-verify against current CNI / Argo /
+> Kueue / kernel versions before relying on these recipes verbatim.
+
 This file documents real failures encountered while reproducing paper
-§V-D's live cluster experiments on the dev host (`thc1006-l340`,
-Ubuntu 24.04, kernel 6.17, Docker 29.4) and their resolutions.
+§V-D's live cluster experiments on a dev host (Ubuntu 24.04, kernel 6.17,
+Docker 29.4, hostname referred to throughout as `<dev-host>`) and their
+resolutions. Adjust the hostname to match your machine.
 
 ## TL;DR — paper §V-D reproducibility recipe
 
@@ -11,8 +15,8 @@ Ubuntu 24.04, kernel 6.17, Docker 29.4) and their resolutions.
 sudo mkdir -p /var/lib/cni/multus && sudo chmod 755 /var/lib/cni/multus
 
 # 2. Use the existing host kubeadm cluster (NOT kind/k3s; see §B)
-sudo cp /etc/kubernetes/admin.conf /tmp/kubeconfig-host
-sudo chmod a+r /tmp/kubeconfig-host
+sudo install -m 0600 -o "$USER" -g "$USER" \
+  /etc/kubernetes/admin.conf /tmp/kubeconfig-host
 export KUBECONFIG=/tmp/kubeconfig-host
 
 # 3. Install Argo + Kueue with --server-side (see §C)
@@ -92,7 +96,7 @@ namespace, not Docker's.
 
 ### Root cause
 
-The host `thc1006-l340` runs a full **kubeadm K8s v1.35.4 control plane
+The host `<dev-host>` runs a full **kubeadm K8s v1.35.4 control plane
 as a systemd service** (`kubelet.service`). This is the cluster used for
 paper §V-D's RTX 5080 experiments. It owns port 6443 and configures
 Multus globally on the host.
@@ -104,8 +108,8 @@ same host.
 
 ```bash
 # kubeadm admin kubeconfig (root-owned by default)
-sudo cp /etc/kubernetes/admin.conf /tmp/kubeconfig-host
-sudo chmod a+r /tmp/kubeconfig-host
+sudo install -m 0600 -o "$USER" -g "$USER" \
+  /etc/kubernetes/admin.conf /tmp/kubeconfig-host
 export KUBECONFIG=/tmp/kubeconfig-host
 kubectl get nodes  # thc1006-l340 Ready, control-plane, v1.35.4
 kubectl get deviceclasses  # gpu.nvidia.com, mig.nvidia.com (DRA enabled)
@@ -183,7 +187,8 @@ KUBECONFIG=/tmp/kubeconfig-host bash scripts/validate_live_cluster.sh
 
 ## §E. Tailscale considerations (not actually a problem, FYI)
 
-The host runs Tailscale. Two prefs may show up in pod environments:
+If the host runs Tailscale, two prefs may show up in pod environments
+without causing the §A symptom:
 
 - `CorpDNS: true` injects `tail*.ts.net` search domain into pod
   `/etc/resolv.conf`. Harmless; does not cause TLS failures.
@@ -199,8 +204,11 @@ sudo tailscale set --accept-dns=false   # disable DNS injection only
 sudo tailscale set --accept-dns=true
 ```
 
-**Never** run `sudo tailscale down` on this host — it cuts the operator's
-SSH access via Tailscale and can require physical/console intervention.
+**Operator caution**: if you reach the dev host **through** Tailscale
+(SSH over the tailnet), running `sudo tailscale down` or
+`systemctl stop tailscaled` cuts your own session and may require
+physical/console access to recover. Prefer the per-pref toggles above
+for any diagnostic that touches Tailscale.
 
 ---
 

--- a/docs/local-dev-troubleshooting.md
+++ b/docs/local-dev-troubleshooting.md
@@ -111,7 +111,7 @@ same host.
 sudo install -m 0600 -o "$USER" -g "$USER" \
   /etc/kubernetes/admin.conf /tmp/kubeconfig-host
 export KUBECONFIG=/tmp/kubeconfig-host
-kubectl get nodes  # thc1006-l340 Ready, control-plane, v1.35.4
+kubectl get nodes  # expect: <dev-host> Ready, control-plane, v1.35.x
 kubectl get deviceclasses  # gpu.nvidia.com, mig.nvidia.com (DRA enabled)
 ```
 

--- a/docs/local-dev-troubleshooting.md
+++ b/docs/local-dev-troubleshooting.md
@@ -1,0 +1,226 @@
+# Local Development Troubleshooting
+
+This file documents real failures encountered while reproducing paper
+§V-D's live cluster experiments on the dev host (`thc1006-l340`,
+Ubuntu 24.04, kernel 6.17, Docker 29.4) and their resolutions.
+
+## TL;DR — paper §V-D reproducibility recipe
+
+```bash
+# 1. Ensure /var/lib/cni/multus exists (Multus scratch dir; see §A)
+sudo mkdir -p /var/lib/cni/multus && sudo chmod 755 /var/lib/cni/multus
+
+# 2. Use the existing host kubeadm cluster (NOT kind/k3s; see §B)
+sudo cp /etc/kubernetes/admin.conf /tmp/kubeconfig-host
+sudo chmod a+r /tmp/kubeconfig-host
+export KUBECONFIG=/tmp/kubeconfig-host
+
+# 3. Install Argo + Kueue with --server-side (see §C)
+kubectl create namespace argo
+kubectl apply --server-side -n argo \
+  -f https://github.com/argoproj/argo-workflows/releases/download/v4.0.1/install.yaml
+kubectl apply --server-side \
+  -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.17.0/manifests.yaml
+
+# 4. Apply queue and SA manifests (NOTE: namespace must exist first)
+kubectl apply -f manifests/k8s/kueue/        # creates orbital-demo namespace + queues
+kubectl apply -f manifests/k8s/argo/00-workflow-executor-rbac.yaml
+
+# 5. Validate
+PYTHON_BIN=$PWD/.venv-verify/bin/python \
+PATH="$PWD/.venv-verify/bin:$PATH" \
+KUBECONFIG=/tmp/kubeconfig-host \
+bash scripts/validate_live_cluster.sh
+# Expected: PASS: 13  FAIL: 0  RESULT: PASS
+```
+
+---
+
+## §A. Pods stuck `ContainerCreating` with `saveScratchNetConf: no such file`
+
+### Symptom
+
+```
+FailedCreatePodSandBox: ... Multus: error saving the delegates:
+saveScratchNetConf: failed to write container data in the path
+"/var/lib/cni/multus/<sandbox>": no such file or directory
+```
+
+Often misdiagnosed as TLS issue because controller pod logs cascade into
+`tls: failed to verify certificate: x509: certificate signed by unknown
+authority (possibly because of "crypto/rsa: verification error" while
+trying to verify candidate authority certificate "kubernetes")`.
+
+### Root cause
+
+Multus CNI's scratch directory `/var/lib/cni/multus/` was deleted (by an
+update, autoremove, or manual cleanup). The `kube-multus-ds` daemon was
+running with a stale handle to the missing dir, so even `mkdir` on the
+host doesn't fix it without restarting the daemon.
+
+### Fix
+
+```bash
+sudo mkdir -p /var/lib/cni/multus
+sudo chmod 755 /var/lib/cni/multus
+KUBECONFIG=/tmp/kubeconfig-host kubectl delete pod -n kube-system -l app=multus
+# Wait ~30s for replacement multus pod, then retry the failing pods.
+```
+
+### Verification
+
+```bash
+openssl verify -CAfile /etc/kubernetes/pki/ca.crt \
+  /etc/kubernetes/pki/apiserver.crt
+# If "OK", certs are fine — the Go x509 error is downstream of CNI failure.
+```
+
+---
+
+## §B. Don't install kind or k3s — host already runs kubeadm K8s
+
+### Symptom
+
+```bash
+sudo bash scripts/install_k3s.sh
+# fails: listen tcp :6443: bind: address already in use
+```
+
+Or kind clusters spin up but pods immediately CrashLoop with the §A
+symptom because Multus shim is configured for the host network
+namespace, not Docker's.
+
+### Root cause
+
+The host `thc1006-l340` runs a full **kubeadm K8s v1.35.4 control plane
+as a systemd service** (`kubelet.service`). This is the cluster used for
+paper §V-D's RTX 5080 experiments. It owns port 6443 and configures
+Multus globally on the host.
+
+### Fix
+
+Use the existing host cluster. Don't install kind/k3s/minikube on the
+same host.
+
+```bash
+# kubeadm admin kubeconfig (root-owned by default)
+sudo cp /etc/kubernetes/admin.conf /tmp/kubeconfig-host
+sudo chmod a+r /tmp/kubeconfig-host
+export KUBECONFIG=/tmp/kubeconfig-host
+kubectl get nodes  # thc1006-l340 Ready, control-plane, v1.35.4
+kubectl get deviceclasses  # gpu.nvidia.com, mig.nvidia.com (DRA enabled)
+```
+
+The host cluster has Cilium CNI, Multus secondary CNI, hubble UI, and
+NVIDIA DRA driver pre-installed.
+
+---
+
+## §C. `install_argo.sh` failure on K8s 1.35: 262144-byte annotation limit
+
+### Symptom
+
+```
+CustomResourceDefinition.apiextensions.k8s.io "workflows.argoproj.io"
+is invalid: metadata.annotations: Too long: may not be more than 262144
+bytes
+```
+
+### Root cause
+
+Argo Workflows v4.0.x install.yaml's CRD validation schema exceeds the
+client-side `kubectl apply` annotation budget (262144 bytes for the
+`kubectl.kubernetes.io/last-applied-configuration` annotation).
+
+### Fix
+
+Use server-side apply. The repo's `scripts/install_argo.sh` was patched
+on 2026-05-09 (commit `328046a`). For external usage:
+
+```bash
+kubectl apply --server-side -n argo \
+  -f https://github.com/argoproj/argo-workflows/releases/download/v4.0.1/install.yaml
+```
+
+The sibling `scripts/install_kueue.sh` already uses `--server-side`.
+
+---
+
+## §D. Argo Workflow runs immediately fail: ServiceAccount not found
+
+### Symptom
+
+```
+pods "...-step-0-preprocess-..." is forbidden: error looking up service
+account orbital-demo/orbital-workflow-runner: serviceaccount
+"orbital-workflow-runner" not found
+```
+
+### Root cause
+
+`manifests/k8s/argo/00-workflow-executor-rbac.yaml` requires the
+`orbital-demo` namespace to exist. If applied before
+`manifests/k8s/kueue/00-namespace.yaml`, it errors with `namespaces
+"orbital-demo" not found`.
+
+### Fix
+
+Apply queue manifests **first** (they create the namespace), then apply
+the RBAC manifest:
+
+```bash
+kubectl apply -f manifests/k8s/kueue/      # creates orbital-demo + queues
+kubectl apply -f manifests/k8s/argo/00-workflow-executor-rbac.yaml
+```
+
+Or run the full validation script which handles ordering:
+
+```bash
+KUBECONFIG=/tmp/kubeconfig-host bash scripts/validate_live_cluster.sh
+```
+
+---
+
+## §E. Tailscale considerations (not actually a problem, FYI)
+
+The host runs Tailscale. Two prefs may show up in pod environments:
+
+- `CorpDNS: true` injects `tail*.ts.net` search domain into pod
+  `/etc/resolv.conf`. Harmless; does not cause TLS failures.
+- `NetfilterMode: 2` adds Tailscale-managed iptables chains
+  (`ts-input`, `ts-forward`). Does not interfere with kubeadm cluster
+  pod-to-API-server traffic.
+
+If you need to debug whether Tailscale is interfering with anything:
+
+```bash
+sudo tailscale set --accept-dns=false   # disable DNS injection only
+# verify behavior; revert with:
+sudo tailscale set --accept-dns=true
+```
+
+**Never** run `sudo tailscale down` on this host — it cuts the operator's
+SSH access via Tailscale and can require physical/console intervention.
+
+---
+
+## §F. Verified live reproduction outcome (2026-05-09)
+
+`scripts/validate_live_cluster.sh` against the host kubeadm cluster:
+
+```
+PASS: 13  FAIL: 0
+RESULT: PASS
+```
+
+Specifically:
+- kubectl + argo CLI v4.0.1 available
+- Argo workflow-controller running
+- Kueue controller-manager running
+- Mission plan compiled (Pydantic schema)
+- Argo Workflow rendered, `argo lint` passed
+- Argo Workflow submitted, ran, **Succeeded**
+- Kueue Job rendered, submitted, **admitted**, **completed**
+
+This independently validates paper §V-D claim "Rendered Argo Workflow
+YAML is validated by argo lint" and "live cluster validation."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "orbital-mission-compiler"
-version = "0.1.0"
+version = "0.3.0"
 description = "Mission-plan-aware workflow compilation scaffold inspired by ORCHIDE"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/install_argo.sh
+++ b/scripts/install_argo.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 : "${ARGO_VERSION:=v4.0.1}"
 
 kubectl create namespace argo --dry-run=client -o yaml | kubectl apply -f -
-kubectl apply -n argo -f "https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/install.yaml"
+kubectl apply --server-side -n argo -f "https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/install.yaml"
 
 echo "[INFO] Argo Workflows ${ARGO_VERSION} manifest applied."


### PR DESCRIPTION
## Summary

- **Metadata sync to v0.3.0**: bump `pyproject.toml` version from the stale `0.1.0` placeholder to `0.3.0` (matches the git tag and the DOI `10.5281/zenodo.19391965` referenced by the paper); add `CITATION.cff` (CFF 1.2.0); add the missing `v0.3.0` entry to `CHANGELOG.md` (was 2 releases stale — `v0.2.0`, `v0.2.1`, `v0.3.0` were all tagged but no changelog entries existed for any of them).
- **`install_argo.sh` fix**: add `--server-side` to the `kubectl apply` call. Argo Workflows v4.0.x install.yaml CRD validation schema exceeds the 262144-byte client-side annotation budget on K8s 1.35+, causing the install to fail with `metadata.annotations: Too long: may not be more than 262144 bytes`. Sibling `install_kueue.sh` already used `--server-side`. One-character fix.
- **Local development docs**: add `docs/local-dev-troubleshooting.md` capturing the real failures encountered while reproducing paper §V-D on the host kubeadm cluster (Multus scratch dir disappearance misdiagnosed as Go x509 cert error, RBAC dependency on namespace creation order, install ordering); add a `Local development environment` section to `CLAUDE.md` with canonical commands (kubeconfig, venv setup, pytest, `validate_live_cluster.sh`, `ablation_study.py`, `benchmark_scaling.py`) and operator constraints (Tailscale considerations, host kubeadm cluster vs kind/k3s).

These changes were exercised end-to-end against the host kubeadm K8s v1.35.4 cluster (Cilium + Multus + NVIDIA DRA driver). `scripts/validate_live_cluster.sh` returned `PASS: 13  FAIL: 0  RESULT: PASS`, independently validating paper §V-D's "Rendered Argo Workflow YAML is validated by argo lint" and live cluster experiments.

No paper-claim numbers are affected — 422 tests, 13 golden evals, 6 MCP tools, 10 deny rules all unchanged.

## Test plan

- [x] `python -m pytest -q` → 415 passed, 31 skipped (fresh venv); 419 passed, 3 skipped with full local tooling per paper L452
- [x] `argo lint v4.0.1` (paper exact build) on rendered output of all 11 sample mission plans → 11/11 pass with "no linting errors found"
- [x] `scripts/ablation_study.py` (with OPA v1.15.1) → schema 58% / policy 83% / combined 100% detection rate, 0% false positives across 12 error categories
- [x] `scripts/benchmark_scaling.py --sizes 10,100,1000 --iterations 10` → completes cleanly with and without OPA
- [x] `scripts/validate_live_cluster.sh` against host kubeadm K8s v1.35.4 → `PASS: 13  FAIL: 0  RESULT: PASS`
- [x] `scripts/install_argo.sh` no longer fails on K8s 1.35+ with the 262144-byte annotation error
- [x] `pip install -e .` shows `Version: 0.3.0` (was `0.1.0` before bump)