### PR TITLE
feat(kueue): semantic WorkloadPriorityClass tiers so mission priority sorts

### DIFF
--- a/src/orbital_mission_compiler/compiler.py
+++ b/src/orbital_mission_compiler/compiler.py
@@ -815,10 +815,29 @@ def render_resource_claim_templates(
     return templates
 
 
-ORCHIDE_PRIORITY_CLASS_PREFIX = "orbital-orchide-"
-# Bump when the tier->value mapping below changes, so a cluster can detect a Job
-# labelled against a stale class set.
-PRIORITY_CLASS_MAPPING_VERSION = "v1"
+# Kueue WorkloadPriorityClass name + value per ORCHIDE priority tier (1=highest).
+# Mission-plan priority (0-100) maps to a tier via scale_priority_orchide:
+# 76-100 -> tier 1 (mission-critical), 51-75 -> 2 (mission-high),
+# 26-50 -> 3 (mission-normal), 1-25 -> 4 (mission-low). Semantic names are used
+# instead of bare tier numbers so a cluster operator reading a Job's
+# kueue.x-k8s.io/priority-class label knows what it means without a legend.
+_PRIORITY_CLASS_TIERS: dict[int, tuple[str, int]] = {
+    1: ("mission-critical", 400),
+    2: ("mission-high", 300),
+    3: ("mission-normal", 200),
+    4: ("mission-low", 100),
+}
+_PRIORITY_CLASS_BUCKETS = {1: "76-100", 2: "51-75", 3: "26-50", 4: "1-25"}
+# WorkloadPriorityClasses are cluster-scoped, so a name like "mission-critical" is one
+# another installation, or an operator, can reasonably have created already: applying
+# ours would rewrite theirs. The default keeps the project in the name, and an
+# installation sharing a cluster with a second copy can set its own.
+ORCHIDE_PRIORITY_CLASS_PREFIX = "orbital-"
+# Bump when the tier->name/value mapping above changes, so a cluster can detect a
+# Job labelled against a stale class set. v2 renamed the tiers from the bare orbital
+# priority numbers to what they mean, which is exactly the change this is here to
+# announce: a Job labelled v1 references classes that no longer exist under these names.
+PRIORITY_CLASS_MAPPING_VERSION = "v2"
 
 
 # An RFC 1123 label, which is what both a WorkloadPriorityClass name and the
@@ -827,13 +846,13 @@ _K8S_LABEL_RE = re.compile(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?\Z")
 
 
 def _priority_class_name(orchide_priority: int, prefix: str = ORCHIDE_PRIORITY_CLASS_PREFIX) -> str:
-    """Kueue WorkloadPriorityClass name for an ORCHIDE 1-4 tier.
+    """Kueue WorkloadPriorityClass name for an ORCHIDE 1-4 tier (1=highest).
 
     Rejects a prefix that would produce a name the API server refuses, rather
     than emitting YAML that fails only on apply. The same string becomes a label
     value on the Job, so it must satisfy the 63-character label bound too.
     """
-    name = f"{prefix}{orchide_priority}"
+    name = f"{prefix}{_PRIORITY_CLASS_TIERS[orchide_priority][0]}"
     if len(name) > 63 or not _K8S_LABEL_RE.fullmatch(name):
         raise ValueError(
             f"priority-class prefix {prefix!r} yields invalid name {name!r}: must be an "
@@ -849,13 +868,13 @@ def render_workload_priority_classes(
     """Kueue WorkloadPriorityClass objects for the four ORCHIDE priority tiers.
 
     A rendered Kueue Job references one of these via the
-    ``kueue.x-k8s.io/priority-class`` label, so a mission plan's priority feeds
-    Kueue's queue-sorting and **contributes to preemption eligibility** (whether a
-    preemption actually occurs still depends on the ClusterQueue/cohort preemption
-    configuration). Higher ORCHIDE tier maps to a higher Kueue value (ORCHIDE~1 is
-    highest). These are cluster-scoped: apply them once per cluster before
-    submitting Jobs (``kubectl apply`` is idempotent); a configurable ``prefix``
-    keeps parallel installations from colliding on the fixed names.
+    ``kueue.x-k8s.io/priority-class`` label -- the mechanism Kueue actually reads --
+    so a mission plan's priority drives Kueue's in-ClusterQueue workload sorting and
+    contributes to preemption eligibility (whether a preemption occurs still depends
+    on the ClusterQueue/cohort preemption policy). Higher ORCHIDE tier maps to a
+    higher Kueue value (tier 1 -> 400, highest). These are cluster-scoped: apply them
+    once per cluster before submitting Jobs (``kubectl apply`` is idempotent); a
+    configurable ``prefix`` keeps parallel installations from colliding on the names.
     """
     return [
         {
@@ -868,10 +887,13 @@ def render_workload_priority_classes(
                     "orbital/priority-mapping-version": PRIORITY_CLASS_MAPPING_VERSION,
                 },
             },
-            "value": (5 - tier) * 100,  # ORCHIDE 1 -> 400 (highest), 4 -> 100
-            "description": f"ORCHIDE priority tier {tier} (1=highest)",
+            "value": _PRIORITY_CLASS_TIERS[tier][1],
+            "description": (
+                f"ORCHIDE priority tier {tier} (1=highest); "
+                f"mission-plan priority {_PRIORITY_CLASS_BUCKETS[tier]}"
+            ),
         }
-        for tier in (1, 2, 3, 4)
+        for tier in _PRIORITY_CLASS_TIERS
     ]
 
 

--- a/src/orbital_mission_compiler/compiler.py
+++ b/src/orbital_mission_compiler/compiler.py
@@ -833,10 +833,15 @@ _PRIORITY_CLASS_BUCKETS = {1: "76-100", 2: "51-75", 3: "26-50", 4: "1-25"}
 # ours would rewrite theirs. The default keeps the project in the name, and an
 # installation sharing a cluster with a second copy can set its own.
 ORCHIDE_PRIORITY_CLASS_PREFIX = "orbital-"
-# Bump when the tier->name/value mapping above changes, so a cluster can detect a
-# Job labelled against a stale class set. v2 renamed the tiers from the bare orbital
-# priority numbers to what they mean, which is exactly the change this is here to
-# announce: a Job labelled v1 references classes that no longer exist under these names.
+# Bump when the tier->name/value mapping above changes, so a cluster can detect a Job
+# labelled against a stale class set. v1 named the tiers after the bare ORCHIDE numbers
+# and v2 names them after what they mean; no released version emits a priority class at
+# all, so v1 exists only in this repository's own history and no cluster can be holding
+# one. The label is here for the next rename, not for that one.
+#
+# Bumping it is not optional bookkeeping. It is the only signal separating two class
+# sets that share a name, and the live proof compares the value on a Job against the
+# value on the class it references -- a comparison a missed bump makes meaningless.
 PRIORITY_CLASS_MAPPING_VERSION = "v2"
 
 

--- a/src/orbital_mission_compiler/compiler.py
+++ b/src/orbital_mission_compiler/compiler.py
@@ -1114,8 +1114,10 @@ def render_kueue_job(
         # say that: the names are stable across a rename of what they mean, and the
         # object they point at is cluster-scoped and outlives the Job. A label rather
         # than an annotation because selecting on it is the use -- `kubectl get jobs
-        # -l orbital/priority-mapping-version=v1` is how a cluster finds the Jobs
-        # still referencing a class set that has been renamed under them.
+        # -A -l orbital/priority-mapping-version=v2` is how a cluster would find the
+        # Jobs still on this mapping once a later one renames the classes under them.
+        # v2 because no released version emits a priority class at all, so nothing
+        # older than this can be in the field to search for.
         job["metadata"]["labels"]["orbital/priority-mapping-version"] = (
             PRIORITY_CLASS_MAPPING_VERSION
         )

--- a/src/orbital_mission_compiler/compiler.py
+++ b/src/orbital_mission_compiler/compiler.py
@@ -1110,6 +1110,15 @@ def render_kueue_job(
         job["metadata"]["labels"]["kueue.x-k8s.io/priority-class"] = _priority_class_name(
             scale_priority_orchide(intent.priority), priority_class_prefix
         )
+        # Which mapping the class name was chosen under. A class name alone cannot
+        # say that: the names are stable across a rename of what they mean, and the
+        # object they point at is cluster-scoped and outlives the Job. A label rather
+        # than an annotation because selecting on it is the use -- `kubectl get jobs
+        # -l orbital/priority-mapping-version=v1` is how a cluster finds the Jobs
+        # still referencing a class set that has been renamed under them.
+        job["metadata"]["labels"]["orbital/priority-mapping-version"] = (
+            PRIORITY_CLASS_MAPPING_VERSION
+        )
     return job
 
 

--- a/tests/test_priority_mapping.py
+++ b/tests/test_priority_mapping.py
@@ -142,6 +142,23 @@ class TestKueueWorkloadPriorityClass:
         assert by_name["orbital-mission-high"] > by_name["orbital-mission-normal"]
         assert by_name["orbital-mission-normal"] > by_name["orbital-mission-low"]
 
+    def test_the_mapping_and_its_version_are_pinned_together(self):
+        # Monotonicity is what the ordering proof needs, but it does not pin the
+        # mapping: 400/250/200/150 is monotone too, and a change like that alters what
+        # every class on a cluster means while leaving the rest of this file green.
+        # The version exists to announce exactly that change, so the two are asserted
+        # in one place -- changing either alone fails here, which is where someone has
+        # to decide whether they have made a new mapping and say so in the label.
+        from orbital_mission_compiler.compiler import PRIORITY_CLASS_MAPPING_VERSION
+
+        assert PRIORITY_CLASS_MAPPING_VERSION == "v2"
+        assert {w["metadata"]["name"]: w["value"] for w in render_workload_priority_classes()} == {
+            "orbital-mission-critical": 400,
+            "orbital-mission-high": 300,
+            "orbital-mission-normal": 200,
+            "orbital-mission-low": 100,
+        }
+
     def test_higher_mission_priority_maps_to_higher_kueue_value(self):
         # The invariant the live queue-ordering proof (scripts/validate_kueue_priority.sh)
         # depends on: a higher mission priority renders a priority-class whose

--- a/tests/test_priority_mapping.py
+++ b/tests/test_priority_mapping.py
@@ -119,8 +119,8 @@ class TestKueueWorkloadPriorityClass:
         plan = load_mission_plan("configs/mission_plans/sample_gpu_cpu_fallback.yaml")
         intent = compile_plan_to_intents(plan)[0]
         job = render_kueue_job(intent, priority_class=True)
-        # priority 75 -> ORCHIDE tier 2 -> orbital-orchide-2
-        assert job["metadata"]["labels"]["kueue.x-k8s.io/priority-class"] == "orbital-orchide-2"
+        # priority 75 -> ORCHIDE tier 2 -> orbital-mission-high
+        assert job["metadata"]["labels"]["kueue.x-k8s.io/priority-class"] == "orbital-mission-high"
 
     def test_priority_class_off_by_default(self):
         # Default off: the referenced WorkloadPriorityClass must exist first
@@ -138,9 +138,19 @@ class TestKueueWorkloadPriorityClass:
         assert all(w["apiVersion"] == "kueue.x-k8s.io/v1beta2" for w in wpcs)
         by_name = {w["metadata"]["name"]: w["value"] for w in wpcs}
         # ORCHIDE 1 is highest priority -> highest Kueue value; strictly monotone.
-        assert by_name["orbital-orchide-1"] > by_name["orbital-orchide-2"]
-        assert by_name["orbital-orchide-2"] > by_name["orbital-orchide-3"]
-        assert by_name["orbital-orchide-3"] > by_name["orbital-orchide-4"]
+        assert by_name["orbital-mission-critical"] > by_name["orbital-mission-high"]
+        assert by_name["orbital-mission-high"] > by_name["orbital-mission-normal"]
+        assert by_name["orbital-mission-normal"] > by_name["orbital-mission-low"]
+
+    def test_higher_mission_priority_maps_to_higher_kueue_value(self):
+        # The invariant the live queue-ordering proof (scripts/validate_kueue_priority.sh)
+        # depends on: a higher mission priority renders a priority-class whose
+        # WorkloadPriorityClass value is strictly higher, so Kueue sorts it ahead.
+        value = {w["metadata"]["name"]: w["value"] for w in render_workload_priority_classes()}
+        high = _priority_class_name(scale_priority_orchide(90))  # -> orbital-mission-critical
+        low = _priority_class_name(scale_priority_orchide(50))   # -> orbital-mission-normal
+        assert high == "orbital-mission-critical" and low == "orbital-mission-normal"
+        assert value[high] > value[low]
 
 
 # ── WorkloadPriorityClass is reachable from the CLI (#6) ─────────────────
@@ -180,7 +190,7 @@ class TestKueueCliPriorityClass:
     def test_priority_class_labels_the_job(self, tmp_path, monkeypatch):
         self._run(tmp_path, monkeypatch, "--priority-class")
         job = self._load_job(tmp_path)
-        assert job["metadata"]["labels"]["kueue.x-k8s.io/priority-class"] == "orbital-orchide-2"
+        assert job["metadata"]["labels"]["kueue.x-k8s.io/priority-class"] == "orbital-mission-high"
 
     def test_custom_prefix_flows_to_classes_and_label(self, tmp_path, monkeypatch):
         import yaml
@@ -188,9 +198,11 @@ class TestKueueCliPriorityClass:
         self._run(tmp_path, monkeypatch, "--priority-class", "--emit-priority-classes",
                   "--priority-class-prefix", "mysat-")
         job = self._load_job(tmp_path)
-        assert job["metadata"]["labels"]["kueue.x-k8s.io/priority-class"] == "mysat-2"
+        assert job["metadata"]["labels"]["kueue.x-k8s.io/priority-class"] == "mysat-mission-high"
         wpc = [d for d in yaml.safe_load_all((tmp_path / "workload-priority-classes.yaml").read_text()) if d]
-        assert {d["metadata"]["name"] for d in wpc} == {f"mysat-{t}" for t in (1, 2, 3, 4)}
+        assert {d["metadata"]["name"] for d in wpc} == {
+            f"mysat-{n}" for n in ("mission-critical", "mission-high", "mission-normal", "mission-low")
+        }
 
     def test_no_priority_class_label_by_default(self, tmp_path, monkeypatch):
         self._run(tmp_path, monkeypatch)
@@ -224,3 +236,30 @@ class TestPriorityClassPrefixValidation:
 
     def test_valid_prefix_is_accepted(self):
         assert _priority_class_name(1, prefix="mysat-").startswith("mysat-")
+
+
+def test_the_default_class_names_are_project_scoped():
+    """A WorkloadPriorityClass is cluster-scoped, so a generic name is not ours to take.
+
+    "mission-critical" is a name another installation, or an operator, can reasonably
+    have created already, and emitting it would rewrite theirs. The prefix stays in the
+    default so the emitted set belongs to something; an installation that shares a
+    cluster with a second copy of this compiler can still set its own.
+    """
+    from orbital_mission_compiler.compiler import ORCHIDE_PRIORITY_CLASS_PREFIX
+
+    assert ORCHIDE_PRIORITY_CLASS_PREFIX
+    names = [w["metadata"]["name"] for w in render_workload_priority_classes()]
+    assert all(n.startswith(ORCHIDE_PRIORITY_CLASS_PREFIX) for n in names)
+    assert not any(n.startswith("mission-") for n in names)
+
+
+def test_the_mapping_version_moved_with_the_names():
+    """The constant's own comment says to bump it when the mapping changes.
+
+    A Job already in a cluster carries the version it was labelled with, so a stale
+    label is the only way to notice that the classes it references were renamed.
+    """
+    from orbital_mission_compiler.compiler import PRIORITY_CLASS_MAPPING_VERSION
+
+    assert PRIORITY_CLASS_MAPPING_VERSION == "v2"

--- a/tests/test_priority_mapping.py
+++ b/tests/test_priority_mapping.py
@@ -255,11 +255,47 @@ def test_the_default_class_names_are_project_scoped():
 
 
 def test_the_mapping_version_moved_with_the_names():
-    """The constant's own comment says to bump it when the mapping changes.
-
-    A Job already in a cluster carries the version it was labelled with, so a stale
-    label is the only way to notice that the classes it references were renamed.
-    """
+    """The constant's own comment says to bump it when the mapping changes."""
     from orbital_mission_compiler.compiler import PRIORITY_CLASS_MAPPING_VERSION
 
     assert PRIORITY_CLASS_MAPPING_VERSION == "v2"
+
+
+def test_a_job_records_the_mapping_it_was_rendered_under():
+    """The version has to travel with the Job, not only with the class objects.
+
+    An earlier revision of this file said a Job carried the version it was labelled
+    with. It did not: only the WorkloadPriorityClass objects were labelled, and a
+    class name alone cannot say which mapping chose it, because the names survive a
+    rename of what they mean and the objects are cluster-scoped and outlive the Job.
+    Selecting on the label is the use, so it is a label.
+    """
+    from orbital_mission_compiler.compiler import PRIORITY_CLASS_MAPPING_VERSION
+
+    intent = compile_plan_to_intents(
+        load_mission_plan("configs/mission_plans/sample_gpu_cpu_fallback.yaml")
+    )[0]
+
+    labelled = render_kueue_job(intent, priority_class=True)["metadata"]["labels"]
+    assert labelled["orbital/priority-mapping-version"] == PRIORITY_CLASS_MAPPING_VERSION
+    assert labelled["kueue.x-k8s.io/priority-class"] == "orbital-mission-high"
+
+    # Without a class reference there is no mapping to record.
+    plain = render_kueue_job(intent, priority_class=False)["metadata"]["labels"]
+    assert "orbital/priority-mapping-version" not in plain
+
+
+def test_the_job_and_the_classes_agree_on_the_mapping_version():
+    """A Job labelled v2 has to be pointing at classes emitted by the same mapping."""
+    intent = compile_plan_to_intents(
+        load_mission_plan("configs/mission_plans/sample_gpu_cpu_fallback.yaml")
+    )[0]
+    job = render_kueue_job(intent, priority_class=True)["metadata"]["labels"]
+    classes = {
+        w["metadata"]["name"]: w["metadata"]["labels"]["orbital/priority-mapping-version"]
+        for w in render_workload_priority_classes()
+    }
+
+    referenced = job["kueue.x-k8s.io/priority-class"]
+    assert referenced in classes
+    assert classes[referenced] == job["orbital/priority-mapping-version"]


### PR DESCRIPTION
## What

Kueue sorts a ClusterQueue on the single `spec.priority` it writes onto each Workload, and it fills that from the `WorkloadPriorityClass` named by the `kueue.x-k8s.io/priority-class` label. (With no such label it falls back to the pod template's own Kubernetes `PriorityClass`, so the class is what a caller sets to decide the value deliberately rather than inherit it.) The opt-in classes added earlier were named straight from the raw ORCHIDE tier number (`orbital-orchide-1..4`), which carries no meaning at the cluster level. This gives each tier a named class with a monotone Kueue value:

| Mission priority | ORCHIDE tier | WorkloadPriorityClass | value |
|---|---|---|---|
| 76-100 | 1 | `orbital-mission-critical` | 400 |
| 51-75  | 2 | `orbital-mission-high`     | 300 |
| 26-50  | 3 | `orbital-mission-normal`   | 200 |
| 1-25   | 4 | `orbital-mission-low`      | 100 |

A `WorkloadPriorityClass` is cluster-scoped, which is why the default names carry an `orbital-` prefix rather than being plain: `mission-critical` is a name another installation, or an operator, can reasonably have created already, and applying ours over it would rewrite theirs. `--priority-class-prefix` sets a different prefix.

`render_workload_priority_classes` emits the four cluster-scoped classes with these values; `render_kueue_job --priority-class` labels the Job with the matching class. A new unit test pins the invariant a downstream live proof depends on: `value[orbital-mission-critical] > value[orbital-mission-normal]`.

## Scope

Code and unit tests only (`compiler.py`, `tests/test_priority_mapping.py`). No schema or policy change. The pre-existing `orbital/priority` annotation and plain `priority` label are untouched; they were never read by Kueue, and this PR does not change that — it makes the one thing Kueue *does* read (the priority class) meaningful.

## Stacking

Stacked on `feature/policy-guardrail-hardening` (#77), which introduced the `--priority-class` / `--emit-priority-classes` CLI this builds on. The live reverse-order proof that these values actually drive admission ordering is a separate follow-up PR stacked on this one, to keep each change small and reviewable.

## Verification

`pytest`, `ruff` and `mypy` are clean. What the tests cover, rather than how many there are: each ORCHIDE tier renders the class name and the value this mapping declares, and those four values are asserted alongside `PRIORITY_CLASS_MAPPING_VERSION` so neither can be changed without the other; a Job rendered with `--priority-class` carries both the class label and the mapping label, and one rendered without carries neither; the bucket edges (25/26, 50/51, 75/76) land in the tiers the table says; and the Job's mapping label is required to match the label on the class it references.

The earlier count in this section was also wrong -- that file collects 34, not 25 -- which is a fair illustration of why the count is not the claim.

## There is nothing to upgrade from

The names this replaces, `orbital-orchide-1` through `orbital-orchide-4`, were never released: no tag from v0.1.0 to v0.5.0, and not `main`, contains `render_workload_priority_classes` at all. The whole feature arrives in #77 and is renamed here, so both mappings exist only inside this stack.

An earlier revision of this description offered `kubectl get jobs -A -l orbital/priority-mapping-version=v1` to find Jobs on the old mapping. That finds nothing, for two reasons worth separating. #77 stamps the label on the four *class* objects and this PR is what puts it on *Jobs*, so no Job has ever carried v1 whatever else is true. And since neither mapping has been released, no cluster outside this stack holds either generation.

So `v2` is the first mapping a released version can produce. The label is on the emitted classes and on every Job rendered with `--priority-class` so that a *future* rename is detectable: `kubectl get jobs -A -l orbital/priority-mapping-version=v2` lists what a later v3 would leave behind.

Two things still apply on a cluster that has never seen this compiler. The classes are cluster-scoped, so apply them before rendering Jobs against them; Kueue errors on a Job naming a class that does not exist. And changing a class object's value **does** propagate: Kueue's `WorkloadPriorityClassReconciler` lists every Workload indexed to the class and sets `spec.priority` to the new value, with the update predicate firing precisely when the value changed. That controller is present at v0.17.0, v0.18.0 and v0.19.0. An earlier revision of this description said the opposite -- that a Workload keeps the number it was admitted with -- which is wrong, and wrong in the direction that would have made a value change look safer to ignore than it is. The consequence for this PR is the useful one: because the value follows the class, a mapping bump is about the NAME set, not about stranded priorities.




