### PR TITLE
test(kueue): live proof priority (not arrival order) drives Kueue admission

### DIFF
--- a/docs/experiments/2026-07-07-perf-scaling.md
+++ b/docs/experiments/2026-07-07-perf-scaling.md
@@ -69,3 +69,40 @@ Run with `PATH="$PWD/.venv-verify/bin:$PATH" .venv-verify/bin/python <this-snipp
 - **OPA is sub-linear** (18.8 → 115 ms): a fixed subprocess-startup floor dominates.
 - **compile/render** are order-of-magnitude costs only — their 20–45% relative std
   is host background-load jitter, not intrinsic to the fixed-work phases.
+
+
+## What commit these numbers measured, and a re-measurement
+
+This table records the host, the iteration count and the exact snippet, and not
+the commit. Every phase in it is a function this repository has changed since, so
+a reader re-running the snippet cannot tell a regression from a different
+codebase. That gap is closed going forward rather than backwards:
+`scripts/benchmark_scaling.py` now prints the commit, the working-tree state, its
+own checksum, the interpreter, the copy of the compiler it imported and the CPU it
+read from the machine, and `scripts/run_experiments.py` files its transcript only
+when all of those are present. The result lives at
+[`results/scaling.txt`](results/scaling.txt).
+
+Reading the current transcript against the frozen table above (same host, same 30
+iterations; `Render` above is `argo + kueue`, reported separately in the transcript):
+
+- **Parse is unchanged** -- 1305 ms against 1323 at N=1000, 123 against 127 at N=100.
+  That is the question that prompted the re-measurement: the schema now runs a model
+  validator on every compiled intent, and it does not show. So the added validation is
+  below this host's jitter.
+- **The render phases got measurably more expensive.** Kueue rendering at N=1000 has
+  roughly doubled across this stack, and Argo and compile rose with it. This is the
+  same trade recorded in [the OPA-vs-baseline note](2026-07-07-opa-vs-baseline.md):
+  the structured-violation work allocates and formats per occurrence where the earlier
+  code appended a string, and the Kueue renderer now derives its claim templates from
+  the steps rather than from a hint. Both are deliberate, and both are still a rounding
+  error beside the 1.3-second parse that dominates every row.
+- **OPA moves with the host, not with the code.** It has read 115, 174 and 155 ms at
+  N=1000 across three measurements of a phase none of these changes touch. This box
+  runs the single-node cluster used in SV-D/SV-E throughout, and the note above already
+  records that its sub-100 ms phases carry background-load jitter. Attributing that
+  spread would need a quiet host and a bisect, and neither has been done -- so it is
+  reported and not explained.
+- The paper's Table V is frozen with the camera-ready and none of this touches it. The
+  numbers here are for a future arXiv version, and the point of recording the commit is
+  that the next comparison can be attributed rather than guessed at.

--- a/manifests/k8s/kueue/priority-ordering/00-namespace-and-queue.yaml
+++ b/manifests/k8s/kueue/priority-ordering/00-namespace-and-queue.yaml
@@ -3,26 +3,37 @@
 # binding constraint. No preemption is configured, so the proof is pure queue
 # sorting: when quota frees, Kueue admits the highest-priority PENDING workload,
 # independent of submission order.
+#
+# A template, not a manifest to apply directly: validate_kueue_priority.sh fills the
+# placeholders with names carrying that run's identifier, so two runs cannot collide and
+# neither can adopt an object that was already on the cluster. The run-id label is what
+# teardown selects on, so it only ever removes what the same run created.
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: mission-prio
+  name: __NS__
+  labels:
+    orbital.test/run-id: __RUN_ID__
 ---
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
-  name: mission-prio-flavor
+  name: __FLAVOR__
+  labels:
+    orbital.test/run-id: __RUN_ID__
 ---
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
-  name: mission-prio-cq
+  name: __CQ__
+  labels:
+    orbital.test/run-id: __RUN_ID__
 spec:
   namespaceSelector: {}
   resourceGroups:
     - coveredResources: ["cpu", "memory"]
       flavors:
-        - name: mission-prio-flavor
+        - name: __FLAVOR__
           resources:
             - name: cpu
               nominalQuota: "1"
@@ -32,7 +43,9 @@ spec:
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
-  name: mission-prio-lq
-  namespace: mission-prio
+  name: __LQ__
+  namespace: __NS__
+  labels:
+    orbital.test/run-id: __RUN_ID__
 spec:
-  clusterQueue: mission-prio-cq
+  clusterQueue: __CQ__

--- a/manifests/k8s/kueue/priority-ordering/00-namespace-and-queue.yaml
+++ b/manifests/k8s/kueue/priority-ordering/00-namespace-and-queue.yaml
@@ -1,0 +1,38 @@
+# Isolated queue for the priority-ordering experiment. The ClusterQueue's CPU
+# nominalQuota is 1, so exactly one cpu=1 Job is admissible at a time -- CPU is the
+# binding constraint. No preemption is configured, so the proof is pure queue
+# sorting: when quota frees, Kueue admits the highest-priority PENDING workload,
+# independent of submission order.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mission-prio
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: mission-prio-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: mission-prio-cq
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+    - coveredResources: ["cpu", "memory"]
+      flavors:
+        - name: mission-prio-flavor
+          resources:
+            - name: cpu
+              nominalQuota: "1"
+            - name: memory
+              nominalQuota: 2Gi
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: mission-prio-lq
+  namespace: mission-prio
+spec:
+  clusterQueue: mission-prio-cq

--- a/manifests/k8s/kueue/priority-ordering/01-blocker-job.yaml
+++ b/manifests/k8s/kueue/priority-ordering/01-blocker-job.yaml
@@ -3,13 +3,16 @@
 # the higher-priority pending workload first. It carries no priority-class (Kueue
 # default priority 0), which is irrelevant here -- it is admitted simply because it
 # arrives while the quota is free.
+#
+# A template, like 00-namespace-and-queue.yaml: the script fills in this run's names.
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: prio-blocker
-  namespace: mission-prio
+  name: __BLOCKER__
+  namespace: __NS__
   labels:
-    kueue.x-k8s.io/queue-name: mission-prio-lq
+    kueue.x-k8s.io/queue-name: __LQ__
+    orbital.test/run-id: __RUN_ID__
 spec:
   parallelism: 1
   completions: 1

--- a/manifests/k8s/kueue/priority-ordering/01-blocker-job.yaml
+++ b/manifests/k8s/kueue/priority-ordering/01-blocker-job.yaml
@@ -1,0 +1,29 @@
+# Blocker: a cpu=1 Job that holds the ClusterQueue's entire CPU quota so the two
+# mission Jobs both stay PENDING. Deleting it frees the quota; Kueue then admits
+# the higher-priority pending workload first. It carries no priority-class (Kueue
+# default priority 0), which is irrelevant here -- it is admitted simply because it
+# arrives while the quota is free.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: prio-blocker
+  namespace: mission-prio
+  labels:
+    kueue.x-k8s.io/queue-name: mission-prio-lq
+spec:
+  parallelism: 1
+  completions: 1
+  suspend: true
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: blocker
+          image: busybox:1.36
+          command: ["sh", "-c"]
+          args: ["echo blocking; sleep 3600"]
+          resources:
+            requests:
+              cpu: "1"
+              memory: 256Mi

--- a/manifests/k8s/kueue/priority-ordering/README.md
+++ b/manifests/k8s/kueue/priority-ordering/README.md
@@ -20,9 +20,11 @@ So `render-kueue --priority-class` sets that label (mission priority -> ORCHIDE 
 | 26-50  | 3 | `orbital-mission-normal`   | 200 |
 | 1-25   | 4 | `orbital-mission-low`      | 100 |
 
-A `WorkloadPriorityClass` is cluster-scoped, so the project stays in the default name:
-`mission-critical` is one another installation or an operator can reasonably have
-created already. `--priority-class-prefix` sets a different one.
+A `WorkloadPriorityClass` is cluster-scoped, which is why the default names carry an
+`orbital-` prefix rather than being plain: `mission-critical` is a name another
+installation, or an operator, can reasonably have created already, and applying ours
+over it would rewrite theirs. `--priority-class-prefix` sets a different prefix, and
+this experiment uses it to give each run its own.
 
 ## What the original case study did and did not show
 

--- a/manifests/k8s/kueue/priority-ordering/README.md
+++ b/manifests/k8s/kueue/priority-ordering/README.md
@@ -6,11 +6,12 @@ order**, and that the effect comes from *priority*, not from *submission order*.
 ## Why this exists
 
 A rendered Kueue Job carries an `orbital/priority` annotation and a plain
-`priority` label. Neither is read by Kueue. Kueue orders workloads only by a
-`WorkloadPriorityClass` (or a Kubernetes `PriorityClass`), referenced through the
-`kueue.x-k8s.io/priority-class` label. So `render-kueue --priority-class` sets that
-label (mission priority -> ORCHIDE tier -> class), and `--emit-priority-classes`
-writes the four cluster-scoped classes:
+`priority` label. Neither is read by Kueue. Kueue sorts on the single `spec.priority`
+it writes onto the Workload, and it fills that from the `WorkloadPriorityClass` named
+by the `kueue.x-k8s.io/priority-class` label; with no such label it falls back to the
+pod template's own Kubernetes `PriorityClass`, then to a cluster default, then to 0.
+So `render-kueue --priority-class` sets that label (mission priority -> ORCHIDE tier
+-> class), and `--emit-priority-classes` writes the four cluster-scoped classes:
 
 | Mission priority | ORCHIDE tier | WorkloadPriorityClass | value |
 |---|---|---|---|
@@ -71,8 +72,11 @@ both PENDING under full quota
 [PASS] priority drove ordering, not creation order
 ```
 
-The `mission-critical`/`mission-normal` values landed on the Kueue **Workloads**
-(200 and 400), confirming the `kueue.x-k8s.io/priority-class` label propagated to
-Kueue's own priority field, which is what sorts the queue. Preemption and cohort
-borrowing use the same priority; this experiment demonstrates the queue-sorting
-half. The script tears down the namespace, queue, and classes on completion.
+The `...mission-critical`/`...mission-normal` values landed on the Kueue **Workloads**
+(400 and 200), confirming the `kueue.x-k8s.io/priority-class` label propagated to
+Kueue's own priority field, which is what sorts the queue. The run also reads back the
+reference's group and kind, so the value is known to have come from the emitted
+`WorkloadPriorityClass` rather than from the pod-template fallback above. Preemption
+and cohort borrowing use the same priority; this experiment demonstrates the
+queue-sorting half. The script tears down the namespace, queue, and classes on
+completion.

--- a/manifests/k8s/kueue/priority-ordering/README.md
+++ b/manifests/k8s/kueue/priority-ordering/README.md
@@ -115,7 +115,7 @@ The script tears down the namespace, queue, and classes on completion.
   starvation of a low tier under a stream of high ones, are neither shown nor bounded.
 - **Queue sorting only.** Preemption, cohort borrowing, admission checks and fair
   sharing use the same priority field and are not exercised. In this configuration a
-  `mission-critical` plan does *not* evict a running lower-priority one — the blocker
+  a mission-critical plan does *not* evict a running lower-priority one — the blocker
   holds its quota at priority 0 throughout and is never preempted.
 - **One trigger.** Quota is freed by deleting the blocker; quota increases, queue
   creation and normal completion are other admission triggers and are not covered.

--- a/manifests/k8s/kueue/priority-ordering/README.md
+++ b/manifests/k8s/kueue/priority-ordering/README.md
@@ -44,9 +44,32 @@ admissible at a time, and **no preemption** is configured.
 4. Both are PENDING (quota held). Delete the blocker.
 5. Kueue admits the highest-priority **pending** workload first.
 
-If Kueue used arrival order it would admit LOW (submitted first). It admits HIGH,
-so priority decided the order. Both Jobs are produced by the compiler
-(`render-kueue --priority-class`), so this validates the compiler's output.
+On its own that is still one cell, and in it "higher priority" and "submitted
+second" are the same Job — so any mechanism that favours the later arrival predicts
+the identical result. The run therefore also races a **control arm**: the same two
+plans, the same order, rendered without `--priority-class`. No class label means
+Kueue resolves no `WorkloadPriorityClass`, both Workloads take priority 0, the sort
+falls through to the creation timestamp, and the prediction inverts to the first
+submitted winning. Observed: it does. The apparatus can see arrival order, and the
+priority arm is what turns it around.
+
+Each arm races `REPS` times (5 by default) and the run reports the tally, because a
+single race cannot separate a mechanism from a coin toss.
+
+Both arms are produced by the compiler (`render-kueue`, with and without
+`--priority-class`), so the difference between them is one compiler flag and nothing
+else about the Jobs.
+
+### What this does and does not establish
+
+That Kueue admits the higher `spec.priority` first is documented Kueue behaviour,
+not a finding. What the run establishes is the **path**: a mission plan's
+`priority: 90` becomes an ORCHIDE tier, becomes a class name, becomes a
+`WorkloadPriorityClass` whose value is 400, becomes the `spec.priority` Kueue
+actually sorts on — with the reference's group read back to show the value came
+from that class rather than from the pod-template fallback. The control arm is what
+attributes the change to the compiler's flag rather than to anything else in the
+rendered Job.
 
 ## Run it
 
@@ -67,18 +90,36 @@ including the compiler commit it was taken from; re-run it after any change to t
 compiler or the harness rather than citing an older capture.
 
 ```
-LOW  workload priority = 200 (...mission-normal)   submitted first
-HIGH workload priority = 400 (...mission-critical) submitted last
-both PENDING under full quota
--> after freeing quota, HIGH admitted before LOW
-[PASS] priority drove ordering, not creation order
+priority arm  LOW=200 submitted first, HIGH=400 submitted last -> HIGH admitted first
+control arm   no priority class, same order                    -> LOW  admitted first
 ```
 
 The `...mission-critical`/`...mission-normal` values landed on the Kueue **Workloads**
 (400 and 200), confirming the `kueue.x-k8s.io/priority-class` label propagated to
 Kueue's own priority field, which is what sorts the queue. The run also reads back the
-reference's group and kind, so the value is known to have come from the emitted
-`WorkloadPriorityClass` rather than from the pod-template fallback above. Preemption
-and cohort borrowing use the same priority; this experiment demonstrates the
-queue-sorting half. The script tears down the namespace, queue, and classes on
-completion.
+reference's group and kind on both Workloads, so the values are known to have come
+from the emitted `WorkloadPriorityClass` rather than from the pod-template fallback
+above. After HIGH is admitted the run waits for LOW and requires it to be admitted
+too: beating a workload that could never have run is not evidence, and every earlier
+step reads "not admitted yet" and "never admissible" the same way.
+
+The script tears down the namespace, queue, and classes on completion.
+
+### Boundaries
+
+- **Two of the four tiers are raced.** All four classes are applied and all four
+  values and mapping labels are read back, but only 400 against 200 is put through an
+  admission race. Adjacent tiers (400 against 300) and the bucket edges (25/26,
+  50/51, 75/76) are unit-test territory.
+- **Two pending workloads, one gap, one direction.** Ordering among k>2, and
+  starvation of a low tier under a stream of high ones, are neither shown nor bounded.
+- **Queue sorting only.** Preemption, cohort borrowing, admission checks and fair
+  sharing use the same priority field and are not exercised. In this configuration a
+  `mission-critical` plan does *not* evict a running lower-priority one — the blocker
+  holds its quota at priority 0 throughout and is never preempted.
+- **One trigger.** Quota is freed by deleting the blocker; quota increases, queue
+  creation and normal completion are other admission triggers and are not covered.
+- **One shape.** CPU-only single-container Jobs, one flavor, one namespace, one node,
+  Kubernetes v1.36.3, Kueue v0.19.0, the v1beta2 `priorityClassRef` form. No DRA or
+  GPU workload takes part.
+- **`--policy-engine baseline`.** The Rego path is not exercised by this run.

--- a/manifests/k8s/kueue/priority-ordering/README.md
+++ b/manifests/k8s/kueue/priority-ordering/README.md
@@ -14,10 +14,14 @@ writes the four cluster-scoped classes:
 
 | Mission priority | ORCHIDE tier | WorkloadPriorityClass | value |
 |---|---|---|---|
-| 76-100 | 1 | `mission-critical` | 400 |
-| 51-75  | 2 | `mission-high`     | 300 |
-| 26-50  | 3 | `mission-normal`   | 200 |
-| 1-25   | 4 | `mission-low`      | 100 |
+| 76-100 | 1 | `orbital-mission-critical` | 400 |
+| 51-75  | 2 | `orbital-mission-high`     | 300 |
+| 26-50  | 3 | `orbital-mission-normal`   | 200 |
+| 1-25   | 4 | `orbital-mission-low`      | 100 |
+
+A `WorkloadPriorityClass` is cluster-scoped, so the project stays in the default name:
+`mission-critical` is one another installation or an operator can reasonably have
+created already. `--priority-class-prefix` sets a different one.
 
 ## What the original case study did and did not show
 
@@ -32,8 +36,8 @@ The ClusterQueue's CPU `nominalQuota` is **1**, so exactly one `cpu=1` Job is
 admissible at a time, and **no preemption** is configured.
 
 1. A blocker Job holds the single CPU slot.
-2. Submit the **LOW** Job (priority 50 -> `mission-normal`, value 200) **first**.
-3. Wait, then submit the **HIGH** Job (priority 90 -> `mission-critical`, value 400) **second**.
+2. Submit the **LOW** Job (priority 50 -> `...mission-normal`, value 200) **first**.
+3. Wait, then submit the **HIGH** Job (priority 90 -> `...mission-critical`, value 400) **second**.
 4. Both are PENDING (quota held). Delete the blocker.
 5. Kueue admits the highest-priority **pending** workload first.
 
@@ -47,13 +51,21 @@ so priority decided the order. Both Jobs are produced by the compiler
 bash scripts/validate_kueue_priority.sh
 ```
 
+Every object the run creates carries that run's identifier in its name and an
+`orbital.test/run-id` label, and teardown selects on the label rather than replaying a
+manifest, so a namespace, queue or class that was already on the cluster is neither
+adopted nor removed. The run refuses to start if any of its names is already taken.
+Set `RUN_ID` to reproduce a specific run's names.
+
 ## Result (live, this cluster)
 
-Verified on Kubernetes v1.36.3 + Kueue v0.19.0, reproduced twice:
+Verified on Kubernetes v1.36.3 + Kueue v0.19.0. `results/` holds the captured run,
+including the compiler commit it was taken from; re-run it after any change to the
+compiler or the harness rather than citing an older capture.
 
 ```
-LOW  workload priority = 200 (mission-normal)   submitted first
-HIGH workload priority = 400 (mission-critical) submitted last
+LOW  workload priority = 200 (...mission-normal)   submitted first
+HIGH workload priority = 400 (...mission-critical) submitted last
 both PENDING under full quota
 -> after freeing quota, HIGH admitted before LOW
 [PASS] priority drove ordering, not creation order

--- a/manifests/k8s/kueue/priority-ordering/README.md
+++ b/manifests/k8s/kueue/priority-ordering/README.md
@@ -85,9 +85,15 @@ Set `RUN_ID` to reproduce a specific run's names.
 
 ## Result (live, this cluster)
 
-Verified on Kubernetes v1.36.3 + Kueue v0.19.0. `results/` holds the captured run,
-including the compiler commit it was taken from; re-run it after any change to the
-compiler or the harness rather than citing an older capture.
+`results/` holds a captured run, verbatim -- the transcript is the artifact, with
+nothing written around it. Every version it was taken against is in the transcript,
+read from the cluster by the run itself, along with the commit, the working-tree
+state and the checksum of the harness that produced it.
+
+Produce it with `python3 scripts/run_experiments.py`, which files the transcript
+only when it carries all of those; otherwise it keeps it as `.rejected.txt` outside
+the results and exits 2. Re-run after any change to the compiler or the harness
+rather than citing an older capture.
 
 ```
 priority arm  LOW=200 submitted first, HIGH=400 submitted last -> HIGH admitted first

--- a/manifests/k8s/kueue/priority-ordering/README.md
+++ b/manifests/k8s/kueue/priority-ordering/README.md
@@ -1,0 +1,66 @@
+# Kueue priority-ordering experiment
+
+This proves that a mission plan's priority actually drives **Kueue admission
+order**, and that the effect comes from *priority*, not from *submission order*.
+
+## Why this exists
+
+A rendered Kueue Job carries an `orbital/priority` annotation and a plain
+`priority` label. Neither is read by Kueue. Kueue orders workloads only by a
+`WorkloadPriorityClass` (or a Kubernetes `PriorityClass`), referenced through the
+`kueue.x-k8s.io/priority-class` label. So `render-kueue --priority-class` sets that
+label (mission priority -> ORCHIDE tier -> class), and `--emit-priority-classes`
+writes the four cluster-scoped classes:
+
+| Mission priority | ORCHIDE tier | WorkloadPriorityClass | value |
+|---|---|---|---|
+| 76-100 | 1 | `mission-critical` | 400 |
+| 51-75  | 2 | `mission-high`     | 300 |
+| 26-50  | 3 | `mission-normal`   | 200 |
+| 1-25   | 4 | `mission-low`      | 100 |
+
+## What the original case study did and did not show
+
+The paper's case study submits two CPU Jobs (priority 90 and 50); the first is
+admitted, the second waits. On its own that only shows **quota gating**: the Job
+that arrives while quota is free runs, the other waits. It does not, by itself,
+isolate priority from arrival order.
+
+## How this experiment isolates priority (reverse submission order)
+
+The ClusterQueue's CPU `nominalQuota` is **1**, so exactly one `cpu=1` Job is
+admissible at a time, and **no preemption** is configured.
+
+1. A blocker Job holds the single CPU slot.
+2. Submit the **LOW** Job (priority 50 -> `mission-normal`, value 200) **first**.
+3. Wait, then submit the **HIGH** Job (priority 90 -> `mission-critical`, value 400) **second**.
+4. Both are PENDING (quota held). Delete the blocker.
+5. Kueue admits the highest-priority **pending** workload first.
+
+If Kueue used arrival order it would admit LOW (submitted first). It admits HIGH,
+so priority decided the order. Both Jobs are produced by the compiler
+(`render-kueue --priority-class`), so this validates the compiler's output.
+
+## Run it
+
+```bash
+bash scripts/validate_kueue_priority.sh
+```
+
+## Result (live, this cluster)
+
+Verified on Kubernetes v1.36.3 + Kueue v0.19.0, reproduced twice:
+
+```
+LOW  workload priority = 200 (mission-normal)   submitted first
+HIGH workload priority = 400 (mission-critical) submitted last
+both PENDING under full quota
+-> after freeing quota, HIGH admitted before LOW
+[PASS] priority drove ordering, not creation order
+```
+
+The `mission-critical`/`mission-normal` values landed on the Kueue **Workloads**
+(200 and 400), confirming the `kueue.x-k8s.io/priority-class` label propagated to
+Kueue's own priority field, which is what sorts the queue. Preemption and cohort
+borrowing use the same priority; this experiment demonstrates the queue-sorting
+half. The script tears down the namespace, queue, and classes on completion.

--- a/manifests/k8s/kueue/priority-ordering/plan-high.yaml
+++ b/manifests/k8s/kueue/priority-ordering/plan-high.yaml
@@ -1,4 +1,4 @@
-# Mission priority 90 -> ORCHIDE tier 1 -> WorkloadPriorityClass mission-critical.
+# Mission priority 90 -> ORCHIDE tier 1 -> WorkloadPriorityClass ...mission-critical (orbital- prefixed; this harness prefixes per run).
 mission_id: prio-high
 events:
   - timestamp: "2026-04-15T10:00:00Z"

--- a/manifests/k8s/kueue/priority-ordering/plan-high.yaml
+++ b/manifests/k8s/kueue/priority-ordering/plan-high.yaml
@@ -1,0 +1,18 @@
+# Mission priority 90 -> ORCHIDE tier 1 -> WorkloadPriorityClass mission-critical.
+mission_id: prio-high
+events:
+  - timestamp: "2026-04-15T10:00:00Z"
+    event_type: acquisition
+    orbit: 1
+    instrument: MSI
+    ground_visibility: false
+    services:
+      - service_id: high
+        priority: 90
+        execution_mode: sequential
+        steps:
+          - name: work
+            image: busybox:1.36
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo high-priority running; sleep 30"]

--- a/manifests/k8s/kueue/priority-ordering/plan-low.yaml
+++ b/manifests/k8s/kueue/priority-ordering/plan-low.yaml
@@ -1,0 +1,18 @@
+# Mission priority 50 -> ORCHIDE tier 3 -> WorkloadPriorityClass mission-normal.
+mission_id: prio-low
+events:
+  - timestamp: "2026-04-15T10:00:00Z"
+    event_type: acquisition
+    orbit: 1
+    instrument: MSI
+    ground_visibility: false
+    services:
+      - service_id: low
+        priority: 50
+        execution_mode: sequential
+        steps:
+          - name: work
+            image: busybox:1.36
+            resource_class: cpu
+            command: ["sh", "-c"]
+            args: ["echo low-priority running; sleep 30"]

--- a/manifests/k8s/kueue/priority-ordering/plan-low.yaml
+++ b/manifests/k8s/kueue/priority-ordering/plan-low.yaml
@@ -1,4 +1,4 @@
-# Mission priority 50 -> ORCHIDE tier 3 -> WorkloadPriorityClass mission-normal.
+# Mission priority 50 -> ORCHIDE tier 3 -> WorkloadPriorityClass ...mission-normal (orbital- prefixed; this harness prefixes per run).
 mission_id: prio-low
 events:
   - timestamp: "2026-04-15T10:00:00Z"

--- a/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
+++ b/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
@@ -1,19 +1,22 @@
 # Live proof: mission priority, not arrival order, drives Kueue admission.
 #
-# Captured on the rebased stack, so the harness and the compiler under test are
-# the ones this PR proposes rather than an earlier pair.
-#   compiler commit : b886815 (dirty tree)
-#   Kubernetes      : v1.36.3
-#   Kueue image     : registry.k8s.io/kueue/kueue:v0.19.0
-#   node            : thc1006-d630mt v1.36.3
+# Captured from a clean working tree on the commit the run itself names below, so
+# this result can be rebuilt from a commit rather than from a state nobody kept.
+#   Kubernetes  : v1.36.3
+#   Kueue image : registry.k8s.io/kueue/kueue:v0.19.0
+#   image ID    : registry.k8s.io/kueue/kueue@sha256:6fe2cbe4c7799eed1a8d49898c38b8bd73f1572df1825d7cf266ec9e2af70bec
+#   node        : thc1006-d630mt v1.36.3
 #
-# Every object is named for the run and labelled orbital.test/run-id, and teardown
-# selects on that label: the cluster's own dra-paper-cq and dra-unified-cq
-# ClusterQueues were present throughout and untouched.
-
-=== run r17855926262478873 ===
-  namespace=prio-r17855926262478873 clusterQueue=prio-cq-r17855926262478873 classes=orbital-r17855926262478873-mission-critical,orbital-r17855926262478873-mission-normal
-  compiler commit: b886815 (dirty tree)
+# Every object the run creates is named for it and carries an orbital.test/run-id
+# label, and teardown selects on that label. These ClusterQueues belong to the
+# cluster, were present throughout, and were untouched:
+#   dra-paper-cq dra-unified-cq gmat-forge-cluster-queue orbital-demo-cq
+#
+=== run r17856201642634482 ===
+  namespace=prio-r17856201642634482 clusterQueue=prio-cq-r17856201642634482 classes=orbital-r17856201642634482-mission-critical,orbital-r17856201642634482-mission-normal
+  compiler commit: 7d755140d3b68ed5668eceaca89615486919822a
+  working tree   : clean
+  harness sha256 : 6985957b8dd71fdfc32e6e01abeda3b0cc4ca47353f782f63c750fbd824ed1bf
 === 0. prerequisites ===
 [PASS] kubectl available
 [PASS] Kueue controller present
@@ -23,26 +26,26 @@
 [PASS] queue applied
 === 2. emit + apply the WorkloadPriorityClasses from the compiler ===
 [PASS] WorkloadPriorityClasses applied
-[PASS] orbital-r17855926262478873-mission-critical + orbital-r17855926262478873-mission-normal exist
-[PASS] class values as mapped (orbital-r17855926262478873-mission-critical=400, orbital-r17855926262478873-mission-normal=200)
+[PASS] orbital-r17856201642634482-mission-critical + orbital-r17856201642634482-mission-normal exist
+[PASS] class values as mapped (orbital-r17856201642634482-mission-critical=400, orbital-r17856201642634482-mission-normal=200)
 === 3. render HIGH (priority 90) and LOW (priority 50) Jobs ===
 === 4. blocker holds the cpu=1 quota ===
 [PASS] blocker admitted (holds quota)
 === 5. submit LOW first, then HIGH (reverse of priority) ===
-  LOW  job=prio-low-low-2026-04-15t10-00-00z-z4wwb workload=job-prio-low-low-2026-04-15t10-00-00z-z4wwb-47cb9 priority=200 class=orbital-r17855926262478873-mission-normal
-  HIGH job=prio-high-high-2026-04-15t10-00-00z-rf46c workload=job-prio-high-high-2026-04-15t10-00-00z-rf46c-4b84d priority=400 class=orbital-r17855926262478873-mission-critical
+  LOW  job=prio-low-low-2026-04-15t10-00-00z-jcdhg workload=job-prio-low-low-2026-04-15t10-00-00z-jcdhg-3fc7d priority=200 class=orbital-r17856201642634482-mission-normal
+  HIGH job=prio-high-high-2026-04-15t10-00-00z-tvng8 workload=job-prio-high-high-2026-04-15t10-00-00z-tvng8-7602c priority=400 class=orbital-r17856201642634482-mission-critical
 === 5b. the chain the claim rests on ===
 [PASS] workload priorities resolved (HIGH=400 LOW=200)
 [PASS] workloads reference the emitted classes
 [PASS] the reference is a WorkloadPriorityClass, not a Pod PriorityClass
-[PASS] LOW was created before HIGH (2026-08-01T13:57:08Z < 2026-08-01T13:57:15Z)
+[PASS] LOW was created before HIGH (2026-08-01T21:36:06Z < 2026-08-01T21:36:12Z)
 === 6. both PENDING while blocker holds quota ===
 [PASS] LOW and HIGH both pending under full quota
 === 7. free quota (delete blocker); the higher-priority pending workload wins ===
   first admitted after quota freed: HIGH
-[PASS] HIGH (orbital-r17855926262478873-mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
+[PASS] HIGH (orbital-r17856201642634482-mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
 
 === Summary ===
 PASS: 14  FAIL: 0
 RESULT: PASS
-=== cleanup (run r17855926262478873) ===
+=== cleanup (run r17856201642634482) ===

--- a/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
+++ b/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
@@ -12,11 +12,11 @@
 # cluster, were present throughout, and were untouched:
 #   dra-paper-cq dra-unified-cq gmat-forge-cluster-queue orbital-demo-cq
 #
-=== run r17856201642634482 ===
-  namespace=prio-r17856201642634482 clusterQueue=prio-cq-r17856201642634482 classes=orbital-r17856201642634482-mission-critical,orbital-r17856201642634482-mission-normal
-  compiler commit: 7d755140d3b68ed5668eceaca89615486919822a
+=== run r17856322192754005 ===
+  namespace=prio-r17856322192754005 clusterQueue=prio-cq-r17856322192754005 classes=orbital-r17856322192754005-mission-critical,orbital-r17856322192754005-mission-normal
+  compiler commit: a36082e8ad5fca022e362b0ee27c3d004c19820b
   working tree   : clean
-  harness sha256 : 6985957b8dd71fdfc32e6e01abeda3b0cc4ca47353f782f63c750fbd824ed1bf
+  harness sha256 : ad00f5d31e3077f4cf9261efcbd1c3386da48d703925332e01bbcc12466172c7
 === 0. prerequisites ===
 [PASS] kubectl available
 [PASS] Kueue controller present
@@ -26,26 +26,27 @@
 [PASS] queue applied
 === 2. emit + apply the WorkloadPriorityClasses from the compiler ===
 [PASS] WorkloadPriorityClasses applied
-[PASS] orbital-r17856201642634482-mission-critical + orbital-r17856201642634482-mission-normal exist
-[PASS] class values as mapped (orbital-r17856201642634482-mission-critical=400, orbital-r17856201642634482-mission-normal=200)
+[PASS] orbital-r17856322192754005-mission-critical + orbital-r17856322192754005-mission-normal exist
+[PASS] class values as mapped (orbital-r17856322192754005-mission-critical=400, orbital-r17856322192754005-mission-normal=200)
 === 3. render HIGH (priority 90) and LOW (priority 50) Jobs ===
 === 4. blocker holds the cpu=1 quota ===
 [PASS] blocker admitted (holds quota)
 === 5. submit LOW first, then HIGH (reverse of priority) ===
-  LOW  job=prio-low-low-2026-04-15t10-00-00z-jcdhg workload=job-prio-low-low-2026-04-15t10-00-00z-jcdhg-3fc7d priority=200 class=orbital-r17856201642634482-mission-normal
-  HIGH job=prio-high-high-2026-04-15t10-00-00z-tvng8 workload=job-prio-high-high-2026-04-15t10-00-00z-tvng8-7602c priority=400 class=orbital-r17856201642634482-mission-critical
+  LOW  job=prio-low-low-2026-04-15t10-00-00z-w56z9 workload=job-prio-low-low-2026-04-15t10-00-00z-w56z9-a21d5 priority=200 class=orbital-r17856322192754005-mission-normal
+  HIGH job=prio-high-high-2026-04-15t10-00-00z-g64qq workload=job-prio-high-high-2026-04-15t10-00-00z-g64qq-6b233 priority=400 class=orbital-r17856322192754005-mission-critical
 === 5b. the chain the claim rests on ===
 [PASS] workload priorities resolved (HIGH=400 LOW=200)
 [PASS] workloads reference the emitted classes
+[PASS] both Jobs carry the mapping that named their class (v2)
 [PASS] the reference is a WorkloadPriorityClass, not a Pod PriorityClass
-[PASS] LOW was created before HIGH (2026-08-01T21:36:06Z < 2026-08-01T21:36:12Z)
+[PASS] LOW was created before HIGH (2026-08-02T00:57:01Z < 2026-08-02T00:57:07Z)
 === 6. both PENDING while blocker holds quota ===
 [PASS] LOW and HIGH both pending under full quota
 === 7. free quota (delete blocker); the higher-priority pending workload wins ===
   first admitted after quota freed: HIGH
-[PASS] HIGH (orbital-r17856201642634482-mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
+[PASS] HIGH (orbital-r17856322192754005-mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
 
 === Summary ===
-PASS: 14  FAIL: 0
+PASS: 15  FAIL: 0
 RESULT: PASS
-=== cleanup (run r17856201642634482) ===
+=== cleanup (run r17856322192754005) ===

--- a/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
+++ b/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
@@ -1,22 +1,31 @@
-# Live proof: mission priority, not arrival order, drives Kueue admission.
+# Live proof: a mission plan's priority reaches the field Kueue sorts on, and
+# inverts an admission order that the same experiment shows is otherwise decided by
+# arrival.
 #
-# Captured from a clean working tree on the commit the run itself names below, so
-# this result can be rebuilt from a commit rather than from a state nobody kept.
-#   Kubernetes  : v1.36.3
-#   Kueue image : registry.k8s.io/kueue/kueue:v0.19.0
-#   image ID    : registry.k8s.io/kueue/kueue@sha256:6fe2cbe4c7799eed1a8d49898c38b8bd73f1572df1825d7cf266ec9e2af70bec
-#   node        : thc1006-d630mt v1.36.3
+# Captured from a clean working tree on the commit the run names below. Every fact
+# about the cluster is printed by the run itself rather than written here, so this
+# file's provenance is the run and not its author.
 #
-# Every object the run creates is named for it and carries an orbital.test/run-id
-# label, and teardown selects on that label. These ClusterQueues belong to the
-# cluster, were present throughout, and were untouched:
-#   dra-paper-cq dra-unified-cq gmat-forge-cluster-queue orbital-demo-cq
+# Untouched throughout: the ClusterQueues that belong to this cluster
+# (dra-paper-cq, dra-unified-cq, gmat-forge-cluster-queue, orbital-demo-cq). Every
+# object the run creates is named for it, labelled orbital.test/run-id, and deleted
+# by that label.
 #
-=== run r17856328122762495 ===
-  namespace=prio-r17856328122762495 clusterQueue=prio-cq-r17856328122762495 classes=orbital-r17856328122762495-mission-critical,orbital-r17856328122762495-mission-normal
-  compiler commit: 572a9c3c7068d6877950c3448dd5a5ccdfd7e956
+=== run r17856368612829183 ===
+  namespace=prio-r17856368612829183 clusterQueue=prio-cq-r17856368612829183 classes=orbital-r17856368612829183-mission-critical,orbital-r17856368612829183-mission-normal
+  compiler commit: bee0dd5e813a494452791f08d36f701f79474f81
   working tree   : clean
-  harness sha256 : bf20445085744ab919be1d3b40a2bad50c43be2e39c9ff1b25d9953a94735572
+  harness sha256 : 5eb02ddb38008d299daafc8fb668f6d0fca0ca771b41d9038047a18d6bf2af28
+  interpreter    : /mnt/fast/work/satellite-mission-compiler/.venv-verify/bin/python
+  compiler module: /tmp/claude-1000/-mnt-fast-work-satellite-mission-compiler/6c6b6570-cadb-4cdf-918a-4970f553d84a/scratchpad/pr79/src/orbital_mission_compiler/compiler.py
+=== environment ===
+  kubectl client : v1.36.3
+  kube-apiserver : v1.36.3
+  nodes          : thc1006-d630mt=v1.36.3 
+  kueue image    : registry.k8s.io/kueue/kueue:v0.19.0
+  kueue imageID  : registry.k8s.io/kueue/kueue@sha256:6fe2cbe4c7799eed1a8d49898c38b8bd73f1572df1825d7cf266ec9e2af70bec
+  kueue gates    : (none set; built-in defaults apply)
+  kueue config   : captured to kueue-priority/kueue-manager-config.yaml
 === 0. prerequisites ===
 [PASS] kubectl available
 [PASS] Kueue controller present
@@ -26,27 +35,50 @@
 [PASS] queue applied
 === 2. emit + apply the WorkloadPriorityClasses from the compiler ===
 [PASS] WorkloadPriorityClasses applied
-[PASS] orbital-r17856328122762495-mission-critical + orbital-r17856328122762495-mission-normal exist
-[PASS] class values as mapped (orbital-r17856328122762495-mission-critical=400, orbital-r17856328122762495-mission-normal=200)
+[PASS] orbital-r17856368612829183-mission-critical + orbital-r17856368612829183-mission-normal exist
+[PASS] all four emitted classes carry the mapped values (400/300/200/100)
+[PASS] all four classes are labelled with the mapping this tree emits (v2)
 === 3. render HIGH (priority 90) and LOW (priority 50) Jobs ===
+[PASS] both arms rendered by the compiler (priority-class and control)
+[PASS] the control arm's Jobs carry no priority class
 === 4. blocker holds the cpu=1 quota ===
 [PASS] blocker admitted (holds quota)
 === 5. submit LOW first, then HIGH (reverse of priority) ===
-  LOW  job=prio-low-low-2026-04-15t10-00-00z-r4xsl workload=job-prio-low-low-2026-04-15t10-00-00z-r4xsl-02eed priority=200 class=orbital-r17856328122762495-mission-normal
-  HIGH job=prio-high-high-2026-04-15t10-00-00z-mtwln workload=job-prio-high-high-2026-04-15t10-00-00z-mtwln-80c06 priority=400 class=orbital-r17856328122762495-mission-critical
+  LOW  job=prio-low-low-2026-04-15t10-00-00z-lw4cq workload=job-prio-low-low-2026-04-15t10-00-00z-lw4cq-f006f priority=200 class=orbital-r17856368612829183-mission-normal
+  HIGH job=prio-high-high-2026-04-15t10-00-00z-m4nwl workload=job-prio-high-high-2026-04-15t10-00-00z-m4nwl-7061e priority=400 class=orbital-r17856368612829183-mission-critical
 === 5b. the chain the claim rests on ===
 [PASS] workload priorities resolved (HIGH=400 LOW=200)
 [PASS] workloads reference the emitted classes
-[PASS] both Jobs carry the mapping that named their class (v2)
-[PASS] the reference is a WorkloadPriorityClass, not a Pod PriorityClass
-[PASS] LOW was created before HIGH (2026-08-02T01:06:54Z < 2026-08-02T01:07:00Z)
+[PASS] each Job carries the mapping its own class carries (v2)
+[PASS] both references are WorkloadPriorityClasses, not Pod PriorityClasses
+[PASS] LOW was created before HIGH (2026-08-02T02:14:25Z < 2026-08-02T02:14:31Z)
 === 6. both PENDING while blocker holds quota ===
-[PASS] LOW and HIGH both pending under full quota
+[PASS] LOW and HIGH both waiting on quota (QuotaReserved=False; LOW Pending, HIGH Pending)
 === 7. free quota (delete blocker); the higher-priority pending workload wins ===
   first admitted after quota freed: HIGH
-[PASS] HIGH (orbital-r17856328122762495-mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
+[PASS] HIGH (orbital-r17856368612829183-mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
+=== 7b. LOW was queued behind HIGH, not unable to run at all ===
+[PASS] LOW admitted once HIGH released the quota -> it was queued, not inadmissible
+  admitted at: HIGH=2026-08-02T02:14:39Z LOW=2026-08-02T02:15:42Z
+  workloads captured to kueue-priority/workloads.yaml
+  defaulted ClusterQueue captured to kueue-priority/clusterqueue.yaml
+=== 8. the same race, repeated ===
+  priority arm race 2/5: HIGH
+  priority arm race 3/5: HIGH
+  priority arm race 4/5: HIGH
+  priority arm race 5/5: HIGH
+  priority arm outcomes: HIGH HIGH HIGH HIGH HIGH
+[PASS] HIGH admitted first in 5/5 races despite being submitted last
+=== 9. control arm: the same plans and order, no priority class ===
+  control arm race 1/5: LOW
+  control arm race 2/5: LOW
+  control arm race 3/5: LOW
+  control arm race 4/5: LOW
+  control arm race 5/5: LOW
+  control arm outcomes: LOW LOW LOW LOW LOW
+[PASS] without a priority class the FIRST submitted won 5/5 races -> the apparatus does observe arrival order, and the treatment arm inverted it
 
 === Summary ===
-PASS: 15  FAIL: 0
+PASS: 21  FAIL: 0
 RESULT: PASS
-=== cleanup (run r17856328122762495) ===
+=== cleanup (run r17856368612829183) ===

--- a/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
+++ b/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
@@ -11,9 +11,9 @@
 # object the run creates is named for it, labelled orbital.test/run-id, and deleted
 # by that label.
 #
-=== run r17856368612829183 ===
-  namespace=prio-r17856368612829183 clusterQueue=prio-cq-r17856368612829183 classes=orbital-r17856368612829183-mission-critical,orbital-r17856368612829183-mission-normal
-  compiler commit: bee0dd5e813a494452791f08d36f701f79474f81
+=== run r17856387592851821 ===
+  namespace=prio-r17856387592851821 clusterQueue=prio-cq-r17856387592851821 classes=orbital-r17856387592851821-mission-critical,orbital-r17856387592851821-mission-normal
+  compiler commit: 7cf5e9678896446a837e7785a88b1ed02bbff9c5
   working tree   : clean
   harness sha256 : 5eb02ddb38008d299daafc8fb668f6d0fca0ca771b41d9038047a18d6bf2af28
   interpreter    : /mnt/fast/work/satellite-mission-compiler/.venv-verify/bin/python
@@ -35,7 +35,7 @@
 [PASS] queue applied
 === 2. emit + apply the WorkloadPriorityClasses from the compiler ===
 [PASS] WorkloadPriorityClasses applied
-[PASS] orbital-r17856368612829183-mission-critical + orbital-r17856368612829183-mission-normal exist
+[PASS] orbital-r17856387592851821-mission-critical + orbital-r17856387592851821-mission-normal exist
 [PASS] all four emitted classes carry the mapped values (400/300/200/100)
 [PASS] all four classes are labelled with the mapping this tree emits (v2)
 === 3. render HIGH (priority 90) and LOW (priority 50) Jobs ===
@@ -44,22 +44,22 @@
 === 4. blocker holds the cpu=1 quota ===
 [PASS] blocker admitted (holds quota)
 === 5. submit LOW first, then HIGH (reverse of priority) ===
-  LOW  job=prio-low-low-2026-04-15t10-00-00z-lw4cq workload=job-prio-low-low-2026-04-15t10-00-00z-lw4cq-f006f priority=200 class=orbital-r17856368612829183-mission-normal
-  HIGH job=prio-high-high-2026-04-15t10-00-00z-m4nwl workload=job-prio-high-high-2026-04-15t10-00-00z-m4nwl-7061e priority=400 class=orbital-r17856368612829183-mission-critical
+  LOW  job=prio-low-low-2026-04-15t10-00-00z-ljjss workload=job-prio-low-low-2026-04-15t10-00-00z-ljjss-45c8f priority=200 class=orbital-r17856387592851821-mission-normal
+  HIGH job=prio-high-high-2026-04-15t10-00-00z-cdswj workload=job-prio-high-high-2026-04-15t10-00-00z-cdswj-7fcd6 priority=400 class=orbital-r17856387592851821-mission-critical
 === 5b. the chain the claim rests on ===
 [PASS] workload priorities resolved (HIGH=400 LOW=200)
 [PASS] workloads reference the emitted classes
 [PASS] each Job carries the mapping its own class carries (v2)
 [PASS] both references are WorkloadPriorityClasses, not Pod PriorityClasses
-[PASS] LOW was created before HIGH (2026-08-02T02:14:25Z < 2026-08-02T02:14:31Z)
+[PASS] LOW was created before HIGH (2026-08-02T02:46:03Z < 2026-08-02T02:46:09Z)
 === 6. both PENDING while blocker holds quota ===
 [PASS] LOW and HIGH both waiting on quota (QuotaReserved=False; LOW Pending, HIGH Pending)
 === 7. free quota (delete blocker); the higher-priority pending workload wins ===
   first admitted after quota freed: HIGH
-[PASS] HIGH (orbital-r17856368612829183-mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
+[PASS] HIGH (orbital-r17856387592851821-mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
 === 7b. LOW was queued behind HIGH, not unable to run at all ===
 [PASS] LOW admitted once HIGH released the quota -> it was queued, not inadmissible
-  admitted at: HIGH=2026-08-02T02:14:39Z LOW=2026-08-02T02:15:42Z
+  admitted at: HIGH=2026-08-02T02:46:16Z LOW=2026-08-02T02:47:20Z
   workloads captured to kueue-priority/workloads.yaml
   defaulted ClusterQueue captured to kueue-priority/clusterqueue.yaml
 === 8. the same race, repeated ===
@@ -81,4 +81,4 @@
 === Summary ===
 PASS: 21  FAIL: 0
 RESULT: PASS
-=== cleanup (run r17856368612829183) ===
+=== cleanup (run r17856387592851821) ===

--- a/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
+++ b/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
@@ -1,0 +1,24 @@
+=== 0. prerequisites ===
+[PASS] kubectl available
+[PASS] Kueue controller present
+=== 1. apply namespace + ClusterQueue (cpu=1) + LocalQueue ===
+[PASS] queue applied
+=== 2. emit + apply the WorkloadPriorityClasses from the compiler ===
+[PASS] WorkloadPriorityClasses applied
+[PASS] mission-critical + mission-normal exist
+=== 3. render HIGH (priority 90) and LOW (priority 50) Jobs ===
+=== 4. blocker holds the cpu=1 quota ===
+[PASS] blocker admitted (holds quota)
+=== 5. submit LOW first, then HIGH (reverse of priority) ===
+  LOW  job=prio-low-low-2026-04-15t10-00-00z-pvrpv workload=job-prio-low-low-2026-04-15t10-00-00z-pvrpv-1ef60 priority=200
+  HIGH job=prio-high-high-2026-04-15t10-00-00z-485l9 workload=job-prio-high-high-2026-04-15t10-00-00z-485l9-0cb24 priority=400
+=== 6. both PENDING while blocker holds quota ===
+[PASS] LOW and HIGH both pending under full quota
+=== 7. free quota (delete blocker); the higher-priority pending workload wins ===
+  first admitted after quota freed: HIGH (LOW status at that moment: n/a)
+[PASS] HIGH (mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
+
+=== Summary ===
+PASS: 8  FAIL: 0
+RESULT: PASS
+=== cleanup ===

--- a/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
+++ b/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
@@ -1,24 +1,48 @@
+# Live proof: mission priority, not arrival order, drives Kueue admission.
+#
+# Captured on the rebased stack, so the harness and the compiler under test are
+# the ones this PR proposes rather than an earlier pair.
+#   compiler commit : b886815 (dirty tree)
+#   Kubernetes      : v1.36.3
+#   Kueue image     : registry.k8s.io/kueue/kueue:v0.19.0
+#   node            : thc1006-d630mt v1.36.3
+#
+# Every object is named for the run and labelled orbital.test/run-id, and teardown
+# selects on that label: the cluster's own dra-paper-cq and dra-unified-cq
+# ClusterQueues were present throughout and untouched.
+
+=== run r17855926262478873 ===
+  namespace=prio-r17855926262478873 clusterQueue=prio-cq-r17855926262478873 classes=orbital-r17855926262478873-mission-critical,orbital-r17855926262478873-mission-normal
+  compiler commit: b886815 (dirty tree)
 === 0. prerequisites ===
 [PASS] kubectl available
 [PASS] Kueue controller present
+=== 0b. nothing this run is about to create already exists ===
+[PASS] no pre-existing object carries this run's names
 === 1. apply namespace + ClusterQueue (cpu=1) + LocalQueue ===
 [PASS] queue applied
 === 2. emit + apply the WorkloadPriorityClasses from the compiler ===
 [PASS] WorkloadPriorityClasses applied
-[PASS] mission-critical + mission-normal exist
+[PASS] orbital-r17855926262478873-mission-critical + orbital-r17855926262478873-mission-normal exist
+[PASS] class values as mapped (orbital-r17855926262478873-mission-critical=400, orbital-r17855926262478873-mission-normal=200)
 === 3. render HIGH (priority 90) and LOW (priority 50) Jobs ===
 === 4. blocker holds the cpu=1 quota ===
 [PASS] blocker admitted (holds quota)
 === 5. submit LOW first, then HIGH (reverse of priority) ===
-  LOW  job=prio-low-low-2026-04-15t10-00-00z-pvrpv workload=job-prio-low-low-2026-04-15t10-00-00z-pvrpv-1ef60 priority=200
-  HIGH job=prio-high-high-2026-04-15t10-00-00z-485l9 workload=job-prio-high-high-2026-04-15t10-00-00z-485l9-0cb24 priority=400
+  LOW  job=prio-low-low-2026-04-15t10-00-00z-z4wwb workload=job-prio-low-low-2026-04-15t10-00-00z-z4wwb-47cb9 priority=200 class=orbital-r17855926262478873-mission-normal
+  HIGH job=prio-high-high-2026-04-15t10-00-00z-rf46c workload=job-prio-high-high-2026-04-15t10-00-00z-rf46c-4b84d priority=400 class=orbital-r17855926262478873-mission-critical
+=== 5b. the chain the claim rests on ===
+[PASS] workload priorities resolved (HIGH=400 LOW=200)
+[PASS] workloads reference the emitted classes
+[PASS] the reference is a WorkloadPriorityClass, not a Pod PriorityClass
+[PASS] LOW was created before HIGH (2026-08-01T13:57:08Z < 2026-08-01T13:57:15Z)
 === 6. both PENDING while blocker holds quota ===
 [PASS] LOW and HIGH both pending under full quota
 === 7. free quota (delete blocker); the higher-priority pending workload wins ===
-  first admitted after quota freed: HIGH (LOW status at that moment: n/a)
-[PASS] HIGH (mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
+  first admitted after quota freed: HIGH
+[PASS] HIGH (orbital-r17855926262478873-mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
 
 === Summary ===
-PASS: 8  FAIL: 0
+PASS: 14  FAIL: 0
 RESULT: PASS
-=== cleanup ===
+=== cleanup (run r17855926262478873) ===

--- a/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
+++ b/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
@@ -1,9 +1,11 @@
-=== run r17856442882993375 ===
-  namespace=prio-r17856442882993375 clusterQueue=prio-cq-r17856442882993375 classes=orbital-r17856442882993375-mission-critical,orbital-r17856442882993375-mission-normal
-  compiler commit: 2c864efa6962ba95ca03ad6cef6a9a4b89740768
+=== run r17856586653405078 ===
+  namespace=prio-r17856586653405078 clusterQueue=prio-cq-r17856586653405078 classes=orbital-r17856586653405078-mission-critical,orbital-r17856586653405078-mission-normal
+  compiler commit: f3107700eeabc679cbd581e3ba1af70af32c59c3
   working tree   : clean
-  harness sha256 : 9f1ae8d8b2f47cc5ef6109b5bf66955f98547a1f9a02d83acc31436e232b24a8
-  interpreter    : /mnt/fast/work/satellite-mission-compiler/.venv-verify/bin/python
+  harness sha256 : 00091acd1dc075a4ff9f27f7e4e6c4fc98878327dd1b04e7af1c338ec0e90cc6
+  inputs sha256  : 718c2350e92c0bb287e16dde78fc19f99b0ef9c65dda4843a52756a137829084
+  harness inputs : 00-namespace-and-queue.yaml 01-blocker-job.yaml plan-high.yaml plan-low.yaml 
+  interpreter    : /mnt/fast/work/satellite-mission-compiler/.venv-verify/bin/python3
   compiler module: /tmp/claude-1000/-mnt-fast-work-satellite-mission-compiler/6c6b6570-cadb-4cdf-918a-4970f553d84a/scratchpad/pr79/src/orbital_mission_compiler/compiler.py
 === environment ===
   kubectl client : v1.36.3
@@ -11,8 +13,71 @@
   nodes          : thc1006-d630mt=v1.36.3 
   kueue image    : registry.k8s.io/kueue/kueue:v0.19.0
   kueue imageID  : registry.k8s.io/kueue/kueue@sha256:6fe2cbe4c7799eed1a8d49898c38b8bd73f1572df1825d7cf266ec9e2af70bec
-  kueue gates    : (none set; built-in defaults apply)
-  kueue config   : captured to run-r17856442882993375/kueue-manager-config.yaml
+  kueue gates    : (args present, none is --feature-gates; gates may still be set in the config inlined below)
+  kueue config   : inlined below
+    | apiVersion: v1
+    | data:
+    |   controller_manager_config.yaml: |
+    |     apiVersion: config.kueue.x-k8s.io/v1beta2
+    |     kind: Configuration
+    |     health:
+    |       healthProbeBindAddress: :8081
+    |     metrics:
+    |       bindAddress: :8443
+    |     webhook:
+    |       port: 9443
+    |     leaderElection:
+    |       leaderElect: true
+    |       resourceName: c1f6bfd2.kueue.x-k8s.io
+    |     controller:
+    |       groupKindConcurrency:
+    |         Job.batch: 5
+    |         Pod: 5
+    |         Workload.kueue.x-k8s.io: 5
+    |         LocalQueue.kueue.x-k8s.io: 1
+    |         Cohort.kueue.x-k8s.io: 1
+    |         ClusterQueue.kueue.x-k8s.io: 1
+    |         ResourceFlavor.kueue.x-k8s.io: 1
+    |     clientConnection:
+    |       qps: 50
+    |       burst: 100
+    |     integrations:
+    |       frameworks:
+    |       - "batch/job"
+    |       - "kubeflow.org/mpijob"
+    |       - "ray.io/rayjob"
+    |       - "ray.io/raycluster"
+    |       - "ray.io/rayservice"
+    |       - "jobset.x-k8s.io/jobset"
+    |       - "kubeflow.org/paddlejob"
+    |       - "kubeflow.org/pytorchjob"
+    |       - "kubeflow.org/tfjob"
+    |       - "kubeflow.org/xgboostjob"
+    |       - "kubeflow.org/jaxjob"
+    |       - "workload.codeflare.dev/appwrapper"
+    |       - "trainer.kubeflow.org/trainjob"
+    |       - "pod"
+    |       - "deployment"
+    |       - "statefulset"
+    |       - "leaderworkerset.x-k8s.io/leaderworkerset"
+    |     resources:
+    |       deviceClassMappings:
+    |       - name: dra.gpu.nvidia.com
+    |         deviceClassNames:
+    |         - gpu.nvidia.com
+    |       - name: dra.cpu
+    |         deviceClassNames:
+    |         - dra.cpu
+    | kind: ConfigMap
+    | metadata:
+    |   annotations:
+    |     kubectl.kubernetes.io/last-applied-configuration: |
+    |       {"apiVersion":"v1","data":{"controller_manager_config.yaml":"apiVersion: config.kueue.x-k8s.io/v1beta2\nkind: Configuration\nhealth:\n  healthProbeBindAddress: :8081\nmetrics:\n  bindAddress: :8443\nwebhook:\n  port: 9443\nleaderElection:\n  leaderElect: true\n  resourceName: c1f6bfd2.kueue.x-k8s.io\ncontroller:\n  groupKindConcurrency:\n    Job.batch: 5\n    Pod: 5\n    Workload.kueue.x-k8s.io: 5\n    LocalQueue.kueue.x-k8s.io: 1\n    Cohort.kueue.x-k8s.io: 1\n    ClusterQueue.kueue.x-k8s.io: 1\n    ResourceFlavor.kueue.x-k8s.io: 1\nclientConnection:\n  qps: 50\n  burst: 100\nintegrations:\n  frameworks:\n  - \"batch/job\"\n  - \"kubeflow.org/mpijob\"\n  - \"ray.io/rayjob\"\n  - \"ray.io/raycluster\"\n  - \"ray.io/rayservice\"\n  - \"jobset.x-k8s.io/jobset\"\n  - \"kubeflow.org/paddlejob\"\n  - \"kubeflow.org/pytorchjob\"\n  - \"kubeflow.org/tfjob\"\n  - \"kubeflow.org/xgboostjob\"\n  - \"kubeflow.org/jaxjob\"\n  - \"workload.codeflare.dev/appwrapper\"\n  - \"trainer.kubeflow.org/trainjob\"\n  - \"pod\"\n  - \"deployment\"\n  - \"statefulset\"\n  - \"leaderworkerset.x-k8s.io/leaderworkerset\"\nresources:\n  deviceClassMappings:\n  - name: dra.gpu.nvidia.com\n    deviceClassNames:\n    - gpu.nvidia.com\n  - name: dra.cpu\n    deviceClassNames:\n    - dra.cpu\n"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"kueue-manager-config","namespace":"kueue-system"}}
+    |   creationTimestamp: "2026-05-06T19:10:24Z"
+    |   name: kueue-manager-config
+    |   namespace: kueue-system
+    |   resourceVersion: "18926344"
+    |   uid: 5e456097-5e19-4dfc-bb87-0b1e7b578234
 === 0. prerequisites ===
 [PASS] kubectl available (/usr/bin/kubectl)
 [PASS] Kueue controller present
@@ -23,7 +88,7 @@
 [PASS] queue applied
 === 2. emit + apply the WorkloadPriorityClasses from the compiler ===
 [PASS] WorkloadPriorityClasses applied
-[PASS] orbital-r17856442882993375-mission-critical + orbital-r17856442882993375-mission-normal exist
+[PASS] orbital-r17856586653405078-mission-critical + orbital-r17856586653405078-mission-normal exist
 [PASS] all four emitted classes carry the mapped values (400/300/200/100)
 [PASS] all four classes are labelled with the mapping this tree emits (v2)
 === 3. render HIGH (priority 90) and LOW (priority 50) Jobs ===
@@ -32,24 +97,275 @@
 === 4. blocker holds the cpu=1 quota ===
 [PASS] blocker admitted (holds quota)
 === 5. submit LOW first, then HIGH (reverse of priority) ===
-  LOW  job=prio-low-low-2026-04-15t10-00-00z-6blpn workload=job-prio-low-low-2026-04-15t10-00-00z-6blpn-d363a priority=200 class=orbital-r17856442882993375-mission-normal
-  HIGH job=prio-high-high-2026-04-15t10-00-00z-hp88q workload=job-prio-high-high-2026-04-15t10-00-00z-hp88q-b318d priority=400 class=orbital-r17856442882993375-mission-critical
+  LOW  job=prio-low-low-2026-04-15t10-00-00z-8xkgq workload=job-prio-low-low-2026-04-15t10-00-00z-8xkgq-7af52 priority=200 class=orbital-r17856586653405078-mission-normal
+  HIGH job=prio-high-high-2026-04-15t10-00-00z-f5vnd workload=job-prio-high-high-2026-04-15t10-00-00z-f5vnd-d8712 priority=400 class=orbital-r17856586653405078-mission-critical
 === 5b. the chain the claim rests on ===
 [PASS] workload priorities resolved (HIGH=400 LOW=200)
 [PASS] workloads reference the emitted classes
 [PASS] each Job carries the mapping its own class carries (v2)
 [PASS] both references are WorkloadPriorityClasses, not Pod PriorityClasses
-[PASS] LOW was created before HIGH (2026-08-02T04:18:14Z < 2026-08-02T04:18:20Z)
+[PASS] LOW was created before HIGH (2026-08-02T08:17:50Z < 2026-08-02T08:17:56Z)
 === 6. both PENDING while blocker holds quota ===
 [PASS] LOW and HIGH both waiting on quota (QuotaReserved=False; LOW Pending, HIGH Pending)
 === 7. free quota (delete blocker); the higher-priority pending workload wins ===
   first admitted after quota freed: HIGH
-[PASS] HIGH (orbital-r17856442882993375-mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
+[PASS] HIGH (orbital-r17856586653405078-mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
 === 7b. LOW was queued behind HIGH, not unable to run at all ===
 [PASS] LOW admitted once HIGH released the quota -> it was queued, not inadmissible
-  admitted at: HIGH=2026-08-02T04:18:28Z LOW=2026-08-02T04:19:32Z
-  workloads captured to run-r17856442882993375/workloads.yaml
-  defaulted ClusterQueue captured to run-r17856442882993375/clusterqueue.yaml
+  admitted at: HIGH=2026-08-02T08:18:03Z LOW=2026-08-02T08:19:07Z
+  --- workloads ---
+    | apiVersion: v1
+    | items:
+    | - apiVersion: kueue.x-k8s.io/v1beta2
+    |   kind: Workload
+    |   metadata:
+    |     creationTimestamp: "2026-08-02T08:17:56Z"
+    |     generation: 1
+    |     labels:
+    |       kueue.x-k8s.io/job-uid: 7e060ae6-40ec-4cd1-a759-5decc1c2a93f
+    |     name: job-prio-high-high-2026-04-15t10-00-00z-f5vnd-d8712
+    |     namespace: prio-r17856586653405078
+    |     ownerReferences:
+    |     - apiVersion: batch/v1
+    |       blockOwnerDeletion: true
+    |       controller: true
+    |       kind: Job
+    |       name: prio-high-high-2026-04-15t10-00-00z-f5vnd
+    |       uid: 7e060ae6-40ec-4cd1-a759-5decc1c2a93f
+    |     resourceVersion: "19822860"
+    |     uid: f9734f70-a459-45cc-8ff2-1dfef35e25dd
+    |   spec:
+    |     active: true
+    |     podSets:
+    |     - count: 1
+    |       name: main
+    |       template:
+    |         metadata:
+    |           labels:
+    |             batch.kubernetes.io/job-name: prio-high-high-2026-04-15t10-00-00z-f5vnd
+    |         spec:
+    |           containers:
+    |           - args:
+    |             - echo high-priority running; sleep 30
+    |             command:
+    |             - sh
+    |             - -c
+    |             image: busybox:1.36
+    |             imagePullPolicy: IfNotPresent
+    |             name: work
+    |             resources:
+    |               requests:
+    |                 cpu: "1"
+    |                 memory: 256Mi
+    |             terminationMessagePath: /dev/termination-log
+    |             terminationMessagePolicy: File
+    |           dnsPolicy: ClusterFirst
+    |           restartPolicy: Never
+    |           schedulerName: default-scheduler
+    |           securityContext: {}
+    |           terminationGracePeriodSeconds: 30
+    |       topologyRequest:
+    |         podIndexLabel: batch.kubernetes.io/job-completion-index
+    |     priority: 400
+    |     priorityClassRef:
+    |       group: kueue.x-k8s.io
+    |       kind: WorkloadPriorityClass
+    |       name: orbital-r17856586653405078-mission-critical
+    |     queueName: prio-lq-r17856586653405078
+    |   status:
+    |     admission:
+    |       clusterQueue: prio-cq-r17856586653405078
+    |       podSetAssignments:
+    |       - count: 1
+    |         flavors:
+    |           cpu: prio-flavor-r17856586653405078
+    |           memory: prio-flavor-r17856586653405078
+    |         name: main
+    |         resourceUsage:
+    |           cpu: "1"
+    |           memory: 256Mi
+    |     conditions:
+    |     - lastTransitionTime: "2026-08-02T08:18:03Z"
+    |       message: Quota reserved in ClusterQueue prio-cq-r17856586653405078
+    |       observedGeneration: 1
+    |       reason: QuotaReserved
+    |       status: "True"
+    |       type: QuotaReserved
+    |     - lastTransitionTime: "2026-08-02T08:18:03Z"
+    |       message: The workload is admitted
+    |       observedGeneration: 1
+    |       reason: Admitted
+    |       status: "True"
+    |       type: Admitted
+    |     - lastTransitionTime: "2026-08-02T08:19:06Z"
+    |       message: Reached expected number of succeeded pods
+    |       observedGeneration: 1
+    |       reason: Succeeded
+    |       status: "True"
+    |       type: Finished
+    |     - lastTransitionTime: "2026-08-02T08:19:06Z"
+    |       message: All pods reached readiness and the workload is running
+    |       observedGeneration: 1
+    |       reason: Recovered
+    |       status: "True"
+    |       type: PodsReady
+    | - apiVersion: kueue.x-k8s.io/v1beta2
+    |   kind: Workload
+    |   metadata:
+    |     creationTimestamp: "2026-08-02T08:17:50Z"
+    |     finalizers:
+    |     - kueue.x-k8s.io/resource-in-use
+    |     generation: 1
+    |     labels:
+    |       kueue.x-k8s.io/job-uid: 17bc8f29-1cae-42ac-9404-bd51c85245f5
+    |     name: job-prio-low-low-2026-04-15t10-00-00z-8xkgq-7af52
+    |     namespace: prio-r17856586653405078
+    |     ownerReferences:
+    |     - apiVersion: batch/v1
+    |       blockOwnerDeletion: true
+    |       controller: true
+    |       kind: Job
+    |       name: prio-low-low-2026-04-15t10-00-00z-8xkgq
+    |       uid: 17bc8f29-1cae-42ac-9404-bd51c85245f5
+    |     resourceVersion: "19822891"
+    |     uid: c445214c-bfde-4e9f-b60f-0d1f54bfdad0
+    |   spec:
+    |     active: true
+    |     podSets:
+    |     - count: 1
+    |       name: main
+    |       template:
+    |         metadata:
+    |           labels:
+    |             batch.kubernetes.io/job-name: prio-low-low-2026-04-15t10-00-00z-8xkgq
+    |         spec:
+    |           containers:
+    |           - args:
+    |             - echo low-priority running; sleep 30
+    |             command:
+    |             - sh
+    |             - -c
+    |             image: busybox:1.36
+    |             imagePullPolicy: IfNotPresent
+    |             name: work
+    |             resources:
+    |               requests:
+    |                 cpu: "1"
+    |                 memory: 256Mi
+    |             terminationMessagePath: /dev/termination-log
+    |             terminationMessagePolicy: File
+    |           dnsPolicy: ClusterFirst
+    |           restartPolicy: Never
+    |           schedulerName: default-scheduler
+    |           securityContext: {}
+    |           terminationGracePeriodSeconds: 30
+    |       topologyRequest:
+    |         podIndexLabel: batch.kubernetes.io/job-completion-index
+    |     priority: 200
+    |     priorityClassRef:
+    |       group: kueue.x-k8s.io
+    |       kind: WorkloadPriorityClass
+    |       name: orbital-r17856586653405078-mission-normal
+    |     queueName: prio-lq-r17856586653405078
+    |   status:
+    |     admission:
+    |       clusterQueue: prio-cq-r17856586653405078
+    |       podSetAssignments:
+    |       - count: 1
+    |         flavors:
+    |           cpu: prio-flavor-r17856586653405078
+    |           memory: prio-flavor-r17856586653405078
+    |         name: main
+    |         resourceUsage:
+    |           cpu: "1"
+    |           memory: 256Mi
+    |     conditions:
+    |     - lastTransitionTime: "2026-08-02T08:19:07Z"
+    |       message: Quota reserved in ClusterQueue prio-cq-r17856586653405078
+    |       observedGeneration: 1
+    |       reason: QuotaReserved
+    |       status: "True"
+    |       type: QuotaReserved
+    |     - lastTransitionTime: "2026-08-02T08:19:07Z"
+    |       message: The workload is admitted
+    |       observedGeneration: 1
+    |       reason: Admitted
+    |       status: "True"
+    |       type: Admitted
+    |     - lastTransitionTime: "2026-08-02T08:19:08Z"
+    |       message: All pods reached readiness and the workload is running
+    |       observedGeneration: 1
+    |       reason: Started
+    |       status: "True"
+    |       type: PodsReady
+    | kind: List
+    | metadata:
+    |   resourceVersion: ""
+  --- ClusterQueue as defaulted ---
+    | apiVersion: kueue.x-k8s.io/v1beta2
+    | kind: ClusterQueue
+    | metadata:
+    |   creationTimestamp: "2026-08-02T08:17:47Z"
+    |   finalizers:
+    |   - kueue.x-k8s.io/resource-in-use
+    |   generation: 1
+    |   labels:
+    |     orbital.test/run-id: r17856586653405078
+    |   name: prio-cq-r17856586653405078
+    |   resourceVersion: "19822889"
+    |   uid: a23e26ae-0528-4586-b739-0cca5dcadc71
+    | spec:
+    |   flavorFungibility:
+    |     whenCanBorrow: MayStopSearch
+    |     whenCanPreempt: TryNextFlavor
+    |   namespaceSelector: {}
+    |   preemption:
+    |     borrowWithinCohort:
+    |       policy: Never
+    |     reclaimWithinCohort: Never
+    |     withinClusterQueue: Never
+    |   queueingStrategy: BestEffortFIFO
+    |   resourceGroups:
+    |   - coveredResources:
+    |     - cpu
+    |     - memory
+    |     flavors:
+    |     - name: prio-flavor-r17856586653405078
+    |       resources:
+    |       - name: cpu
+    |         nominalQuota: "1"
+    |       - name: memory
+    |         nominalQuota: 2Gi
+    |   stopPolicy: None
+    | status:
+    |   admittedWorkloads: 1
+    |   conditions:
+    |   - lastTransitionTime: "2026-08-02T08:17:47Z"
+    |     message: Can admit new workloads
+    |     observedGeneration: 1
+    |     reason: Ready
+    |     status: "True"
+    |     type: Active
+    |   flavorsReservation:
+    |   - name: prio-flavor-r17856586653405078
+    |     resources:
+    |     - borrowed: "0"
+    |       name: cpu
+    |       total: "1"
+    |     - borrowed: "0"
+    |       name: memory
+    |       total: 256Mi
+    |   flavorsUsage:
+    |   - name: prio-flavor-r17856586653405078
+    |     resources:
+    |     - borrowed: "0"
+    |       name: cpu
+    |       total: "1"
+    |     - borrowed: "0"
+    |       name: memory
+    |       total: 256Mi
+    |   pendingWorkloads: 0
+    |   reservingWorkloads: 1
 === 8. the same race, repeated ===
   priority arm race 2/5: HIGH
   priority arm race 3/5: HIGH
@@ -68,5 +384,5 @@
 
 === Summary ===
 PASS: 22  FAIL: 0
-=== cleanup (run r17856442882993375) ===
+=== cleanup (run r17856586653405078) ===
 RESULT: PASS

--- a/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
+++ b/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
@@ -1,21 +1,8 @@
-# Live proof: a mission plan's priority reaches the field Kueue sorts on, and
-# inverts an admission order that the same experiment shows is otherwise decided by
-# arrival.
-#
-# Captured from a clean working tree on the commit the run names below. Every fact
-# about the cluster is printed by the run itself rather than written here, so this
-# file's provenance is the run and not its author.
-#
-# Untouched throughout: the ClusterQueues that belong to this cluster
-# (dra-paper-cq, dra-unified-cq, gmat-forge-cluster-queue, orbital-demo-cq). Every
-# object the run creates is named for it, labelled orbital.test/run-id, and deleted
-# by that label.
-#
-=== run r17856387592851821 ===
-  namespace=prio-r17856387592851821 clusterQueue=prio-cq-r17856387592851821 classes=orbital-r17856387592851821-mission-critical,orbital-r17856387592851821-mission-normal
-  compiler commit: 7cf5e9678896446a837e7785a88b1ed02bbff9c5
+=== run r17856442882993375 ===
+  namespace=prio-r17856442882993375 clusterQueue=prio-cq-r17856442882993375 classes=orbital-r17856442882993375-mission-critical,orbital-r17856442882993375-mission-normal
+  compiler commit: 2c864efa6962ba95ca03ad6cef6a9a4b89740768
   working tree   : clean
-  harness sha256 : 5eb02ddb38008d299daafc8fb668f6d0fca0ca771b41d9038047a18d6bf2af28
+  harness sha256 : 9f1ae8d8b2f47cc5ef6109b5bf66955f98547a1f9a02d83acc31436e232b24a8
   interpreter    : /mnt/fast/work/satellite-mission-compiler/.venv-verify/bin/python
   compiler module: /tmp/claude-1000/-mnt-fast-work-satellite-mission-compiler/6c6b6570-cadb-4cdf-918a-4970f553d84a/scratchpad/pr79/src/orbital_mission_compiler/compiler.py
 === environment ===
@@ -25,17 +12,18 @@
   kueue image    : registry.k8s.io/kueue/kueue:v0.19.0
   kueue imageID  : registry.k8s.io/kueue/kueue@sha256:6fe2cbe4c7799eed1a8d49898c38b8bd73f1572df1825d7cf266ec9e2af70bec
   kueue gates    : (none set; built-in defaults apply)
-  kueue config   : captured to kueue-priority/kueue-manager-config.yaml
+  kueue config   : captured to run-r17856442882993375/kueue-manager-config.yaml
 === 0. prerequisites ===
-[PASS] kubectl available
+[PASS] kubectl available (/usr/bin/kubectl)
 [PASS] Kueue controller present
+[PASS] the cluster-scoped verbs this run needs are permitted
 === 0b. nothing this run is about to create already exists ===
 [PASS] no pre-existing object carries this run's names
 === 1. apply namespace + ClusterQueue (cpu=1) + LocalQueue ===
 [PASS] queue applied
 === 2. emit + apply the WorkloadPriorityClasses from the compiler ===
 [PASS] WorkloadPriorityClasses applied
-[PASS] orbital-r17856387592851821-mission-critical + orbital-r17856387592851821-mission-normal exist
+[PASS] orbital-r17856442882993375-mission-critical + orbital-r17856442882993375-mission-normal exist
 [PASS] all four emitted classes carry the mapped values (400/300/200/100)
 [PASS] all four classes are labelled with the mapping this tree emits (v2)
 === 3. render HIGH (priority 90) and LOW (priority 50) Jobs ===
@@ -44,24 +32,24 @@
 === 4. blocker holds the cpu=1 quota ===
 [PASS] blocker admitted (holds quota)
 === 5. submit LOW first, then HIGH (reverse of priority) ===
-  LOW  job=prio-low-low-2026-04-15t10-00-00z-ljjss workload=job-prio-low-low-2026-04-15t10-00-00z-ljjss-45c8f priority=200 class=orbital-r17856387592851821-mission-normal
-  HIGH job=prio-high-high-2026-04-15t10-00-00z-cdswj workload=job-prio-high-high-2026-04-15t10-00-00z-cdswj-7fcd6 priority=400 class=orbital-r17856387592851821-mission-critical
+  LOW  job=prio-low-low-2026-04-15t10-00-00z-6blpn workload=job-prio-low-low-2026-04-15t10-00-00z-6blpn-d363a priority=200 class=orbital-r17856442882993375-mission-normal
+  HIGH job=prio-high-high-2026-04-15t10-00-00z-hp88q workload=job-prio-high-high-2026-04-15t10-00-00z-hp88q-b318d priority=400 class=orbital-r17856442882993375-mission-critical
 === 5b. the chain the claim rests on ===
 [PASS] workload priorities resolved (HIGH=400 LOW=200)
 [PASS] workloads reference the emitted classes
 [PASS] each Job carries the mapping its own class carries (v2)
 [PASS] both references are WorkloadPriorityClasses, not Pod PriorityClasses
-[PASS] LOW was created before HIGH (2026-08-02T02:46:03Z < 2026-08-02T02:46:09Z)
+[PASS] LOW was created before HIGH (2026-08-02T04:18:14Z < 2026-08-02T04:18:20Z)
 === 6. both PENDING while blocker holds quota ===
 [PASS] LOW and HIGH both waiting on quota (QuotaReserved=False; LOW Pending, HIGH Pending)
 === 7. free quota (delete blocker); the higher-priority pending workload wins ===
   first admitted after quota freed: HIGH
-[PASS] HIGH (orbital-r17856387592851821-mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
+[PASS] HIGH (orbital-r17856442882993375-mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
 === 7b. LOW was queued behind HIGH, not unable to run at all ===
 [PASS] LOW admitted once HIGH released the quota -> it was queued, not inadmissible
-  admitted at: HIGH=2026-08-02T02:46:16Z LOW=2026-08-02T02:47:20Z
-  workloads captured to kueue-priority/workloads.yaml
-  defaulted ClusterQueue captured to kueue-priority/clusterqueue.yaml
+  admitted at: HIGH=2026-08-02T04:18:28Z LOW=2026-08-02T04:19:32Z
+  workloads captured to run-r17856442882993375/workloads.yaml
+  defaulted ClusterQueue captured to run-r17856442882993375/clusterqueue.yaml
 === 8. the same race, repeated ===
   priority arm race 2/5: HIGH
   priority arm race 3/5: HIGH
@@ -79,6 +67,6 @@
 [PASS] without a priority class the FIRST submitted won 5/5 races -> the apparatus does observe arrival order, and the treatment arm inverted it
 
 === Summary ===
-PASS: 21  FAIL: 0
+PASS: 22  FAIL: 0
+=== cleanup (run r17856442882993375) ===
 RESULT: PASS
-=== cleanup (run r17856387592851821) ===

--- a/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
+++ b/manifests/k8s/kueue/priority-ordering/results/run-k8s-1.36.3-kueue-0.19.0.txt
@@ -12,11 +12,11 @@
 # cluster, were present throughout, and were untouched:
 #   dra-paper-cq dra-unified-cq gmat-forge-cluster-queue orbital-demo-cq
 #
-=== run r17856322192754005 ===
-  namespace=prio-r17856322192754005 clusterQueue=prio-cq-r17856322192754005 classes=orbital-r17856322192754005-mission-critical,orbital-r17856322192754005-mission-normal
-  compiler commit: a36082e8ad5fca022e362b0ee27c3d004c19820b
+=== run r17856328122762495 ===
+  namespace=prio-r17856328122762495 clusterQueue=prio-cq-r17856328122762495 classes=orbital-r17856328122762495-mission-critical,orbital-r17856328122762495-mission-normal
+  compiler commit: 572a9c3c7068d6877950c3448dd5a5ccdfd7e956
   working tree   : clean
-  harness sha256 : ad00f5d31e3077f4cf9261efcbd1c3386da48d703925332e01bbcc12466172c7
+  harness sha256 : bf20445085744ab919be1d3b40a2bad50c43be2e39c9ff1b25d9953a94735572
 === 0. prerequisites ===
 [PASS] kubectl available
 [PASS] Kueue controller present
@@ -26,27 +26,27 @@
 [PASS] queue applied
 === 2. emit + apply the WorkloadPriorityClasses from the compiler ===
 [PASS] WorkloadPriorityClasses applied
-[PASS] orbital-r17856322192754005-mission-critical + orbital-r17856322192754005-mission-normal exist
-[PASS] class values as mapped (orbital-r17856322192754005-mission-critical=400, orbital-r17856322192754005-mission-normal=200)
+[PASS] orbital-r17856328122762495-mission-critical + orbital-r17856328122762495-mission-normal exist
+[PASS] class values as mapped (orbital-r17856328122762495-mission-critical=400, orbital-r17856328122762495-mission-normal=200)
 === 3. render HIGH (priority 90) and LOW (priority 50) Jobs ===
 === 4. blocker holds the cpu=1 quota ===
 [PASS] blocker admitted (holds quota)
 === 5. submit LOW first, then HIGH (reverse of priority) ===
-  LOW  job=prio-low-low-2026-04-15t10-00-00z-w56z9 workload=job-prio-low-low-2026-04-15t10-00-00z-w56z9-a21d5 priority=200 class=orbital-r17856322192754005-mission-normal
-  HIGH job=prio-high-high-2026-04-15t10-00-00z-g64qq workload=job-prio-high-high-2026-04-15t10-00-00z-g64qq-6b233 priority=400 class=orbital-r17856322192754005-mission-critical
+  LOW  job=prio-low-low-2026-04-15t10-00-00z-r4xsl workload=job-prio-low-low-2026-04-15t10-00-00z-r4xsl-02eed priority=200 class=orbital-r17856328122762495-mission-normal
+  HIGH job=prio-high-high-2026-04-15t10-00-00z-mtwln workload=job-prio-high-high-2026-04-15t10-00-00z-mtwln-80c06 priority=400 class=orbital-r17856328122762495-mission-critical
 === 5b. the chain the claim rests on ===
 [PASS] workload priorities resolved (HIGH=400 LOW=200)
 [PASS] workloads reference the emitted classes
 [PASS] both Jobs carry the mapping that named their class (v2)
 [PASS] the reference is a WorkloadPriorityClass, not a Pod PriorityClass
-[PASS] LOW was created before HIGH (2026-08-02T00:57:01Z < 2026-08-02T00:57:07Z)
+[PASS] LOW was created before HIGH (2026-08-02T01:06:54Z < 2026-08-02T01:07:00Z)
 === 6. both PENDING while blocker holds quota ===
 [PASS] LOW and HIGH both pending under full quota
 === 7. free quota (delete blocker); the higher-priority pending workload wins ===
   first admitted after quota freed: HIGH
-[PASS] HIGH (orbital-r17856322192754005-mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
+[PASS] HIGH (orbital-r17856328122762495-mission-critical, submitted LAST) admitted before LOW -> priority drove ordering
 
 === Summary ===
 PASS: 15  FAIL: 0
 RESULT: PASS
-=== cleanup (run r17856322192754005) ===
+=== cleanup (run r17856328122762495) ===

--- a/scripts/validate_kueue_priority.sh
+++ b/scripts/validate_kueue_priority.sh
@@ -12,29 +12,83 @@
 #
 # The Jobs are rendered by the compiler (`render-kueue --priority-class`), so this
 # validates the compiler's own output, not a hand-written manifest.
+#
+# Everything this run creates carries a run-specific name and an ownership label, and
+# teardown deletes only what it made. An earlier version used fixed names and deleted
+# them unconditionally, which on a cluster that already had a `mission-prio` namespace
+# or a `mission-critical` class would have adopted someone else's object and then
+# removed it -- deleting a namespace takes everything inside it.
 set -uo pipefail
 
 PYTHON_BIN="${PYTHON_BIN:-python3}"
-NS="${NS:-mission-prio}"
-LQ="${LQ:-mission-prio-lq}"
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
 MANIFESTS="${HERE}/manifests/k8s/kueue/priority-ordering"
 OUT="${OUT:-${HERE}/out/kueue-priority}"
+
+# One identifier per run, so two runs on one cluster cannot collide and neither can
+# touch anything that was already there. Override RUN_ID to reproduce a name.
+RUN_ID="${RUN_ID:-r$(date +%s)$$}"
+NS="prio-${RUN_ID}"
+FLAVOR="prio-flavor-${RUN_ID}"
+CQ="prio-cq-${RUN_ID}"
+LQ="prio-lq-${RUN_ID}"
+BLOCKER="prio-blocker-${RUN_ID}"
+# The classes are cluster-scoped, so they get the run in their name too, through the
+# compiler's own --priority-class-prefix rather than a second naming scheme.
+CLASS_PREFIX="orbital-${RUN_ID}-"
+HIGH_CLASS="${CLASS_PREFIX}mission-critical"
+LOW_CLASS="${CLASS_PREFIX}mission-normal"
+OWNER_LABEL="orbital.test/run-id=${RUN_ID}"
+
 rm -rf "$OUT"; mkdir -p "$OUT"
 
 PASS=0; FAIL=0
 LOW_JOB=""; HIGH_JOB=""   # set mid-run; initialised so the cleanup trap is set -u safe
+CREATED_QUEUES=0; CREATED_WPCS=0   # only tear down what was actually applied
 report() { if [ "$1" = PASS ]; then echo "[PASS] $2"; PASS=$((PASS+1)); else echo "[FAIL] $2"; FAIL=$((FAIL+1)); fi; }
 
-# Unconditional teardown: runs on normal exit AND on interrupt (Ctrl-C / timeout),
-# so the experiment never leaves the namespace, queue, or cluster-scoped classes behind.
+# Teardown removes only objects carrying this run's ownership label. Deleting by label
+# rather than by manifest is what keeps a pre-existing object of the same kind safe.
 cleanup() {
-  echo "=== cleanup ==="
-  kubectl delete job "$LOW_JOB" "$HIGH_JOB" prio-blocker -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
-  kubectl delete -f "${OUT}/wpc/workload-priority-classes.yaml" --ignore-not-found >/dev/null 2>&1 || true
-  kubectl delete -f "${MANIFESTS}/00-namespace-and-queue.yaml" --ignore-not-found >/dev/null 2>&1 || true
+  echo "=== cleanup (run ${RUN_ID}) ==="
+  kubectl delete job "$LOW_JOB" "$HIGH_JOB" "$BLOCKER" -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
+  if [ "$CREATED_WPCS" -eq 1 ]; then
+    kubectl delete workloadpriorityclass -l "$OWNER_LABEL" --ignore-not-found >/dev/null 2>&1 || true
+  fi
+  if [ "$CREATED_QUEUES" -eq 1 ]; then
+    kubectl delete localqueue -n "$NS" -l "$OWNER_LABEL" --ignore-not-found >/dev/null 2>&1 || true
+    kubectl delete clusterqueue -l "$OWNER_LABEL" --ignore-not-found >/dev/null 2>&1 || true
+    kubectl delete resourceflavor -l "$OWNER_LABEL" --ignore-not-found >/dev/null 2>&1 || true
+    kubectl delete namespace -l "$OWNER_LABEL" --ignore-not-found >/dev/null 2>&1 || true
+  fi
 }
-trap cleanup EXIT INT TERM
+# EXIT covers the normal path. INT and TERM clean up and then stop: a handler that
+# returns lets the script carry on and create the resources it has just deleted.
+trap cleanup EXIT
+trap 'cleanup; trap - EXIT; exit 130' INT
+trap 'cleanup; trap - EXIT; exit 143' TERM
+
+# Fill the run's names into a template. One substitution table feeds setup, render,
+# lookup and teardown, so an override cannot leave the queue in one namespace and the
+# Jobs in another.
+render_template() { # $1 template path -> stdout
+  "${PYTHON_BIN}" - "$1" "$NS" "$FLAVOR" "$CQ" "$LQ" "$BLOCKER" "$RUN_ID" <<'PY'
+import sys
+path, ns, flavor, cq, lq, blocker, run_id = sys.argv[1:8]
+text = open(path, encoding="utf-8").read()
+for token, value in (
+    ("__NS__", ns), ("__FLAVOR__", flavor), ("__CQ__", cq),
+    ("__LQ__", lq), ("__BLOCKER__", blocker), ("__RUN_ID__", run_id),
+):
+    text = text.replace(token, value)
+sys.stdout.write(text)
+PY
+}
+
+absent() { # $1 kind, $2 name, [$3 namespace] -> 0 when the object does not exist
+  if [ $# -ge 3 ]; then kubectl get "$1" "$2" -n "$3" >/dev/null 2>&1; else kubectl get "$1" "$2" >/dev/null 2>&1; fi
+  [ $? -ne 0 ]
+}
 
 wl_for_job() { # $1 job name -> workload name (via job-uid label)
   local uid; uid=$(kubectl get job "$1" -n "$NS" -o jsonpath='{.metadata.uid}' 2>/dev/null)
@@ -44,41 +98,88 @@ wl_for_job() { # $1 job name -> workload name (via job-uid label)
 }
 wl_admitted() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Admitted")].status}' 2>/dev/null; }
 wl_priority() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priority}' 2>/dev/null; }
+wl_class() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priorityClassName}' 2>/dev/null; }
+wl_created() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null; }
 wait_wl() { # $1 job name -> echo workload name once it exists (up to 30s)
   local w=""; local d=$((SECONDS+30))
   while [ $SECONDS -lt $d ]; do w=$(wl_for_job "$1"); [ -n "$w" ] && break; sleep 2; done
   echo "$w"
 }
 
+echo "=== run ${RUN_ID} ==="
+echo "  namespace=${NS} clusterQueue=${CQ} classes=${HIGH_CLASS},${LOW_CLASS}"
+echo "  compiler commit: $(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || echo unknown)$( [ -n "$(git -C "$HERE" status --porcelain 2>/dev/null)" ] && echo ' (dirty tree)' )"
+
 echo "=== 0. prerequisites ==="
 command -v kubectl >/dev/null 2>&1 && report PASS "kubectl available" || { report FAIL "kubectl missing"; exit 2; }
 kubectl get deployment -n kueue-system kueue-controller-manager >/dev/null 2>&1 \
   && report PASS "Kueue controller present" || report FAIL "Kueue controller missing"
 
+echo "=== 0b. nothing this run is about to create already exists ==="
+COLLIDE=""
+absent namespace "$NS" || COLLIDE="${COLLIDE} namespace/${NS}"
+absent clusterqueue "$CQ" || COLLIDE="${COLLIDE} clusterqueue/${CQ}"
+absent resourceflavor "$FLAVOR" || COLLIDE="${COLLIDE} resourceflavor/${FLAVOR}"
+absent workloadpriorityclass "$HIGH_CLASS" || COLLIDE="${COLLIDE} wpc/${HIGH_CLASS}"
+absent workloadpriorityclass "$LOW_CLASS" || COLLIDE="${COLLIDE} wpc/${LOW_CLASS}"
+if [ -z "$COLLIDE" ]; then
+  report PASS "no pre-existing object carries this run's names"
+else
+  report FAIL "refusing to adopt existing object(s):${COLLIDE}"
+  echo "RESULT: FAIL"; exit 1
+fi
+
 echo "=== 1. apply namespace + ClusterQueue (cpu=1) + LocalQueue ==="
-kubectl apply -f "${MANIFESTS}/00-namespace-and-queue.yaml" >/dev/null && report PASS "queue applied" || report FAIL "queue apply failed"
+if render_template "${MANIFESTS}/00-namespace-and-queue.yaml" | kubectl apply -f - >/dev/null; then
+  CREATED_QUEUES=1; report PASS "queue applied"
+else
+  report FAIL "queue apply failed"
+fi
 
 echo "=== 2. emit + apply the WorkloadPriorityClasses from the compiler ==="
 PYTHONPATH="${HERE}/src" ${PYTHON_BIN} -m orbital_mission_compiler.cli render-kueue \
   --input "${MANIFESTS}/plan-high.yaml" --output-dir "${OUT}/wpc" --queue "$LQ" --namespace "$NS" \
-  --emit-priority-classes --priority-class --policy-engine baseline >/dev/null 2>&1
-kubectl apply -f "${OUT}/wpc/workload-priority-classes.yaml" >/dev/null \
-  && report PASS "WorkloadPriorityClasses applied" || report FAIL "WPC apply failed"
-kubectl get workloadpriorityclass mission-critical mission-normal >/dev/null 2>&1 \
-  && report PASS "mission-critical + mission-normal exist" || report FAIL "priority classes missing"
+  --emit-priority-classes --priority-class --priority-class-prefix "$CLASS_PREFIX" \
+  --policy-engine baseline >/dev/null 2>&1
+# The compiler does not know about this run, so the ownership label is added here.
+if "${PYTHON_BIN}" - "${OUT}/wpc/workload-priority-classes.yaml" "$RUN_ID" <<'PY' | kubectl apply -f - >/dev/null
+import sys, yaml
+path, run_id = sys.argv[1], sys.argv[2]
+docs = [d for d in yaml.safe_load_all(open(path, encoding="utf-8")) if d]
+for d in docs:
+    d.setdefault("metadata", {}).setdefault("labels", {})["orbital.test/run-id"] = run_id
+yaml.safe_dump_all(docs, sys.stdout)
+PY
+then
+  CREATED_WPCS=1; report PASS "WorkloadPriorityClasses applied"
+else
+  report FAIL "WPC apply failed"
+fi
+kubectl get workloadpriorityclass "$HIGH_CLASS" "$LOW_CLASS" >/dev/null 2>&1 \
+  && report PASS "${HIGH_CLASS} + ${LOW_CLASS} exist" || report FAIL "priority classes missing"
+
+# The ordering claim rests on these two values, so read them back rather than trusting
+# the mapping: a rename that silently changed a value would otherwise pass unnoticed.
+HIGH_VALUE=$(kubectl get workloadpriorityclass "$HIGH_CLASS" -o jsonpath='{.value}' 2>/dev/null)
+LOW_VALUE=$(kubectl get workloadpriorityclass "$LOW_CLASS" -o jsonpath='{.value}' 2>/dev/null)
+if [ "$HIGH_VALUE" = "400" ] && [ "$LOW_VALUE" = "200" ]; then
+  report PASS "class values as mapped (${HIGH_CLASS}=400, ${LOW_CLASS}=200)"
+else
+  report FAIL "unexpected class values: ${HIGH_CLASS}=${HIGH_VALUE:-<none>} ${LOW_CLASS}=${LOW_VALUE:-<none>}"
+fi
 
 echo "=== 3. render HIGH (priority 90) and LOW (priority 50) Jobs ==="
 for p in high low; do
   PYTHONPATH="${HERE}/src" ${PYTHON_BIN} -m orbital_mission_compiler.cli render-kueue \
     --input "${MANIFESTS}/plan-${p}.yaml" --output-dir "${OUT}/${p}" --queue "$LQ" --namespace "$NS" \
-    --priority-class --policy-engine baseline >/dev/null 2>&1
+    --priority-class --priority-class-prefix "$CLASS_PREFIX" --policy-engine baseline >/dev/null 2>&1
 done
 HIGH_JOB_FILE=$(find "${OUT}/high" -name '*-kueue.yaml' | head -1)
 LOW_JOB_FILE=$(find "${OUT}/low" -name '*-kueue.yaml' | head -1)
 
 echo "=== 4. blocker holds the cpu=1 quota ==="
-kubectl apply -f "${MANIFESTS}/01-blocker-job.yaml" >/dev/null
-BLOCK_WL=$(wait_wl prio-blocker)
+render_template "${MANIFESTS}/01-blocker-job.yaml" | kubectl apply -f - >/dev/null
+BLOCK_WL=$(wait_wl "$BLOCKER")
 d=$((SECONDS+60)); ba=""
 while [ $SECONDS -lt $d ]; do ba=$(wl_admitted "$BLOCK_WL"); [ "$ba" = "True" ] && break; sleep 2; done
 [ "$ba" = "True" ] && report PASS "blocker admitted (holds quota)" || report FAIL "blocker not admitted"
@@ -86,11 +187,29 @@ while [ $SECONDS -lt $d ]; do ba=$(wl_admitted "$BLOCK_WL"); [ "$ba" = "True" ] 
 echo "=== 5. submit LOW first, then HIGH (reverse of priority) ==="
 LOW_JOB=$(kubectl create -f "$LOW_JOB_FILE" -o jsonpath='{.metadata.name}' 2>/dev/null)
 LOW_WL=$(wait_wl "$LOW_JOB")
-echo "  LOW  job=$LOW_JOB workload=$LOW_WL priority=$(wl_priority "$LOW_WL")"
-sleep 6   # ensure LOW creationTimestamp strictly precedes HIGH
+echo "  LOW  job=$LOW_JOB workload=$LOW_WL priority=$(wl_priority "$LOW_WL") class=$(wl_class "$LOW_WL")"
+sleep 6   # give the clock room; the assertion below reads the real timestamps
 HIGH_JOB=$(kubectl create -f "$HIGH_JOB_FILE" -o jsonpath='{.metadata.name}' 2>/dev/null)
 HIGH_WL=$(wait_wl "$HIGH_JOB")
-echo "  HIGH job=$HIGH_JOB workload=$HIGH_WL priority=$(wl_priority "$HIGH_WL")"
+echo "  HIGH job=$HIGH_JOB workload=$HIGH_WL priority=$(wl_priority "$HIGH_WL") class=$(wl_class "$HIGH_WL")"
+
+echo "=== 5b. the chain the claim rests on ==="
+HP=$(wl_priority "$HIGH_WL"); LP=$(wl_priority "$LOW_WL")
+[ "$HP" = "400" ] && [ "$LP" = "200" ] \
+  && report PASS "workload priorities resolved (HIGH=400 LOW=200)" \
+  || report FAIL "workload priorities: HIGH=${HP:-<none>} LOW=${LP:-<none>}"
+HC=$(wl_class "$HIGH_WL"); LC=$(wl_class "$LOW_WL")
+[ "$HC" = "$HIGH_CLASS" ] && [ "$LC" = "$LOW_CLASS" ] \
+  && report PASS "workloads reference the emitted classes" \
+  || report FAIL "class references: HIGH=${HC:-<none>} LOW=${LC:-<none>}"
+# Arrival order is the thing priority has to beat, so read it rather than assume the
+# sleep achieved it.
+HT=$(wl_created "$HIGH_WL"); LT=$(wl_created "$LOW_WL")
+if [ -n "$HT" ] && [ -n "$LT" ] && [ "$LT" \< "$HT" ]; then
+  report PASS "LOW was created before HIGH (${LT} < ${HT})"
+else
+  report FAIL "arrival order not established: LOW=${LT:-<none>} HIGH=${HT:-<none>}"
+fi
 
 echo "=== 6. both PENDING while blocker holds quota ==="
 sleep 5
@@ -104,20 +223,24 @@ else
 fi
 
 echo "=== 7. free quota (delete blocker); the higher-priority pending workload wins ==="
-kubectl delete -f "${MANIFESTS}/01-blocker-job.yaml" --ignore-not-found >/dev/null 2>&1
+kubectl delete job "$BLOCKER" -n "$NS" --ignore-not-found >/dev/null 2>&1
 FIRST=""; d=$((SECONDS+60))
 while [ $SECONDS -lt $d ]; do
   ha=$(wl_admitted "$HIGH_WL"); la=$(wl_admitted "$LOW_WL")
-  if [ "$ha" = "True" ]; then FIRST="HIGH"; HIGH_LOW_AT_ADMIT="$la"; break; fi
+  # Both true at the first observation means the order happened between two polls and
+  # is no longer knowable. Checking HIGH first would report it as a win either way.
+  if [ "$ha" = "True" ] && [ "$la" = "True" ]; then FIRST="BOTH"; break; fi
+  if [ "$ha" = "True" ]; then FIRST="HIGH"; break; fi
   if [ "$la" = "True" ]; then FIRST="LOW"; break; fi
   sleep 2
 done
-echo "  first admitted after quota freed: ${FIRST:-<none>} (LOW status at that moment: ${HIGH_LOW_AT_ADMIT:-n/a})"
-if [ "$FIRST" = "HIGH" ]; then
-  report PASS "HIGH (mission-critical, submitted LAST) admitted before LOW -> priority drove ordering"
-else
-  report FAIL "expected HIGH first, got ${FIRST:-none} -> could not distinguish priority from creation order"
-fi
+echo "  first admitted after quota freed: ${FIRST:-<none>}"
+case "$FIRST" in
+  HIGH) report PASS "HIGH (${HIGH_CLASS}, submitted LAST) admitted before LOW -> priority drove ordering" ;;
+  BOTH) report FAIL "both admitted within one poll -> order unobservable, not evidence either way" ;;
+  LOW)  report FAIL "LOW admitted first -> creation order, not priority, decided" ;;
+  *)    report FAIL "neither workload was admitted within the window" ;;
+esac
 
 echo "" ; echo "=== Summary ===" ; echo "PASS: ${PASS}  FAIL: ${FAIL}"
 # Teardown runs via the EXIT trap (also covers interrupts).

--- a/scripts/validate_kueue_priority.sh
+++ b/scripts/validate_kueue_priority.sh
@@ -23,7 +23,9 @@ set -uo pipefail
 PYTHON_BIN="${PYTHON_BIN:-python3}"
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
 MANIFESTS="${HERE}/manifests/k8s/kueue/priority-ordering"
-OUT="${OUT:-${HERE}/out/kueue-priority}"
+# OUT, if the caller sets it, is a PARENT for this run's directory rather than the
+# directory itself; see where OUT_ROOT is resolved below. Left unset it becomes a
+# temporary directory this script creates and removes.
 
 # One identifier per run, so two runs on one cluster cannot collide and neither can
 # touch anything that was already there. Override RUN_ID to reproduce a name.
@@ -80,33 +82,103 @@ LOW_CLASS="${CLASS_PREFIX}mission-normal"
 ALL_CLASSES="${CLASS_PREFIX}mission-critical ${CLASS_PREFIX}mission-high ${CLASS_PREFIX}mission-normal ${CLASS_PREFIX}mission-low"
 OWNER_LABEL="orbital.test/run-id=${RUN_ID}"
 
-rm -rf "$OUT"; mkdir -p "$OUT"
+# The output directory is deleted at the start, so it must be one this script owns.
+# It used to be whatever the caller put in OUT, deleted recursively with no check at
+# all: an inherited CI variable, a wrapper passing the wrong argument or a typo like
+# OUT=$HOME was a recursive delete of that path. Now the caller chooses a parent at
+# most, the run works inside a subdirectory named for itself, and that subdirectory
+# is only removed when it carries this script's own marker.
+OUT_ROOT="${OUT:-}"
+if [ -z "${OUT_ROOT}" ]; then
+  OUT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/kueue-priority.XXXXXXXX")" || {
+    printf 'could not create a working directory\n' >&2; printf 'RESULT: FAIL\n'; exit 2; }
+  OUT_ROOT_IS_OURS=1
+else
+  case "${OUT_ROOT}" in
+    /) printf 'OUT must not be the filesystem root\n' >&2; printf 'RESULT: FAIL\n'; exit 2 ;;
+  esac
+  mkdir -p "${OUT_ROOT}" || { printf 'OUT is not creatable: %s\n' "${OUT_ROOT}" >&2; printf 'RESULT: FAIL\n'; exit 2; }
+  OUT_ROOT_IS_OURS=0
+fi
+OUT="${OUT_ROOT}/run-${RUN_ID}"
+SENTINEL="${OUT}/.kueue-priority-run"
+if [ -e "$OUT" ] && [ ! -e "$SENTINEL" ]; then
+  printf '%s exists and was not created by this script; refusing to delete it\n' "$OUT" >&2
+  printf 'RESULT: FAIL\n'; exit 2
+fi
+rm -rf "$OUT"; mkdir -p "$OUT"; : > "$SENTINEL"
 
 PASS=0; FAIL=0
 LOW_JOB=""; HIGH_JOB=""   # set mid-run; initialised so the cleanup trap is set -u safe
-CREATED_QUEUES=0; CREATED_WPCS=0   # only tear down what was actually applied
+# Set once, immediately BEFORE the first thing that can create an object -- not after
+# a successful apply. `kubectl apply -f` over a multi-document manifest is not one
+# transaction: it creates the documents in order and can fail on a later one, so a
+# flag set only on overall success left a namespace and a flavor on the cluster with
+# teardown believing nothing had been made.
+MUTATION_STARTED=0
+CLEANUP_FAILED=0
 report() { if [ "$1" = PASS ]; then echo "[PASS] $2"; PASS=$((PASS+1)); else echo "[FAIL] $2"; FAIL=$((FAIL+1)); fi; }
 
 # Teardown removes only objects carrying this run's ownership label. Deleting by label
 # rather than by manifest is what keeps a pre-existing object of the same kind safe.
+CLEANED=0
 cleanup() {
+  [ "${CLEANED}" -eq 1 ] && return 0
+  CLEANED=1
+  # Removing the working directory is safe whatever happened: it is named for this
+  # run and carries this script's marker.
+  if [ "${OUT_ROOT_IS_OURS:-0}" -eq 1 ]; then rm -rf "${OUT_ROOT}"; else rm -rf "${OUT}"; fi
+  [ "${MUTATION_STARTED}" -eq 1 ] || return 0
   echo "=== cleanup (run ${RUN_ID}) ==="
-  kubectl delete job "$LOW_JOB" "$HIGH_JOB" "$BLOCKER" -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
-  if [ "$CREATED_WPCS" -eq 1 ]; then
-    kubectl delete workloadpriorityclass -l "$OWNER_LABEL" --ignore-not-found >/dev/null 2>&1 || true
-  fi
-  if [ "$CREATED_QUEUES" -eq 1 ]; then
-    kubectl delete localqueue -n "$NS" -l "$OWNER_LABEL" --ignore-not-found >/dev/null 2>&1 || true
-    kubectl delete clusterqueue -l "$OWNER_LABEL" --ignore-not-found >/dev/null 2>&1 || true
-    kubectl delete resourceflavor -l "$OWNER_LABEL" --ignore-not-found >/dev/null 2>&1 || true
-    kubectl delete namespace -l "$OWNER_LABEL" --ignore-not-found >/dev/null 2>&1 || true
+  # Every delete's failure is kept. Swallowing them let a run print RESULT: PASS
+  # while leaving cluster-scoped WorkloadPriorityClasses behind, which is the
+  # "safe to run anywhere" claim failing silently.
+  _del() {
+    if ! kget delete "$@" --ignore-not-found >/dev/null 2>&1; then
+      CLEANUP_FAILED=1
+      echo "  cleanup could not delete: $*" >&2
+    fi
+  }
+  _del job "$LOW_JOB" "$HIGH_JOB" "$BLOCKER" -n "$NS"
+  _del workloadpriorityclass -l "$OWNER_LABEL"
+  _del localqueue -n "$NS" -l "$OWNER_LABEL"
+  _del clusterqueue -l "$OWNER_LABEL"
+  _del resourceflavor -l "$OWNER_LABEL"
+  _del namespace -l "$OWNER_LABEL"
+  # Say what is left rather than leaving the operator to discover it. The
+  # cluster-scoped kinds are the ones that outlive the namespace.
+  local leftover
+  leftover=$(kget get workloadpriorityclass,clusterqueue,resourceflavor -l "$OWNER_LABEL" \
+    -o name 2>/dev/null | tr '\n' ' ')
+  if [ -n "${leftover// /}" ]; then
+    CLEANUP_FAILED=1
+    echo "  STILL PRESENT after cleanup: ${leftover}" >&2
   fi
 }
 # EXIT covers the normal path. INT and TERM clean up and then stop: a handler that
 # returns lets the script carry on and create the resources it has just deleted.
-trap cleanup EXIT
-trap 'cleanup; trap - EXIT; exit 130' INT
-trap 'cleanup; trap - EXIT; exit 143' TERM
+# The verdict, called explicitly at the end so cleanup has already run and its
+# outcome can enter it. The EXIT trap cleans but never judges: a prerequisite
+# failure exits 2, and a trap that re-judged would turn that into 1.
+finish() {
+  if [ "$FAIL" -ne 0 ] && [ "$CLEANUP_FAILED" -ne 0 ]; then
+    echo "RESULT: FAIL (and cleanup left objects behind -- see above)"; exit 1
+  elif [ "$FAIL" -ne 0 ]; then
+    echo "RESULT: FAIL"; exit 1
+  elif [ "$CLEANUP_FAILED" -ne 0 ]; then
+    # The experiment's own verdict stands; the run is still not safe to call clean,
+    # because cluster-scoped objects outlive the namespace and this one leaked some.
+    echo "RESULT: PASS, CLEANUP FAILED -- objects from this run may remain"; exit 3
+  fi
+  echo "RESULT: PASS"; exit 0
+}
+
+_warn_leftovers() {
+  [ "${CLEANUP_FAILED}" -eq 0 ] || echo "cleanup left objects from run ${RUN_ID} behind" >&2
+}
+trap 'cleanup; _warn_leftovers' EXIT
+trap 'cleanup; trap - EXIT; _warn_leftovers; exit 130' INT
+trap 'cleanup; trap - EXIT; _warn_leftovers; exit 143' TERM
 
 # Fill the run's names into a template. One substitution table feeds setup, render,
 # lookup and teardown, so an override cannot leave the queue in one namespace and the
@@ -127,9 +199,30 @@ sys.stdout.write(text)
 PY
 }
 
-absent() { # $1 kind, $2 name, [$3 namespace] -> 0 when the object does not exist
-  if [ $# -ge 3 ]; then kubectl get "$1" "$2" -n "$3" >/dev/null 2>&1; else kubectl get "$1" "$2" >/dev/null 2>&1; fi
-  [ $? -ne 0 ]
+# Three outcomes, not two. An earlier version ran `kubectl get` and read any
+# non-zero exit as "the name is free", so Forbidden, an expired token, a TLS
+# failure, a discovery error and a timeout all licensed the run to start creating
+# objects on a cluster it had never successfully read. --ignore-not-found makes a
+# missing object a success with empty output, which separates "not there" from
+# "could not look".
+# Every call goes through a bounded request timeout. Not one of them had one, so a
+# wedged apiserver, a proxy that stops answering or an admission webhook that never
+# returns left the harness waiting with no upper bound -- and it holds cluster-scoped
+# objects while it waits. Wrapping the name rather than editing forty call sites is
+# what makes it exhaustive; `command` is what keeps it from recursing.
+K8S_TIMEOUT="${K8S_TIMEOUT:-30s}"
+KUBECTL_BIN="$(command -v kubectl 2>/dev/null || true)"
+kubectl() { command kubectl --request-timeout="${K8S_TIMEOUT}" "$@"; }
+kget() { kubectl "$@"; }
+
+existence() { # $1 kind, $2 name, [$3 namespace] -> absent | present | unreadable
+  local out
+  if [ $# -ge 3 ]; then
+    out=$(kubectl get "$1" "$2" -n "$3" --ignore-not-found -o name 2>/dev/null) || { echo unreadable; return; }
+  else
+    out=$(kubectl get "$1" "$2" --ignore-not-found -o name 2>/dev/null) || { echo unreadable; return; }
+  fi
+  [ -z "$out" ] && echo absent || echo present
 }
 
 wl_for_job() { # $1 job name -> workload name (via job-uid label)
@@ -280,18 +373,56 @@ kubectl get configmap -n kueue-system kueue-manager-config -o yaml > "${OUT}/kue
   || echo "  kueue config   : not readable"
 
 echo "=== 0. prerequisites ==="
-command -v kubectl >/dev/null 2>&1 && report PASS "kubectl available" || { report FAIL "kubectl missing"; exit 2; }
-kubectl get deployment -n kueue-system kueue-controller-manager >/dev/null 2>&1 \
-  && report PASS "Kueue controller present" || report FAIL "Kueue controller missing"
+# Prerequisites gate the rest. Reporting one as FAIL and carrying on into object
+# creation, which is what happened before, means a run with no Kueue on the cluster
+# still made a namespace, a queue and four cluster-scoped classes before failing on
+# something downstream.
+# The binary, resolved before the wrapper function shadowed the name -- `command -v
+# kubectl` would otherwise find the function and report a missing binary as present.
+[ -n "${KUBECTL_BIN}" ] && report PASS "kubectl available (${KUBECTL_BIN})" \
+  || { report FAIL "kubectl missing"; echo "RESULT: FAIL"; exit 2; }
+if kget get deployment -n kueue-system kueue-controller-manager >/dev/null 2>&1; then
+  report PASS "Kueue controller present"
+else
+  report FAIL "Kueue controller missing or unreadable -- nothing was created"
+  echo "RESULT: FAIL"; exit 2
+fi
+# The verbs this run needs, checked before it needs them. Namespace-level access
+# says nothing about the cluster-scoped objects, which are the ones a failed
+# teardown would leave behind.
+RBAC_MISSING=""
+for spec in "create:workloadpriorityclasses" "delete:workloadpriorityclasses" \
+            "create:clusterqueues" "delete:clusterqueues" \
+            "create:resourceflavors" "delete:resourceflavors" \
+            "create:namespaces" "delete:namespaces"; do
+  verb="${spec%%:*}"; res="${spec##*:}"
+  kget auth can-i "$verb" "$res" >/dev/null 2>&1 || RBAC_MISSING="${RBAC_MISSING} ${verb}/${res}"
+done
+if [ -z "$RBAC_MISSING" ]; then
+  report PASS "the cluster-scoped verbs this run needs are permitted"
+else
+  report FAIL "missing permission for:${RBAC_MISSING} -- nothing was created"
+  echo "RESULT: FAIL"; exit 2
+fi
 
 echo "=== 0b. nothing this run is about to create already exists ==="
-COLLIDE=""
-absent namespace "$NS" || COLLIDE="${COLLIDE} namespace/${NS}"
-absent clusterqueue "$CQ" || COLLIDE="${COLLIDE} clusterqueue/${CQ}"
-absent resourceflavor "$FLAVOR" || COLLIDE="${COLLIDE} resourceflavor/${FLAVOR}"
-for cls in ${ALL_CLASSES}; do
-  absent workloadpriorityclass "$cls" || COLLIDE="${COLLIDE} wpc/${cls}"
-done
+COLLIDE=""; UNREADABLE=""
+check_free() { # $@ -> args for existence()
+  case "$(existence "$@")" in
+    present)    COLLIDE="${COLLIDE} $1/$2" ;;
+    unreadable) UNREADABLE="${UNREADABLE} $1/$2" ;;
+  esac
+}
+check_free namespace "$NS"
+check_free clusterqueue "$CQ"
+check_free resourceflavor "$FLAVOR"
+for cls in ${ALL_CLASSES}; do check_free workloadpriorityclass "$cls"; done
+if [ -n "$UNREADABLE" ]; then
+  # Not "free". A lookup that failed says nothing about the name, and creating on
+  # top of that guess is how a run adopts and then deletes someone else's object.
+  report FAIL "could not determine whether these names are free:${UNREADABLE} -- nothing was created"
+  echo "RESULT: FAIL"; exit 2
+fi
 if [ -z "$COLLIDE" ]; then
   report PASS "no pre-existing object carries this run's names"
 else
@@ -300,8 +431,13 @@ else
 fi
 
 echo "=== 1. apply namespace + ClusterQueue (cpu=1) + LocalQueue ==="
-if render_template "${MANIFESTS}/00-namespace-and-queue.yaml" | kubectl apply -f - >/dev/null; then
-  CREATED_QUEUES=1; report PASS "queue applied"
+MUTATION_STARTED=1   # before the first create: a partial apply must still be torn down
+# create, not apply. The preflight above establishes that these names are free, but
+# it is a check-then-act: another run or another operator can create the same name in
+# the gap, and apply would quietly adopt it, relabel it as ours, and let teardown
+# delete it. create turns that race into AlreadyExists, which stops the run.
+if render_template "${MANIFESTS}/00-namespace-and-queue.yaml" | kubectl create -f - >/dev/null; then
+  report PASS "queue applied"
 else
   report FAIL "queue apply failed"
 fi
@@ -312,7 +448,10 @@ PYTHONPATH="${HERE}/src" "${PYTHON_BIN}" -m orbital_mission_compiler.cli render-
   --emit-priority-classes --priority-class --priority-class-prefix "$CLASS_PREFIX" \
   --policy-engine baseline >"${OUT}/render-wpc.log" 2>&1
 # The compiler does not know about this run, so the ownership label is added here.
-if "${PYTHON_BIN}" - "${OUT}/wpc/workload-priority-classes.yaml" "$RUN_ID" <<'PY' | kubectl apply -f - >/dev/null
+# create for the same reason as the queue above, and more so: these four are
+# cluster-scoped, so adopting one would relabel an object shared with everything
+# else on the cluster, and teardown would then delete it.
+if "${PYTHON_BIN}" - "${OUT}/wpc/workload-priority-classes.yaml" "$RUN_ID" <<'PY' | kubectl create -f - >/dev/null
 import sys, yaml
 path, run_id = sys.argv[1], sys.argv[2]
 docs = [d for d in yaml.safe_load_all(open(path, encoding="utf-8")) if d]
@@ -321,7 +460,7 @@ for d in docs:
 yaml.safe_dump_all(docs, sys.stdout)
 PY
 then
-  CREATED_WPCS=1; report PASS "WorkloadPriorityClasses applied"
+  report PASS "WorkloadPriorityClasses applied"
 else
   report FAIL "WPC apply failed"
 fi
@@ -607,4 +746,5 @@ fi
 
 echo "" ; echo "=== Summary ===" ; echo "PASS: ${PASS}  FAIL: ${FAIL}"
 # Teardown runs via the EXIT trap (also covers interrupts).
-[ "$FAIL" -eq 0 ] && { echo "RESULT: PASS"; exit 0; } || { echo "RESULT: FAIL"; exit 1; }
+cleanup
+finish

--- a/scripts/validate_kueue_priority.sh
+++ b/scripts/validate_kueue_priority.sh
@@ -390,13 +390,30 @@ fi
 # The verbs this run needs, checked before it needs them. Namespace-level access
 # says nothing about the cluster-scoped objects, which are the ones a failed
 # teardown would leave behind.
+# `kubectl auth can-i` answers on stdout -- "yes" or "no" -- and exits 1 only for
+# "no". Reading the exit code alone is not enough here, because a resource type the
+# server does not have still answers "yes" with exit 0: RBAC grants verbs on a
+# resource NAME, and a name nothing implements is grantable. That case is reported
+# on stderr instead. So the check is stdout "yes" AND nothing on stderr, which
+# separates permitted, denied, and misspelled. --all-namespaces is the documented
+# form for a cluster-scoped resource; without it kubectl warns about scope and the
+# warning would read as a missing type.
 RBAC_MISSING=""
+can_i() { # $1 verb, $2 resource -> 0 when permitted and the type is real
+  local out err
+  err=$(kget auth can-i "$1" "$2" --all-namespaces 2>&1 >/dev/null)
+  out=$(kget auth can-i "$1" "$2" --all-namespaces 2>/dev/null)
+  [ "$out" = "yes" ] && [ -z "$err" ]
+}
 for spec in "create:workloadpriorityclasses" "delete:workloadpriorityclasses" \
             "create:clusterqueues" "delete:clusterqueues" \
             "create:resourceflavors" "delete:resourceflavors" \
-            "create:namespaces" "delete:namespaces"; do
+            "create:namespaces" "delete:namespaces" \
+            "create:localqueues" "delete:localqueues" \
+            "create:jobs" "delete:jobs" \
+            "get:workloads" "get:workloadpriorityclasses" "get:clusterqueues"; do
   verb="${spec%%:*}"; res="${spec##*:}"
-  kget auth can-i "$verb" "$res" >/dev/null 2>&1 || RBAC_MISSING="${RBAC_MISSING} ${verb}/${res}"
+  can_i "$verb" "$res" || RBAC_MISSING="${RBAC_MISSING} ${verb}/${res}"
 done
 if [ -z "$RBAC_MISSING" ]; then
   report PASS "the cluster-scoped verbs this run needs are permitted"

--- a/scripts/validate_kueue_priority.sh
+++ b/scripts/validate_kueue_priority.sh
@@ -98,7 +98,12 @@ wl_for_job() { # $1 job name -> workload name (via job-uid label)
 }
 wl_admitted() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Admitted")].status}' 2>/dev/null; }
 wl_priority() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priority}' 2>/dev/null; }
-wl_class() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priorityClassName}' 2>/dev/null; }
+# v1beta2 carries the class as a reference, not a bare name: the group is what
+# separates a WorkloadPriorityClass from a Pod PriorityClass, and only the first
+# feeds queue sorting.
+wl_class() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priorityClassRef.name}' 2>/dev/null; }
+wl_class_group() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priorityClassRef.group}' 2>/dev/null; }
+wl_class_kind() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priorityClassRef.kind}' 2>/dev/null; }
 wl_created() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null; }
 wait_wl() { # $1 job name -> echo workload name once it exists (up to 30s)
   local w=""; local d=$((SECONDS+30))
@@ -202,6 +207,10 @@ HC=$(wl_class "$HIGH_WL"); LC=$(wl_class "$LOW_WL")
 [ "$HC" = "$HIGH_CLASS" ] && [ "$LC" = "$LOW_CLASS" ] \
   && report PASS "workloads reference the emitted classes" \
   || report FAIL "class references: HIGH=${HC:-<none>} LOW=${LC:-<none>}"
+HG=$(wl_class_group "$HIGH_WL"); HK=$(wl_class_kind "$HIGH_WL")
+[ "$HG" = "kueue.x-k8s.io" ] && [ "$HK" = "WorkloadPriorityClass" ] \
+  && report PASS "the reference is a WorkloadPriorityClass, not a Pod PriorityClass" \
+  || report FAIL "unexpected class reference: group=${HG:-<none>} kind=${HK:-<none>}"
 # Arrival order is the thing priority has to beat, so read it rather than assume the
 # sleep achieved it.
 HT=$(wl_created "$HIGH_WL"); LT=$(wl_created "$LOW_WL")

--- a/scripts/validate_kueue_priority.sh
+++ b/scripts/validate_kueue_priority.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# validate_kueue_priority.sh — prove that mission priority (via a Kueue
+# WorkloadPriorityClass) drives admission ORDER, isolated from creation order.
+#
+# Method (reverse submission order):
+#   1. A ClusterQueue with cpu nominalQuota=1 (one cpu=1 Job admissible at a time).
+#   2. A blocker Job holds that quota.
+#   3. Submit the LOW-priority Job FIRST, then the HIGH-priority Job.
+#   4. Both are PENDING (quota held). Delete the blocker.
+#   5. Kueue admits the higher-priority PENDING workload first. If HIGH is admitted
+#      before LOW despite being submitted later, priority (not arrival order) decided.
+#
+# The Jobs are rendered by the compiler (`render-kueue --priority-class`), so this
+# validates the compiler's own output, not a hand-written manifest.
+set -uo pipefail
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+NS="${NS:-mission-prio}"
+LQ="${LQ:-mission-prio-lq}"
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+MANIFESTS="${HERE}/manifests/k8s/kueue/priority-ordering"
+OUT="${OUT:-${HERE}/out/kueue-priority}"
+rm -rf "$OUT"; mkdir -p "$OUT"
+
+PASS=0; FAIL=0
+LOW_JOB=""; HIGH_JOB=""   # set mid-run; initialised so the cleanup trap is set -u safe
+report() { if [ "$1" = PASS ]; then echo "[PASS] $2"; PASS=$((PASS+1)); else echo "[FAIL] $2"; FAIL=$((FAIL+1)); fi; }
+
+# Unconditional teardown: runs on normal exit AND on interrupt (Ctrl-C / timeout),
+# so the experiment never leaves the namespace, queue, or cluster-scoped classes behind.
+cleanup() {
+  echo "=== cleanup ==="
+  kubectl delete job "$LOW_JOB" "$HIGH_JOB" prio-blocker -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
+  kubectl delete -f "${OUT}/wpc/workload-priority-classes.yaml" --ignore-not-found >/dev/null 2>&1 || true
+  kubectl delete -f "${MANIFESTS}/00-namespace-and-queue.yaml" --ignore-not-found >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+wl_for_job() { # $1 job name -> workload name (via job-uid label)
+  local uid; uid=$(kubectl get job "$1" -n "$NS" -o jsonpath='{.metadata.uid}' 2>/dev/null)
+  [ -z "$uid" ] && return
+  kubectl get workloads.kueue.x-k8s.io -n "$NS" -l "kueue.x-k8s.io/job-uid=${uid}" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+wl_admitted() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Admitted")].status}' 2>/dev/null; }
+wl_priority() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priority}' 2>/dev/null; }
+wait_wl() { # $1 job name -> echo workload name once it exists (up to 30s)
+  local w=""; local d=$((SECONDS+30))
+  while [ $SECONDS -lt $d ]; do w=$(wl_for_job "$1"); [ -n "$w" ] && break; sleep 2; done
+  echo "$w"
+}
+
+echo "=== 0. prerequisites ==="
+command -v kubectl >/dev/null 2>&1 && report PASS "kubectl available" || { report FAIL "kubectl missing"; exit 2; }
+kubectl get deployment -n kueue-system kueue-controller-manager >/dev/null 2>&1 \
+  && report PASS "Kueue controller present" || report FAIL "Kueue controller missing"
+
+echo "=== 1. apply namespace + ClusterQueue (cpu=1) + LocalQueue ==="
+kubectl apply -f "${MANIFESTS}/00-namespace-and-queue.yaml" >/dev/null && report PASS "queue applied" || report FAIL "queue apply failed"
+
+echo "=== 2. emit + apply the WorkloadPriorityClasses from the compiler ==="
+PYTHONPATH="${HERE}/src" ${PYTHON_BIN} -m orbital_mission_compiler.cli render-kueue \
+  --input "${MANIFESTS}/plan-high.yaml" --output-dir "${OUT}/wpc" --queue "$LQ" --namespace "$NS" \
+  --emit-priority-classes --priority-class --policy-engine baseline >/dev/null 2>&1
+kubectl apply -f "${OUT}/wpc/workload-priority-classes.yaml" >/dev/null \
+  && report PASS "WorkloadPriorityClasses applied" || report FAIL "WPC apply failed"
+kubectl get workloadpriorityclass mission-critical mission-normal >/dev/null 2>&1 \
+  && report PASS "mission-critical + mission-normal exist" || report FAIL "priority classes missing"
+
+echo "=== 3. render HIGH (priority 90) and LOW (priority 50) Jobs ==="
+for p in high low; do
+  PYTHONPATH="${HERE}/src" ${PYTHON_BIN} -m orbital_mission_compiler.cli render-kueue \
+    --input "${MANIFESTS}/plan-${p}.yaml" --output-dir "${OUT}/${p}" --queue "$LQ" --namespace "$NS" \
+    --priority-class --policy-engine baseline >/dev/null 2>&1
+done
+HIGH_JOB_FILE=$(find "${OUT}/high" -name '*-kueue.yaml' | head -1)
+LOW_JOB_FILE=$(find "${OUT}/low" -name '*-kueue.yaml' | head -1)
+
+echo "=== 4. blocker holds the cpu=1 quota ==="
+kubectl apply -f "${MANIFESTS}/01-blocker-job.yaml" >/dev/null
+BLOCK_WL=$(wait_wl prio-blocker)
+d=$((SECONDS+60)); ba=""
+while [ $SECONDS -lt $d ]; do ba=$(wl_admitted "$BLOCK_WL"); [ "$ba" = "True" ] && break; sleep 2; done
+[ "$ba" = "True" ] && report PASS "blocker admitted (holds quota)" || report FAIL "blocker not admitted"
+
+echo "=== 5. submit LOW first, then HIGH (reverse of priority) ==="
+LOW_JOB=$(kubectl create -f "$LOW_JOB_FILE" -o jsonpath='{.metadata.name}' 2>/dev/null)
+LOW_WL=$(wait_wl "$LOW_JOB")
+echo "  LOW  job=$LOW_JOB workload=$LOW_WL priority=$(wl_priority "$LOW_WL")"
+sleep 6   # ensure LOW creationTimestamp strictly precedes HIGH
+HIGH_JOB=$(kubectl create -f "$HIGH_JOB_FILE" -o jsonpath='{.metadata.name}' 2>/dev/null)
+HIGH_WL=$(wait_wl "$HIGH_JOB")
+echo "  HIGH job=$HIGH_JOB workload=$HIGH_WL priority=$(wl_priority "$HIGH_WL")"
+
+echo "=== 6. both PENDING while blocker holds quota ==="
+sleep 5
+la=$(wl_admitted "$LOW_WL"); ha=$(wl_admitted "$HIGH_WL")
+# Require both Workloads to actually EXIST and be un-admitted -- a missing Workload
+# (empty name) must NOT be mistaken for "pending".
+if [ -n "$LOW_WL" ] && [ -n "$HIGH_WL" ] && [ "$la" != "True" ] && [ "$ha" != "True" ]; then
+  report PASS "LOW and HIGH both pending under full quota"
+else
+  report FAIL "expected both workloads present and pending, got LOW=($LOW_WL)=$la HIGH=($HIGH_WL)=$ha"
+fi
+
+echo "=== 7. free quota (delete blocker); the higher-priority pending workload wins ==="
+kubectl delete -f "${MANIFESTS}/01-blocker-job.yaml" --ignore-not-found >/dev/null 2>&1
+FIRST=""; d=$((SECONDS+60))
+while [ $SECONDS -lt $d ]; do
+  ha=$(wl_admitted "$HIGH_WL"); la=$(wl_admitted "$LOW_WL")
+  if [ "$ha" = "True" ]; then FIRST="HIGH"; HIGH_LOW_AT_ADMIT="$la"; break; fi
+  if [ "$la" = "True" ]; then FIRST="LOW"; break; fi
+  sleep 2
+done
+echo "  first admitted after quota freed: ${FIRST:-<none>} (LOW status at that moment: ${HIGH_LOW_AT_ADMIT:-n/a})"
+if [ "$FIRST" = "HIGH" ]; then
+  report PASS "HIGH (mission-critical, submitted LAST) admitted before LOW -> priority drove ordering"
+else
+  report FAIL "expected HIGH first, got ${FIRST:-none} -> could not distinguish priority from creation order"
+fi
+
+echo "" ; echo "=== Summary ===" ; echo "PASS: ${PASS}  FAIL: ${FAIL}"
+# Teardown runs via the EXIT trap (also covers interrupts).
+[ "$FAIL" -eq 0 ] && { echo "RESULT: PASS"; exit 0; } || { echo "RESULT: FAIL"; exit 1; }

--- a/scripts/validate_kueue_priority.sh
+++ b/scripts/validate_kueue_priority.sh
@@ -142,7 +142,13 @@ wait_wl() { # $1 job name -> echo workload name once it exists (up to 30s)
 
 echo "=== run ${RUN_ID} ==="
 echo "  namespace=${NS} clusterQueue=${CQ} classes=${HIGH_CLASS},${LOW_CLASS}"
-echo "  compiler commit: $(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || echo unknown)$( [ -n "$(git -C "$HERE" status --porcelain 2>/dev/null)" ] && echo ' (dirty tree)' )"
+# The full object name, and whether the tree it came from was clean. A short hash
+# names a commit only until the repository grows, and a capture taken from a dirty
+# tree cannot be rebuilt from any commit at all -- which matters here, because the
+# captured run is what this experiment produces.
+echo "  compiler commit: $(git -C "$HERE" rev-parse HEAD 2>/dev/null || echo unknown)"
+echo "  working tree   : $( [ -n "$(git -C "$HERE" status --porcelain 2>/dev/null)" ] && echo 'DIRTY -- this capture cannot be rebuilt from a commit' || echo 'clean' )"
+echo "  harness sha256 : $(sha256sum "$0" 2>/dev/null | cut -d' ' -f1 || echo unknown)"
 
 echo "=== 0. prerequisites ==="
 command -v kubectl >/dev/null 2>&1 && report PASS "kubectl available" || { report FAIL "kubectl missing"; exit 2; }

--- a/scripts/validate_kueue_priority.sh
+++ b/scripts/validate_kueue_priority.sh
@@ -102,11 +102,26 @@ else
 fi
 OUT="${OUT_ROOT}/run-${RUN_ID}"
 SENTINEL="${OUT}/.kueue-priority-run"
-if [ -e "$OUT" ] && [ ! -e "$SENTINEL" ]; then
-  printf '%s exists and was not created by this script; refusing to delete it\n' "$OUT" >&2
-  printf 'RESULT: FAIL\n'; exit 2
+# The sentinel names the run that owns the directory, and must be a regular file.
+# `[ -e ]` alone said only "something this script might have made is here", so a
+# second run sharing OUT and RUN_ID -- which line 31 documents as a way to
+# reproduce a name -- deleted the first run's live output from under it. A
+# directory or symlink called .kueue-priority-run satisfied it too, which let a
+# planted path licence the deletion of whatever sat beside it.
+if [ -e "$OUT" ]; then
+  if [ ! -f "$SENTINEL" ] || [ "$(cat "$SENTINEL" 2>/dev/null)" != "owned-by-${RUN_ID}" ]; then
+    printf '%s exists and is not this run\x27s to delete; refusing\n' "$OUT" >&2
+    printf 'RESULT: FAIL\n'; exit 2
+  fi
+  printf 'a previous run with id %s left %s behind; reusing it\n' "${RUN_ID}" "$OUT" >&2
 fi
-rm -rf "$OUT"; mkdir -p "$OUT"; : > "$SENTINEL"
+rm -rf "$OUT" || { printf 'could not clear %s\n' "$OUT" >&2; printf 'RESULT: FAIL\n'; exit 2; }
+# F7: unchecked, these two failures surfaced much later as a compiler that
+# "exposes no mapping version" -- a filesystem error reported as a code fault.
+mkdir -p "$OUT" || { printf 'could not create %s\n' "$OUT" >&2; printf 'RESULT: FAIL\n'; exit 2; }
+printf 'owned-by-%s\n' "${RUN_ID}" > "$SENTINEL" || {
+  printf 'could not write the ownership marker in %s\n' "$OUT" >&2
+  printf 'RESULT: FAIL\n'; exit 2; }
 
 PASS=0; FAIL=0
 LOW_JOB=""; HIGH_JOB=""   # set mid-run; initialised so the cleanup trap is set -u safe
@@ -133,13 +148,23 @@ cleanup() {
   # Every delete's failure is kept. Swallowing them let a run print RESULT: PASS
   # while leaving cluster-scoped WorkloadPriorityClasses behind, which is the
   # "safe to run anywhere" claim failing silently.
+  # --wait=false: the default waits for finalizers, and every call now carries a
+  # 30s request timeout. A terminating namespace routinely takes longer than that,
+  # which would end an otherwise clean run at exit 3 for a delete that was working.
   _del() {
-    if ! kget delete "$@" --ignore-not-found >/dev/null 2>&1; then
+    if ! kget delete "$@" --ignore-not-found --wait=false >/dev/null 2>&1; then
       CLEANUP_FAILED=1
       echo "  cleanup could not delete: $*" >&2
     fi
   }
-  _del job "$LOW_JOB" "$HIGH_JOB" "$BLOCKER" -n "$NS"
+  # One name at a time, and empty ones skipped. `kubectl delete job "" a b` is not
+  # a NotFound and --ignore-not-found does not cover it: kubectl aborts the whole
+  # request list at the empty name, so `a` and `b` were never deleted -- and the
+  # run reported a cleanup failure for objects that mostly did not exist while
+  # genuinely leaving behind the ones that did.
+  for _job in "$LOW_JOB" "$HIGH_JOB" "$BLOCKER"; do
+    [ -n "$_job" ] && _del job "$_job" -n "$NS"
+  done
   _del workloadpriorityclass -l "$OWNER_LABEL"
   _del localqueue -n "$NS" -l "$OWNER_LABEL"
   _del clusterqueue -l "$OWNER_LABEL"
@@ -147,12 +172,17 @@ cleanup() {
   _del namespace -l "$OWNER_LABEL"
   # Say what is left rather than leaving the operator to discover it. The
   # cluster-scoped kinds are the ones that outlive the namespace.
+  # The one check that verifies the leak this design exists to prevent, so a read
+  # that failed must not read as "nothing left". Empty output from a failed lookup
+  # is the same conflation `existence()` was rewritten to remove.
   local leftover
-  leftover=$(kget get workloadpriorityclass,clusterqueue,resourceflavor -l "$OWNER_LABEL" \
-    -o name 2>/dev/null | tr '\n' ' ')
-  if [ -n "${leftover// /}" ]; then
+  if ! leftover=$(kget get workloadpriorityclass,clusterqueue,resourceflavor \
+      -l "$OWNER_LABEL" -o name 2>/dev/null); then
     CLEANUP_FAILED=1
-    echo "  STILL PRESENT after cleanup: ${leftover}" >&2
+    echo "  could not verify whether anything from run ${RUN_ID} is left behind" >&2
+  elif [ -n "$(printf '%s' "$leftover" | tr -d '[:space:]')" ]; then
+    CLEANUP_FAILED=1
+    echo "  STILL PRESENT after cleanup: $(printf '%s' "$leftover" | tr '\n' ' ')" >&2
   fi
 }
 # EXIT covers the normal path. INT and TERM clean up and then stop: a handler that
@@ -293,6 +323,24 @@ class_value() { kubectl get workloadpriorityclass "$1" -o jsonpath='{.value}' 2>
 # The blocker name is a parameter so cycles cannot collide with each other or with the
 # detailed pass; everything it creates is deleted before it returns, and the namespace
 # teardown is the backstop.
+# kubectl aborts a whole request list at an empty name -- "resource name may not
+# be empty", which is not a NotFound, so --ignore-not-found does not cover it and
+# every name AFTER the empty one is never acted on. Any name here can be empty:
+# `kubectl create` failures leave `lj`/`hj` unset. Both the deletes and the drain
+# read go through this.
+jobs_present() { # $@ job names, possibly empty -> the ones that exist, on stdout
+  local named=() n
+  for n in "$@"; do [ -n "$n" ] && named+=("$n"); done
+  [ ${#named[@]} -eq 0 ] && return 0
+  kubectl get jobs "${named[@]}" -n "$NS" --ignore-not-found -o name 2>/dev/null
+}
+del_jobs() { # $@ job names, possibly empty
+  local n
+  for n in "$@"; do
+    [ -n "$n" ] && kubectl delete job "$n" -n "$NS" --ignore-not-found --wait=false >/dev/null 2>&1
+  done
+}
+
 race_once() { # $1 blocker name, $2 low job file, $3 high job file -> HIGH|LOW|BOTH|NONE
   local blocker="$1" lowf="$2" highf="$3"
   local lj hj lw hw first="" d ba
@@ -301,7 +349,7 @@ race_once() { # $1 blocker name, $2 low job file, $3 high job file -> HIGH|LOW|B
   d=$((SECONDS+60)); ba=""
   while [ $SECONDS -lt $d ]; do ba=$(wl_admitted "$(wl_for_job "$blocker")"); [ "$ba" = "True" ] && break; sleep 2; done
   if [ "$ba" != "True" ]; then
-    kubectl delete job "$blocker" -n "$NS" --ignore-not-found >/dev/null 2>&1
+    del_jobs "$blocker"
     echo "NOBLOCK"; return
   fi
   lj=$(kubectl create -f "$lowf" -o jsonpath='{.metadata.name}' 2>/dev/null)
@@ -310,10 +358,10 @@ race_once() { # $1 blocker name, $2 low job file, $3 high job file -> HIGH|LOW|B
   hj=$(kubectl create -f "$highf" -o jsonpath='{.metadata.name}' 2>/dev/null)
   hw=$(wait_wl "$hj")
   if [ -z "$lw" ] || [ -z "$hw" ]; then
-    kubectl delete job "$blocker" "$lj" "$hj" -n "$NS" --ignore-not-found >/dev/null 2>&1
+    del_jobs "$blocker" "$lj" "$hj"
     echo "NOWL"; return
   fi
-  kubectl delete job "$blocker" -n "$NS" --ignore-not-found >/dev/null 2>&1
+  del_jobs "$blocker"
   d=$((SECONDS+60))
   while [ $SECONDS -lt $d ]; do
     local h l; h=$(wl_admitted "$hw"); l=$(wl_admitted "$lw")
@@ -322,12 +370,17 @@ race_once() { # $1 blocker name, $2 low job file, $3 high job file -> HIGH|LOW|B
     if [ "$l" = "True" ]; then first="LOW"; break; fi
     sleep 2
   done
-  kubectl delete job "$lj" "$hj" -n "$NS" --ignore-not-found >/dev/null 2>&1
-  # Wait for the quota to come back before the next cycle starts, or its blocker
-  # cannot be admitted and the cycle reports NOBLOCK for a reason unrelated to it.
+  del_jobs "$lj" "$hj"
+  # Wait for THIS cycle's Jobs to go, so the next cycle's blocker can be admitted.
+  # The earlier version waited for the namespace to hold no Jobs at all, which can
+  # never happen: the detailed pass's own LOW and HIGH Jobs live until teardown, so
+  # every repeat burned its full 90 seconds and established nothing. A read that
+  # failed is not "drained" either -- it is a read that did not answer.
   d=$((SECONDS+90))
   while [ $SECONDS -lt $d ]; do
-    [ -z "$(kubectl get jobs -n "$NS" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)" ] && break
+    local remaining
+    remaining=$(jobs_present "$blocker" "$lj" "$hj") || { sleep 3; continue; }
+    [ -z "$remaining" ] && break
     sleep 3
   done
   echo "${first:-NONE}"
@@ -367,7 +420,16 @@ echo "  kueue image    : $(kubectl get deployment -n kueue-system kueue-controll
 echo "  kueue imageID  : $(kubectl get pods -n kueue-system -l control-plane=controller-manager -o jsonpath='{.items[0].status.containerStatuses[?(@.name=="manager")].imageID}' 2>/dev/null || echo unknown)"
 # The sort this experiment measures is affected by Kueue's own configuration, so the
 # gates and the config are captured rather than assumed to be defaults.
-echo "  kueue gates    : $(kubectl get deployment -n kueue-system kueue-controller-manager -o jsonpath='{range .spec.template.spec.containers[?(@.name=="manager")].args[*]}{@}{"\n"}{end}' 2>/dev/null | grep -- '--feature-gates' || echo '(none set; built-in defaults apply)')"
+# The deployment's args only. Gates can also travel inside the file named by
+# --config, which this does not read, so the line says what it looked at rather
+# than concluding "defaults apply". And a failed read is reported as a failed
+# read: `grep` exits 1 both when the flag is absent and when kubectl printed
+# nothing, so the earlier version transcribed an unreadable cluster as a positive
+# claim about its configuration.
+KUEUE_ARGS=$(kubectl get deployment -n kueue-system kueue-controller-manager \
+  -o jsonpath='{range .spec.template.spec.containers[?(@.name=="manager")].args[*]}{@}{"\n"}{end}' 2>/dev/null) \
+  && echo "  kueue gates    : $(printf '%s' "$KUEUE_ARGS" | grep -- '--feature-gates' || echo '(no --feature-gates arg; see the config file captured below)')" \
+  || echo "  kueue gates    : could not read the deployment"
 kubectl get configmap -n kueue-system kueue-manager-config -o yaml > "${OUT}/kueue-manager-config.yaml" 2>/dev/null \
   && echo "  kueue config   : captured to $(basename "${OUT}")/kueue-manager-config.yaml" \
   || echo "  kueue config   : not readable"
@@ -398,12 +460,27 @@ fi
 # separates permitted, denied, and misspelled. --all-namespaces is the documented
 # form for a cluster-scoped resource; without it kubectl warns about scope and the
 # warning would read as a missing type.
-RBAC_MISSING=""
-can_i() { # $1 verb, $2 resource -> 0 when permitted and the type is real
-  local out err
-  err=$(kget auth can-i "$1" "$2" --all-namespaces 2>&1 >/dev/null)
-  out=$(kget auth can-i "$1" "$2" --all-namespaces 2>/dev/null)
-  [ "$out" = "yes" ] && [ -z "$err" ]
+RBAC_MISSING=""; RBAC_UNKNOWN=""
+# Two questions, asked separately, because kubectl answers them together and
+# ambiguously. "Does this resource type exist" comes from discovery, once. "Is the
+# verb permitted" comes from `auth can-i -q`, whose exit code is the answer and
+# which prints nothing.
+#
+# Reading stderr, as an earlier version did, could not tell an unknown type from a
+# deprecation warning from a partial-discovery hiccup -- so a cluster that emits
+# any warning at all failed every check and aborted the run.
+KNOWN_RESOURCES=$(kubectl api-resources --no-headers -o name 2>/dev/null | sed 's/\..*//' | sort -u)
+if [ -z "$KNOWN_RESOURCES" ]; then
+  report FAIL "could not list the cluster's resource types -- nothing was created"
+  echo "RESULT: FAIL"; exit 2
+fi
+can_i() { # $1 verb, $2 resource -> permitted | denied | unknown-type
+  printf '%s\n' "$KNOWN_RESOURCES" | grep -qx -- "$2" || { echo unknown-type; return; }
+  if kubectl auth can-i "$1" "$2" --all-namespaces -q >/dev/null 2>&1; then
+    echo permitted
+  else
+    echo denied
+  fi
 }
 for spec in "create:workloadpriorityclasses" "delete:workloadpriorityclasses" \
             "create:clusterqueues" "delete:clusterqueues" \
@@ -413,8 +490,20 @@ for spec in "create:workloadpriorityclasses" "delete:workloadpriorityclasses" \
             "create:jobs" "delete:jobs" \
             "get:workloads" "get:workloadpriorityclasses" "get:clusterqueues"; do
   verb="${spec%%:*}"; res="${spec##*:}"
-  can_i "$verb" "$res" || RBAC_MISSING="${RBAC_MISSING} ${verb}/${res}"
+  case "$(can_i "$verb" "$res")" in
+    permitted)    ;;
+    denied)       RBAC_MISSING="${RBAC_MISSING} ${verb}/${res}" ;;
+    unknown-type) RBAC_UNKNOWN="${RBAC_UNKNOWN} ${res}" ;;
+  esac
 done
+if [ -n "$RBAC_UNKNOWN" ]; then
+  # Not a denial. An unresolvable resource type, a discovery hiccup or an
+  # unreachable apiserver produce the same shape, and naming RBAC for any of them
+  # sends the reader to the wrong place -- while proceeding would start creating
+  # objects on a cluster this run could not question.
+  report FAIL "the cluster has no such resource type(s):${RBAC_UNKNOWN} -- nothing was created"
+  echo "RESULT: FAIL"; exit 2
+fi
 if [ -z "$RBAC_MISSING" ]; then
   report PASS "the cluster-scoped verbs this run needs are permitted"
 else
@@ -456,7 +545,8 @@ MUTATION_STARTED=1   # before the first create: a partial apply must still be to
 if render_template "${MANIFESTS}/00-namespace-and-queue.yaml" | kubectl create -f - >/dev/null; then
   report PASS "queue applied"
 else
-  report FAIL "queue apply failed"
+  report FAIL "queue apply failed -- nothing further attempted"
+  cleanup; finish
 fi
 
 echo "=== 2. emit + apply the WorkloadPriorityClasses from the compiler ==="
@@ -479,7 +569,8 @@ PY
 then
   report PASS "WorkloadPriorityClasses applied"
 else
-  report FAIL "WPC apply failed"
+  report FAIL "WPC apply failed -- nothing further attempted"
+  cleanup; finish
 fi
 kubectl get workloadpriorityclass "$HIGH_CLASS" "$LOW_CLASS" >/dev/null 2>&1 \
   && report PASS "${HIGH_CLASS} + ${LOW_CLASS} exist" || report FAIL "priority classes missing"
@@ -564,7 +655,8 @@ CTL_LOW_FILE=$(find "${OUT}/ctl-low" -name '*-kueue.yaml' | head -1)
 if [ -z "$RENDER_BAD" ]; then
   report PASS "both arms rendered by the compiler (priority-class and control)"
 else
-  report FAIL "render failed:${RENDER_BAD} (logs in ${OUT})"
+  report FAIL "render failed:${RENDER_BAD} (logs in ${OUT}) -- nothing further attempted"
+  cleanup; finish
 fi
 
 # The control arm is only a control if its Jobs really carry no class. Checked here
@@ -725,7 +817,13 @@ kubectl get clusterqueue "$CQ" -o yaml > "${OUT}/clusterqueue.yaml" 2>/dev/null 
 
 echo "=== 8. the same race, repeated ==="
 # The detailed pass above is race 1 of this arm; the remainder run here.
-TREAT_WINS=0; TREAT_LOG="HIGH"
+# Race 1 is the detailed pass above, and its outcome is $FIRST. An earlier version
+# seeded the log with the literal "HIGH" and counted the win unconditionally, so a
+# run whose first race went the other way printed "[FAIL] LOW admitted first" and
+# then, three lines later, "priority arm outcomes: HIGH" and a PASS for 1/1. The
+# transcript reported a result nobody observed.
+TREAT_WINS=0; TREAT_LOG="${FIRST:-NONE}"
+[ "${FIRST:-}" = "HIGH" ] && TREAT_WINS=1
 i=1
 while [ "$i" -lt "$REPS" ]; do
   i=$((i+1))
@@ -734,7 +832,6 @@ while [ "$i" -lt "$REPS" ]; do
   [ "$w" = "HIGH" ] && TREAT_WINS=$((TREAT_WINS+1))
   echo "  priority arm race ${i}/${REPS}: ${w}"
 done
-TREAT_WINS=$((TREAT_WINS+1))   # race 1 was the detailed pass, which asserted HIGH
 echo "  priority arm outcomes: ${TREAT_LOG}"
 if [ "$TREAT_WINS" -eq "$REPS" ]; then
   report PASS "HIGH admitted first in ${TREAT_WINS}/${REPS} races despite being submitted last"

--- a/scripts/validate_kueue_priority.sh
+++ b/scripts/validate_kueue_priority.sh
@@ -127,9 +127,12 @@ wl_for_job() { # $1 job name -> workload name (via job-uid label)
 }
 wl_admitted() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Admitted")].status}' 2>/dev/null; }
 wl_priority() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priority}' 2>/dev/null; }
-# v1beta2 carries the class as a reference, not a bare name: the group is what
-# separates a WorkloadPriorityClass from a Pod PriorityClass, and only the first
-# feeds queue sorting.
+# v1beta2 records the resolved class as a reference rather than a bare name, and the
+# group is what says the value came from the WorkloadPriorityClass this proof emitted.
+# It matters because the fallback is silent: with no such class Kueue takes the pod
+# template's own PriorityClass instead, writes that into the same spec.priority, and
+# sorts the queue by it just as well -- so the run would still admit HIGH first while
+# proving nothing about the compiler's mapping.
 wl_class() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priorityClassRef.name}' 2>/dev/null; }
 wl_class_group() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priorityClassRef.group}' 2>/dev/null; }
 wl_class_kind() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priorityClassRef.kind}' 2>/dev/null; }

--- a/scripts/validate_kueue_priority.sh
+++ b/scripts/validate_kueue_priority.sh
@@ -134,6 +134,10 @@ wl_class() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priorityClas
 wl_class_group() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priorityClassRef.group}' 2>/dev/null; }
 wl_class_kind() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priorityClassRef.kind}' 2>/dev/null; }
 wl_created() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null; }
+# The label the compiler puts on a Job it renders with --priority-class, naming the
+# mapping that chose the class. Read off the Job rather than the Workload: Kueue copies
+# the priority and the class reference onto the Workload, not the Job's own labels.
+job_mapping() { kubectl get job "$1" -n "$NS" -o "jsonpath={.metadata.labels['orbital/priority-mapping-version']}" 2>/dev/null; }
 wait_wl() { # $1 job name -> echo workload name once it exists (up to 30s)
   local w=""; local d=$((SECONDS+30))
   while [ $SECONDS -lt $d ]; do w=$(wl_for_job "$1"); [ -n "$w" ] && break; sleep 2; done
@@ -243,6 +247,21 @@ HC=$(wl_class "$HIGH_WL"); LC=$(wl_class "$LOW_WL")
 [ "$HC" = "$HIGH_CLASS" ] && [ "$LC" = "$LOW_CLASS" ] \
   && report PASS "workloads reference the emitted classes" \
   || report FAIL "class references: HIGH=${HC:-<none>} LOW=${LC:-<none>}"
+# Which mapping produced those class names, read back off the live Jobs. The compiler
+# supplies the value it stamps, so a later bump to v3 does not make this fail; what it
+# catches is a Job reaching the cluster without the label, or the two disagreeing --
+# either of which would leave `kubectl get jobs -l orbital/priority-mapping-version=...`
+# unable to find what a rename left behind.
+MAPPING_VERSION=$(PYTHONPATH="${HERE}/src" ${PYTHON_BIN} -c \
+  'from orbital_mission_compiler.compiler import PRIORITY_CLASS_MAPPING_VERSION as v; print(v)' 2>/dev/null)
+HM=$(job_mapping "$HIGH_JOB"); LM=$(job_mapping "$LOW_JOB")
+if [ -z "$MAPPING_VERSION" ]; then
+  report FAIL "the compiler exposes no mapping version to compare against"
+elif [ "$HM" = "$MAPPING_VERSION" ] && [ "$LM" = "$MAPPING_VERSION" ]; then
+  report PASS "both Jobs carry the mapping that named their class (${MAPPING_VERSION})"
+else
+  report FAIL "mapping version on the Jobs: HIGH=${HM:-<none>} LOW=${LM:-<none>}, compiler says ${MAPPING_VERSION}"
+fi
 HG=$(wl_class_group "$HIGH_WL"); HK=$(wl_class_kind "$HIGH_WL")
 [ "$HG" = "kueue.x-k8s.io" ] && [ "$HK" = "WorkloadPriorityClass" ] \
   && report PASS "the reference is a WorkloadPriorityClass, not a Pod PriorityClass" \

--- a/scripts/validate_kueue_priority.sh
+++ b/scripts/validate_kueue_priority.sh
@@ -109,12 +109,19 @@ SENTINEL="${OUT}/.kueue-priority-run"
 # directory or symlink called .kueue-priority-run satisfied it too, which let a
 # planted path licence the deletion of whatever sat beside it.
 if [ -e "$OUT" ]; then
-  if [ ! -f "$SENTINEL" ] || [ "$(cat "$SENTINEL" 2>/dev/null)" != "owned-by-${RUN_ID}" ]; then
-    printf '%s exists and is not this run\x27s to delete; refusing\n' "$OUT" >&2
-    printf 'RESULT: FAIL\n'; exit 2
-  fi
-  printf 'a previous run with id %s left %s behind; reusing it\n' "${RUN_ID}" "$OUT" >&2
+  # Refuse, always. An earlier version accepted the directory when the marker
+  # named this RUN_ID -- but two runs sharing a RUN_ID is precisely the collision
+  # the marker exists to catch, so the check passed exactly when it mattered and
+  # the second run deleted the first's live output while printing "reusing it".
+  # There is no safe way to tell "my own leftovers" from "another run of me still
+  # working", so neither is deleted.
+  printf '%s already exists; refusing to delete it. Choose a different RUN_ID or\n' "$OUT" >&2
+  printf 'remove it yourself once you are sure no run is using it.\n' >&2
+  printf 'RESULT: FAIL\n'; exit 2
 fi
+# -L before -e above would not have been enough either: a symlink AT $OUT is
+# followed by mkdir -p and by every redirection into it, so the run would write
+# through it. Refusing any pre-existing path covers that too.
 rm -rf "$OUT" || { printf 'could not clear %s\n' "$OUT" >&2; printf 'RESULT: FAIL\n'; exit 2; }
 # F7: unchecked, these two failures surfaced much later as a compiler that
 # "exposes no mapping version" -- a filesystem error reported as a code fault.
@@ -207,6 +214,7 @@ _warn_leftovers() {
   [ "${CLEANUP_FAILED}" -eq 0 ] || echo "cleanup left objects from run ${RUN_ID} behind" >&2
 }
 trap 'cleanup; _warn_leftovers' EXIT
+trap 'cleanup; trap - EXIT; _warn_leftovers; exit 129' HUP
 trap 'cleanup; trap - EXIT; _warn_leftovers; exit 130' INT
 trap 'cleanup; trap - EXIT; _warn_leftovers; exit 143' TERM
 
@@ -334,11 +342,33 @@ jobs_present() { # $@ job names, possibly empty -> the ones that exist, on stdou
   [ ${#named[@]} -eq 0 ] && return 0
   kubectl get jobs "${named[@]}" -n "$NS" --ignore-not-found -o name 2>/dev/null
 }
-del_jobs() { # $@ job names, possibly empty
+del_jobs() { # $@ job names, possibly empty. Waits, by default.
+  # Synchronous on purpose. The observation window opens as soon as the blocker's
+  # delete returns, so returning early starts the measurement while the blocker may
+  # still hold the quota -- and that made races 2..N a different procedure from
+  # race 1, tallied together. Callers that genuinely do not need to wait pass
+  # NOWAIT=1.
   local n
   for n in "$@"; do
-    [ -n "$n" ] && kubectl delete job "$n" -n "$NS" --ignore-not-found --wait=false >/dev/null 2>&1
+    [ -n "$n" ] || continue
+    if [ "${NOWAIT:-0}" = "1" ]; then
+      kubectl delete job "$n" -n "$NS" --ignore-not-found --wait=false >/dev/null 2>&1
+    else
+      kubectl delete job "$n" -n "$NS" --ignore-not-found >/dev/null 2>&1
+    fi
   done
+  return 0
+}
+
+_drain() { # $@ job names -> 0 when they are gone, 1 when the wait ran out
+  local d remaining
+  d=$((SECONDS+90))
+  while [ $SECONDS -lt $d ]; do
+    remaining=$(jobs_present "$@") || { sleep 3; continue; }
+    [ -z "$remaining" ] && return 0
+    sleep 3
+  done
+  return 1
 }
 
 race_once() { # $1 blocker name, $2 low job file, $3 high job file -> HIGH|LOW|BOTH|NONE
@@ -350,6 +380,7 @@ race_once() { # $1 blocker name, $2 low job file, $3 high job file -> HIGH|LOW|B
   while [ $SECONDS -lt $d ]; do ba=$(wl_admitted "$(wl_for_job "$blocker")"); [ "$ba" = "True" ] && break; sleep 2; done
   if [ "$ba" != "True" ]; then
     del_jobs "$blocker"
+    _drain "$blocker"
     echo "NOBLOCK"; return
   fi
   lj=$(kubectl create -f "$lowf" -o jsonpath='{.metadata.name}' 2>/dev/null)
@@ -359,6 +390,7 @@ race_once() { # $1 blocker name, $2 low job file, $3 high job file -> HIGH|LOW|B
   hw=$(wait_wl "$hj")
   if [ -z "$lw" ] || [ -z "$hw" ]; then
     del_jobs "$blocker" "$lj" "$hj"
+    _drain "$blocker" "$lj" "$hj"
     echo "NOWL"; return
   fi
   del_jobs "$blocker"
@@ -371,18 +403,14 @@ race_once() { # $1 blocker name, $2 low job file, $3 high job file -> HIGH|LOW|B
     sleep 2
   done
   del_jobs "$lj" "$hj"
-  # Wait for THIS cycle's Jobs to go, so the next cycle's blocker can be admitted.
-  # The earlier version waited for the namespace to hold no Jobs at all, which can
-  # never happen: the detailed pass's own LOW and HIGH Jobs live until teardown, so
-  # every repeat burned its full 90 seconds and established nothing. A read that
-  # failed is not "drained" either -- it is a read that did not answer.
-  d=$((SECONDS+90))
-  while [ $SECONDS -lt $d ]; do
-    local remaining
-    remaining=$(jobs_present "$blocker" "$lj" "$hj") || { sleep 3; continue; }
-    [ -z "$remaining" ] && break
-    sleep 3
-  done
+  # Wait for THIS cycle's Jobs, so the next cycle's blocker can be admitted. An
+  # earlier version waited for the namespace to hold no Jobs at all, which can
+  # never happen: the detailed pass's own Jobs live until teardown. A drain that
+  # runs out is reported rather than passed over, because the next race would then
+  # fail for a reason that has nothing to do with priority.
+  if ! _drain "$blocker" "$lj" "$hj"; then
+    echo "NODRAIN"; return
+  fi
   echo "${first:-NONE}"
 }
 
@@ -426,13 +454,27 @@ echo "  kueue imageID  : $(kubectl get pods -n kueue-system -l control-plane=con
 # read: `grep` exits 1 both when the flag is absent and when kubectl printed
 # nothing, so the earlier version transcribed an unreadable cluster as a positive
 # claim about its configuration.
-KUEUE_ARGS=$(kubectl get deployment -n kueue-system kueue-controller-manager \
-  -o jsonpath='{range .spec.template.spec.containers[?(@.name=="manager")].args[*]}{@}{"\n"}{end}' 2>/dev/null) \
-  && echo "  kueue gates    : $(printf '%s' "$KUEUE_ARGS" | grep -- '--feature-gates' || echo '(no --feature-gates arg; see the config file captured below)')" \
-  || echo "  kueue gates    : could not read the deployment"
-kubectl get configmap -n kueue-system kueue-manager-config -o yaml > "${OUT}/kueue-manager-config.yaml" 2>/dev/null \
-  && echo "  kueue config   : captured to $(basename "${OUT}")/kueue-manager-config.yaml" \
-  || echo "  kueue config   : not readable"
+if ! KUEUE_ARGS=$(kubectl get deployment -n kueue-system kueue-controller-manager \
+    -o jsonpath='{range .spec.template.spec.containers[?(@.name=="manager")].args[*]}{@}{"\n"}{end}' 2>/dev/null); then
+  echo "  kueue gates    : could not read the deployment"
+elif [ -z "${KUEUE_ARGS//[[:space:]]/}" ]; then
+  # Empty output with exit 0 means the container selector matched nothing, or the
+  # container has no args at all. Either way this read nothing, and saying "no
+  # --feature-gates arg" would be a statement about a list it never saw.
+  echo "  kueue gates    : the manager container reported no args; not read"
+else
+  echo "  kueue gates    : $(printf '%s' "$KUEUE_ARGS" | grep -- '--feature-gates' || echo '(args present, none is --feature-gates; gates may still be set in the config inlined below)')"
+fi
+# Inlined, not written to a file. Everything this run writes into $OUT is removed
+# by cleanup on every path, and $OUT is a temporary tree by default -- so "captured
+# to <file>" described evidence that did not outlive the run that claimed it. The
+# transcript is the artifact, so the evidence belongs in the transcript.
+if KUEUE_CFG=$(kubectl get configmap -n kueue-system kueue-manager-config -o yaml 2>/dev/null); then
+  echo "  kueue config   : inlined below"
+  printf '%s\n' "$KUEUE_CFG" | sed 's/^/    | /'
+else
+  echo "  kueue config   : not readable"
+fi
 
 echo "=== 0. prerequisites ==="
 # Prerequisites gate the rest. Reporting one as FAIL and carrying on into object
@@ -460,7 +502,7 @@ fi
 # separates permitted, denied, and misspelled. --all-namespaces is the documented
 # form for a cluster-scoped resource; without it kubectl warns about scope and the
 # warning would read as a missing type.
-RBAC_MISSING=""; RBAC_UNKNOWN=""
+RBAC_MISSING=""; RBAC_UNKNOWN=""; RBAC_UNREACHABLE=""
 # Two questions, asked separately, because kubectl answers them together and
 # ambiguously. "Does this resource type exist" comes from discovery, once. "Is the
 # verb permitted" comes from `auth can-i -q`, whose exit code is the answer and
@@ -469,18 +511,35 @@ RBAC_MISSING=""; RBAC_UNKNOWN=""
 # Reading stderr, as an earlier version did, could not tell an unknown type from a
 # deprecation warning from a partial-discovery hiccup -- so a cluster that emits
 # any warning at all failed every check and aborted the run.
-KNOWN_RESOURCES=$(kubectl api-resources --no-headers -o name 2>/dev/null | sed 's/\..*//' | sort -u)
+# The exit status matters as much as the output. A partial discovery failure --
+# a stale APIService, an aggregated API that is down -- prints the types it could
+# reach AND exits non-zero, so checking only for empty output turned a hiccup into
+# "this cluster has no Kueue types" and a hard exit, one line after confirming the
+# Kueue controller was running.
+if ! KNOWN_RAW=$(kubectl api-resources --no-headers -o name 2>/dev/null); then
+  report FAIL "the cluster's resource types could not be listed completely, so this run cannot tell a missing type from an unreachable one -- nothing was created"
+  echo "RESULT: FAIL"; exit 2
+fi
+KNOWN_RESOURCES=$(printf '%s\n' "$KNOWN_RAW" | sed 's/\..*//' | sort -u)
 if [ -z "$KNOWN_RESOURCES" ]; then
-  report FAIL "could not list the cluster's resource types -- nothing was created"
+  report FAIL "the cluster reported no resource types at all -- nothing was created"
   echo "RESULT: FAIL"; exit 2
 fi
 can_i() { # $1 verb, $2 resource -> permitted | denied | unknown-type
-  printf '%s\n' "$KNOWN_RESOURCES" | grep -qx -- "$2" || { echo unknown-type; return; }
-  if kubectl auth can-i "$1" "$2" --all-namespaces -q >/dev/null 2>&1; then
-    echo permitted
-  else
-    echo denied
-  fi
+  # -F: without it the name is a regex, so a typo containing a dot matches the
+  # resource it was a typo for -- 'c.usterqueues' resolved as 'clusterqueues'.
+  printf '%s\n' "$KNOWN_RESOURCES" | grep -qxF -- "$2" || { echo unknown-type; return; }
+  local answer
+  answer=$(kubectl auth can-i "$1" "$2" --all-namespaces 2>/dev/null)
+  case "$answer" in
+    yes) echo permitted ;;
+    no)  echo denied ;;
+    # Neither word: the request did not get an answer at all -- an unreachable
+    # apiserver, an expired credential. `-q` alone could not see this, because it
+    # exits 1 for "no" and for every error alike, so an authentication failure was
+    # reported as missing permission.
+    *)   echo unreachable ;;
+  esac
 }
 for spec in "create:workloadpriorityclasses" "delete:workloadpriorityclasses" \
             "create:clusterqueues" "delete:clusterqueues" \
@@ -494,8 +553,15 @@ for spec in "create:workloadpriorityclasses" "delete:workloadpriorityclasses" \
     permitted)    ;;
     denied)       RBAC_MISSING="${RBAC_MISSING} ${verb}/${res}" ;;
     unknown-type) RBAC_UNKNOWN="${RBAC_UNKNOWN} ${res}" ;;
+    # An answer that was never given. Reporting it as a denial names RBAC for an
+    # apiserver that did not respond.
+    unreachable)  RBAC_UNREACHABLE="${RBAC_UNREACHABLE} ${verb}/${res}" ;;
   esac
 done
+if [ -n "$RBAC_UNREACHABLE" ]; then
+  report FAIL "the apiserver did not answer whether these are permitted:${RBAC_UNREACHABLE} -- nothing was created"
+  echo "RESULT: FAIL"; exit 2
+fi
 if [ -n "$RBAC_UNKNOWN" ]; then
   # Not a denial. An unresolvable resource type, a discovery hiccup or an
   # unreachable apiserver produce the same shape, and naming RBAC for any of them
@@ -602,7 +668,7 @@ if [ -z "$MAPPING_VERSION" ]; then
   # exposing the constant, and an interpreter that could not import the compiler at
   # all. Reporting the second as the first sends the reader to the wrong file.
   if [ -s "${OUT}/mapping-version.err" ]; then
-    report FAIL "the compiler could not be imported by ${PYTHON_BIN} (see ${OUT}/mapping-version.err)"
+    report FAIL "the compiler could not be imported by ${PYTHON_BIN}: $(tr '\n' ' ' < "${OUT}/mapping-version.err" | cut -c1-200)"
   else
     report FAIL "the compiler exposes no mapping version to compare against"
   fi
@@ -655,14 +721,24 @@ CTL_LOW_FILE=$(find "${OUT}/ctl-low" -name '*-kueue.yaml' | head -1)
 if [ -z "$RENDER_BAD" ]; then
   report PASS "both arms rendered by the compiler (priority-class and control)"
 else
-  report FAIL "render failed:${RENDER_BAD} (logs in ${OUT}) -- nothing further attempted"
+  report FAIL "render failed:${RENDER_BAD} -- nothing further attempted"
+  # Printed, not pointed at: cleanup removes $OUT on the way out, so a message
+  # naming a path there sends the reader somewhere that no longer exists.
+  for _log in "${OUT}"/render-*.log; do
+    [ -s "$_log" ] || continue
+    echo "  --- $(basename "$_log") ---"; sed 's/^/    | /' "$_log"
+  done
   cleanup; finish
 fi
 
 # The control arm is only a control if its Jobs really carry no class. Checked here
 # rather than assumed, because a control that silently kept the label would agree with
 # the treatment arm and be read as the treatment arm failing to matter.
-CTL_LABELLED=$("${PYTHON_BIN}" - "$CTL_HIGH_FILE" "$CTL_LOW_FILE" <<'PY'
+# The exit status is read. Discarding it made every failure -- an unparseable
+# sibling file, a broken interpreter, a missing render -- print "the control arm's
+# Jobs carry no priority class", which is the check the experiment's causal claim
+# rests on.
+if CTL_LABELLED=$("${PYTHON_BIN}" - "$CTL_HIGH_FILE" "$CTL_LOW_FILE" <<'PY'
 import sys, yaml
 hits = []
 for path in sys.argv[1:3]:
@@ -675,10 +751,16 @@ for path in sys.argv[1:3]:
 print(" ".join(hits))
 PY
 )
-if [ -z "$CTL_LABELLED" ]; then
-  report PASS "the control arm's Jobs carry no priority class"
+then
+  if [ -z "$CTL_LABELLED" ]; then
+    report PASS "the control arm's Jobs carry no priority class"
+  else
+    report FAIL "the control arm is not a control; it carries: ${CTL_LABELLED}"
+    cleanup; finish
+  fi
 else
-  report FAIL "the control arm is not a control; it carries: ${CTL_LABELLED}"
+  report FAIL "could not read the control arm's rendered Jobs, so it cannot be shown to be a control -- nothing further attempted"
+  cleanup; finish
 fi
 
 echo "=== 4. blocker holds the cpu=1 quota ==="
@@ -686,7 +768,15 @@ render_template "${MANIFESTS}/01-blocker-job.yaml" | kubectl apply -f - >/dev/nu
 BLOCK_WL=$(wait_wl "$BLOCKER")
 d=$((SECONDS+60)); ba=""
 while [ $SECONDS -lt $d ]; do ba=$(wl_admitted "$BLOCK_WL"); [ "$ba" = "True" ] && break; sleep 2; done
-[ "$ba" = "True" ] && report PASS "blocker admitted (holds quota)" || report FAIL "blocker not admitted"
+if [ "$ba" = "True" ]; then
+  report PASS "blocker admitted (holds quota)"
+else
+  # Without the blocker the quota was never held, so every measurement after this
+  # is about nothing. The run used to continue into nine races at roughly forty
+  # minutes -- the exact shape this file was fixed for one section earlier.
+  report FAIL "blocker not admitted, so the quota was never held -- nothing further attempted"
+  cleanup; finish
+fi
 
 echo "=== 5. submit LOW first, then HIGH (reverse of priority) ==="
 LOW_JOB=$(kubectl create -f "$LOW_JOB_FILE" -o jsonpath='{.metadata.name}' 2>/dev/null)
@@ -733,11 +823,18 @@ fi
 # a LOW whose value arrived through the pod-template fallback would leave the comparison
 # measuring something other than this mapping.
 REF_BAD=""
-for pair in "HIGH ${HIGH_WL}" "LOW ${LOW_WL}"; do
-  set -- $pair
-  g=$(wl_class_group "$2"); k=$(wl_class_kind "$2")
+for _side in HIGH LOW; do
+  # Indexed by name rather than by splitting a string: an empty workload name made
+  # `set -- $pair` leave $2 unset, which under set -u wrote bash errors into the
+  # middle of the transcript and clobbered the positional parameters.
+  [ "$_side" = HIGH ] && _wl="$HIGH_WL" || _wl="$LOW_WL"
+  if [ -z "$_wl" ]; then
+    REF_BAD="${REF_BAD} ${_side}(no workload)"
+    continue
+  fi
+  g=$(wl_class_group "$_wl"); k=$(wl_class_kind "$_wl")
   { [ "$g" = "kueue.x-k8s.io" ] && [ "$k" = "WorkloadPriorityClass" ]; } \
-    || REF_BAD="${REF_BAD} $1(group=${g:-<none>} kind=${k:-<none>})"
+    || REF_BAD="${REF_BAD} ${_side}(group=${g:-<none>} kind=${k:-<none>})"
 done
 if [ -z "$REF_BAD" ]; then
   report PASS "both references are WorkloadPriorityClasses, not Pod PriorityClasses"
@@ -810,10 +907,19 @@ echo "  admitted at: HIGH=$(wl_admitted_at "$HIGH_WL") LOW=$(wl_admitted_at "$LO
 # The objects the claim is about, kept so a reader can check the resource shapes were
 # symmetric, what quota each reserved, and that neither carried a requeue backoff --
 # none of which is recoverable once the namespace goes.
-kubectl get workloads.kueue.x-k8s.io -n "$NS" -o yaml > "${OUT}/workloads.yaml" 2>/dev/null \
-  && echo "  workloads captured to $(basename "${OUT}")/workloads.yaml" || true
-kubectl get clusterqueue "$CQ" -o yaml > "${OUT}/clusterqueue.yaml" 2>/dev/null \
-  && echo "  defaulted ClusterQueue captured to $(basename "${OUT}")/clusterqueue.yaml" || true
+# Inlined for the same reason. These are what let a reader check the resource
+# shapes were symmetric, what quota each reserved, and that neither carried a
+# requeue backoff -- none of which survives the namespace.
+if WL_YAML=$(kubectl get workloads.kueue.x-k8s.io -n "$NS" -o yaml 2>/dev/null); then
+  echo "  --- workloads ---"; printf '%s\n' "$WL_YAML" | sed 's/^/    | /'
+else
+  echo "  --- workloads: not readable ---"
+fi
+if CQ_YAML=$(kubectl get clusterqueue "$CQ" -o yaml 2>/dev/null); then
+  echo "  --- ClusterQueue as defaulted ---"; printf '%s\n' "$CQ_YAML" | sed 's/^/    | /'
+else
+  echo "  --- ClusterQueue: not readable ---"
+fi
 
 echo "=== 8. the same race, repeated ==="
 # The detailed pass above is race 1 of this arm; the remainder run here.

--- a/scripts/validate_kueue_priority.sh
+++ b/scripts/validate_kueue_priority.sh
@@ -429,6 +429,21 @@ echo "  namespace=${NS} clusterQueue=${CQ} classes=${HIGH_CLASS},${LOW_CLASS}"
 echo "  compiler commit: $(git -C "$HERE" rev-parse HEAD 2>/dev/null || echo unknown)"
 echo "  working tree   : $( [ -n "$(git -C "$HERE" status --porcelain 2>/dev/null)" ] && echo 'DIRTY -- this capture cannot be rebuilt from a commit' || echo 'clean' )"
 echo "  harness sha256 : $(sha256sum "$0" 2>/dev/null | cut -d' ' -f1 || echo unknown)"
+# And the templates. The harness digest covers this file; the ClusterQueue's cpu
+# quota of 1 -- which is the entire reason the blocker blocks -- lives in
+# 00-namespace-and-queue.yaml, and the two plans are what the compiler renders the
+# racing Jobs from. All four sat outside this run's own provenance, so editing one
+# produced a different experiment under an unchanged digest.
+#
+# Basenames, not the paths sha256sum prints: a figure that changes when the
+# repository is cloned elsewhere cannot be compared across the two runs it exists
+# to compare. The glob is *.yaml and the transcripts land under results/, so a
+# filed result cannot feed back into the digest of the run that produced it.
+echo "  inputs sha256  : $( { sha256sum "${MANIFESTS}"/*.yaml 2>/dev/null \
+  | while read -r _h _p; do printf '%s  %s\n' "$_h" "$(basename "$_p")"; done \
+  | sort | sha256sum | cut -d' ' -f1; } || echo unknown)"
+echo "  harness inputs : $( { for _f in "${MANIFESTS}"/*.yaml; do
+    [ -e "$_f" ] && printf '%s ' "$(basename "$_f")"; done; } 2>/dev/null)"
 # Which interpreter, and which copy of the compiler it actually imported. The commit
 # above names the tree; it does not establish that the tree is what ran. `python -c`
 # puts the current directory ahead of PYTHONPATH, so a stray orbital_mission_compiler/

--- a/scripts/validate_kueue_priority.sh
+++ b/scripts/validate_kueue_priority.sh
@@ -53,6 +53,17 @@ if [ -n "${RUN_ID_BAD}" ]; then
   printf 'RESULT: FAIL\n'
   exit 2
 fi
+# How many races each arm runs. One race cannot separate a mechanism from a coin
+# toss: under "the order is arbitrary" a single expected result has probability 1/2.
+# Five per arm puts that at 1/32, and the run reports the tally rather than a sentence
+# about it, so a reader can see how many attempts there were.
+REPS="${REPS:-5}"
+case "${REPS}" in
+  ''|*[!0-9]*) printf 'REPS must be a positive integer, got %s\n' "${REPS}" >&2
+               printf 'RESULT: FAIL\n'; exit 2 ;;
+esac
+[ "${REPS}" -ge 1 ] || { printf 'REPS must be at least 1\n' >&2; printf 'RESULT: FAIL\n'; exit 2; }
+
 NS="prio-${RUN_ID}"
 FLAVOR="prio-flavor-${RUN_ID}"
 CQ="prio-cq-${RUN_ID}"
@@ -101,7 +112,9 @@ trap 'cleanup; trap - EXIT; exit 143' TERM
 # lookup and teardown, so an override cannot leave the queue in one namespace and the
 # Jobs in another.
 render_template() { # $1 template path -> stdout
-  "${PYTHON_BIN}" - "$1" "$NS" "$FLAVOR" "$CQ" "$LQ" "$BLOCKER" "$RUN_ID" <<'PY'
+  # BLOCKER_OVERRIDE lets a repeat cycle name its own blocker without a second naming
+  # scheme; unset, every template still gets the run's single blocker name.
+  "${PYTHON_BIN}" - "$1" "$NS" "$FLAVOR" "$CQ" "$LQ" "${BLOCKER_OVERRIDE:-$BLOCKER}" "$RUN_ID" <<'PY'
 import sys
 path, ns, flavor, cq, lq, blocker, run_id = sys.argv[1:8]
 text = open(path, encoding="utf-8").read()
@@ -180,6 +193,53 @@ else:
 job_mapping() { _label_of get job "$1" -n "$NS"; }
 class_mapping() { _label_of get workloadpriorityclass "$1"; }
 class_value() { kubectl get workloadpriorityclass "$1" -o jsonpath='{.value}' 2>/dev/null; }
+# One admission race, start to finish, reporting only who won. The detailed pass in
+# sections 4-7b examines a single race; this repeats it, and repeats it for the control
+# arm, where the only difference is which pair of rendered Jobs it is given.
+#
+# The blocker name is a parameter so cycles cannot collide with each other or with the
+# detailed pass; everything it creates is deleted before it returns, and the namespace
+# teardown is the backstop.
+race_once() { # $1 blocker name, $2 low job file, $3 high job file -> HIGH|LOW|BOTH|NONE
+  local blocker="$1" lowf="$2" highf="$3"
+  local lj hj lw hw first="" d ba
+  BLOCKER_OVERRIDE="$blocker" render_template "${MANIFESTS}/01-blocker-job.yaml" \
+    | kubectl apply -f - >/dev/null 2>&1
+  d=$((SECONDS+60)); ba=""
+  while [ $SECONDS -lt $d ]; do ba=$(wl_admitted "$(wl_for_job "$blocker")"); [ "$ba" = "True" ] && break; sleep 2; done
+  if [ "$ba" != "True" ]; then
+    kubectl delete job "$blocker" -n "$NS" --ignore-not-found >/dev/null 2>&1
+    echo "NOBLOCK"; return
+  fi
+  lj=$(kubectl create -f "$lowf" -o jsonpath='{.metadata.name}' 2>/dev/null)
+  lw=$(wait_wl "$lj")
+  sleep 6   # the same separation the detailed pass uses, and for the same reason
+  hj=$(kubectl create -f "$highf" -o jsonpath='{.metadata.name}' 2>/dev/null)
+  hw=$(wait_wl "$hj")
+  if [ -z "$lw" ] || [ -z "$hw" ]; then
+    kubectl delete job "$blocker" "$lj" "$hj" -n "$NS" --ignore-not-found >/dev/null 2>&1
+    echo "NOWL"; return
+  fi
+  kubectl delete job "$blocker" -n "$NS" --ignore-not-found >/dev/null 2>&1
+  d=$((SECONDS+60))
+  while [ $SECONDS -lt $d ]; do
+    local h l; h=$(wl_admitted "$hw"); l=$(wl_admitted "$lw")
+    if [ "$h" = "True" ] && [ "$l" = "True" ]; then first="BOTH"; break; fi
+    if [ "$h" = "True" ]; then first="HIGH"; break; fi
+    if [ "$l" = "True" ]; then first="LOW"; break; fi
+    sleep 2
+  done
+  kubectl delete job "$lj" "$hj" -n "$NS" --ignore-not-found >/dev/null 2>&1
+  # Wait for the quota to come back before the next cycle starts, or its blocker
+  # cannot be admitted and the cycle reports NOBLOCK for a reason unrelated to it.
+  d=$((SECONDS+90))
+  while [ $SECONDS -lt $d ]; do
+    [ -z "$(kubectl get jobs -n "$NS" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)" ] && break
+    sleep 3
+  done
+  echo "${first:-NONE}"
+}
+
 wait_wl() { # $1 job name -> echo workload name once it exists (up to 30s)
   local w=""; local d=$((SECONDS+30))
   while [ $SECONDS -lt $d ]; do w=$(wl_for_job "$1"); [ -n "$w" ] && break; sleep 2; done
@@ -327,10 +387,50 @@ LOW_JOB_FILE=$(find "${OUT}/low" -name '*-kueue.yaml' | head -1)
 # are checked, because a command can succeed and still write nothing this run can use.
 [ -n "$HIGH_JOB_FILE" ] || RENDER_BAD="${RENDER_BAD} high(no -kueue.yaml)"
 [ -n "$LOW_JOB_FILE" ] || RENDER_BAD="${RENDER_BAD} low(no -kueue.yaml)"
+
+# The control arm: the same two plans, the same submission order, rendered WITHOUT
+# --priority-class. No priority-class label means Kueue resolves no
+# WorkloadPriorityClass, both Workloads take priority 0, and the sort falls through to
+# the creation timestamp -- so the prediction inverts and the first submitted should
+# win. It is what makes the treatment arm evidence rather than an observation: without
+# it, "priority beat arrival order" is asserted against a null that was never run, and
+# any mechanism favouring the later submission would look identical.
+for p in high low; do
+  PYTHONPATH="${HERE}/src" "${PYTHON_BIN}" -m orbital_mission_compiler.cli render-kueue \
+    --input "${MANIFESTS}/plan-${p}.yaml" --output-dir "${OUT}/ctl-${p}" --queue "$LQ" --namespace "$NS" \
+    --policy-engine baseline >"${OUT}/render-ctl-${p}.log" 2>&1 || RENDER_BAD="${RENDER_BAD} ctl-${p}(exit $?)"
+done
+CTL_HIGH_FILE=$(find "${OUT}/ctl-high" -name '*-kueue.yaml' | head -1)
+CTL_LOW_FILE=$(find "${OUT}/ctl-low" -name '*-kueue.yaml' | head -1)
+[ -n "$CTL_HIGH_FILE" ] || RENDER_BAD="${RENDER_BAD} ctl-high(no -kueue.yaml)"
+[ -n "$CTL_LOW_FILE" ] || RENDER_BAD="${RENDER_BAD} ctl-low(no -kueue.yaml)"
+
 if [ -z "$RENDER_BAD" ]; then
-  report PASS "both Jobs rendered by the compiler"
+  report PASS "both arms rendered by the compiler (priority-class and control)"
 else
   report FAIL "render failed:${RENDER_BAD} (logs in ${OUT})"
+fi
+
+# The control arm is only a control if its Jobs really carry no class. Checked here
+# rather than assumed, because a control that silently kept the label would agree with
+# the treatment arm and be read as the treatment arm failing to matter.
+CTL_LABELLED=$("${PYTHON_BIN}" - "$CTL_HIGH_FILE" "$CTL_LOW_FILE" <<'PY'
+import sys, yaml
+hits = []
+for path in sys.argv[1:3]:
+    for doc in yaml.safe_load_all(open(path, encoding="utf-8")):
+        if not doc:
+            continue
+        labels = (doc.get("metadata") or {}).get("labels") or {}
+        if "kueue.x-k8s.io/priority-class" in labels:
+            hits.append(f"{path}={labels['kueue.x-k8s.io/priority-class']}")
+print(" ".join(hits))
+PY
+)
+if [ -z "$CTL_LABELLED" ]; then
+  report PASS "the control arm's Jobs carry no priority class"
+else
+  report FAIL "the control arm is not a control; it carries: ${CTL_LABELLED}"
 fi
 
 echo "=== 4. blocker holds the cpu=1 quota ==="
@@ -466,6 +566,44 @@ kubectl get workloads.kueue.x-k8s.io -n "$NS" -o yaml > "${OUT}/workloads.yaml" 
   && echo "  workloads captured to $(basename "${OUT}")/workloads.yaml" || true
 kubectl get clusterqueue "$CQ" -o yaml > "${OUT}/clusterqueue.yaml" 2>/dev/null \
   && echo "  defaulted ClusterQueue captured to $(basename "${OUT}")/clusterqueue.yaml" || true
+
+echo "=== 8. the same race, repeated ==="
+# The detailed pass above is race 1 of this arm; the remainder run here.
+TREAT_WINS=0; TREAT_LOG="HIGH"
+i=1
+while [ "$i" -lt "$REPS" ]; do
+  i=$((i+1))
+  w=$(race_once "${BLOCKER}-t${i}" "$LOW_JOB_FILE" "$HIGH_JOB_FILE")
+  TREAT_LOG="${TREAT_LOG} ${w}"
+  [ "$w" = "HIGH" ] && TREAT_WINS=$((TREAT_WINS+1))
+  echo "  priority arm race ${i}/${REPS}: ${w}"
+done
+TREAT_WINS=$((TREAT_WINS+1))   # race 1 was the detailed pass, which asserted HIGH
+echo "  priority arm outcomes: ${TREAT_LOG}"
+if [ "$TREAT_WINS" -eq "$REPS" ]; then
+  report PASS "HIGH admitted first in ${TREAT_WINS}/${REPS} races despite being submitted last"
+else
+  report FAIL "HIGH admitted first in only ${TREAT_WINS}/${REPS} races (${TREAT_LOG})"
+fi
+
+echo "=== 9. control arm: the same plans and order, no priority class ==="
+# The prediction inverts here. If the control also gives HIGH, the apparatus favours
+# the later submission and the treatment arm shows nothing about priority.
+CTL_WINS=0; CTL_LOG=""
+i=0
+while [ "$i" -lt "$REPS" ]; do
+  i=$((i+1))
+  w=$(race_once "${BLOCKER}-c${i}" "$CTL_LOW_FILE" "$CTL_HIGH_FILE")
+  CTL_LOG="${CTL_LOG} ${w}"
+  [ "$w" = "LOW" ] && CTL_WINS=$((CTL_WINS+1))
+  echo "  control arm race ${i}/${REPS}: ${w}"
+done
+echo "  control arm outcomes:${CTL_LOG}"
+if [ "$CTL_WINS" -eq "$REPS" ]; then
+  report PASS "without a priority class the FIRST submitted won ${CTL_WINS}/${REPS} races -> the apparatus does observe arrival order, and the treatment arm inverted it"
+else
+  report FAIL "control arm did not follow arrival order:${CTL_LOG} (${CTL_WINS}/${REPS} to LOW)"
+fi
 
 echo "" ; echo "=== Summary ===" ; echo "PASS: ${PASS}  FAIL: ${FAIL}"
 # Teardown runs via the EXIT trap (also covers interrupts).

--- a/scripts/validate_kueue_priority.sh
+++ b/scripts/validate_kueue_priority.sh
@@ -28,6 +28,31 @@ OUT="${OUT:-${HERE}/out/kueue-priority}"
 # One identifier per run, so two runs on one cluster cannot collide and neither can
 # touch anything that was already there. Override RUN_ID to reproduce a name.
 RUN_ID="${RUN_ID:-r$(date +%s)$$}"
+
+# The identifier is substituted into object names, a label value, a label selector
+# and the YAML templates, so an override carrying a newline, a comma, an equals or a
+# slash would break the manifest, silently widen what cleanup deletes, or produce a
+# name the API server refuses. Held to what all four uses accept: an RFC 1123 label.
+# The 32-character cap leaves room for the longest name built from it,
+# "orbital-<id>-mission-critical", inside the 63 a label value allows.
+case "${RUN_ID}" in
+  # Unreachable while the assignment above uses :- , which substitutes the default
+  # for an empty override as well as an unset one. Kept because without it an empty
+  # value would fall through to the accepting branch rather than be caught.
+  "")            RUN_ID_BAD="it is empty" ;;
+  [!a-z0-9]*)    RUN_ID_BAD="it must start with a lowercase letter or digit" ;;
+  *[!a-z0-9])    RUN_ID_BAD="it must end with a lowercase letter or digit" ;;
+  *[!a-z0-9-]*)  RUN_ID_BAD="it may hold only lowercase letters, digits and '-'" ;;
+  *)             RUN_ID_BAD="" ;;
+esac
+if [ -z "${RUN_ID_BAD}" ] && [ "${#RUN_ID}" -gt 32 ]; then
+  RUN_ID_BAD="it is longer than 32 characters"
+fi
+if [ -n "${RUN_ID_BAD}" ]; then
+  printf 'RUN_ID is not usable: %s\n' "${RUN_ID_BAD}" >&2
+  printf 'RESULT: FAIL\n'
+  exit 2
+fi
 NS="prio-${RUN_ID}"
 FLAVOR="prio-flavor-${RUN_ID}"
 CQ="prio-cq-${RUN_ID}"
@@ -38,6 +63,10 @@ BLOCKER="prio-blocker-${RUN_ID}"
 CLASS_PREFIX="orbital-${RUN_ID}-"
 HIGH_CLASS="${CLASS_PREFIX}mission-critical"
 LOW_CLASS="${CLASS_PREFIX}mission-normal"
+# --emit-priority-classes writes one class per ORCHIDE tier, so the run creates four
+# whether or not the proof reads them all back. Checking only the two it reads left
+# the other two applied over whatever was already there.
+ALL_CLASSES="${CLASS_PREFIX}mission-critical ${CLASS_PREFIX}mission-high ${CLASS_PREFIX}mission-normal ${CLASS_PREFIX}mission-low"
 OWNER_LABEL="orbital.test/run-id=${RUN_ID}"
 
 rm -rf "$OUT"; mkdir -p "$OUT"
@@ -125,8 +154,9 @@ COLLIDE=""
 absent namespace "$NS" || COLLIDE="${COLLIDE} namespace/${NS}"
 absent clusterqueue "$CQ" || COLLIDE="${COLLIDE} clusterqueue/${CQ}"
 absent resourceflavor "$FLAVOR" || COLLIDE="${COLLIDE} resourceflavor/${FLAVOR}"
-absent workloadpriorityclass "$HIGH_CLASS" || COLLIDE="${COLLIDE} wpc/${HIGH_CLASS}"
-absent workloadpriorityclass "$LOW_CLASS" || COLLIDE="${COLLIDE} wpc/${LOW_CLASS}"
+for cls in ${ALL_CLASSES}; do
+  absent workloadpriorityclass "$cls" || COLLIDE="${COLLIDE} wpc/${cls}"
+done
 if [ -z "$COLLIDE" ]; then
   report PASS "no pre-existing object carries this run's names"
 else

--- a/scripts/validate_kueue_priority.sh
+++ b/scripts/validate_kueue_priority.sh
@@ -307,10 +307,10 @@ else
 fi
 
 echo "=== 2. emit + apply the WorkloadPriorityClasses from the compiler ==="
-PYTHONPATH="${HERE}/src" ${PYTHON_BIN} -m orbital_mission_compiler.cli render-kueue \
+PYTHONPATH="${HERE}/src" "${PYTHON_BIN}" -m orbital_mission_compiler.cli render-kueue \
   --input "${MANIFESTS}/plan-high.yaml" --output-dir "${OUT}/wpc" --queue "$LQ" --namespace "$NS" \
   --emit-priority-classes --priority-class --priority-class-prefix "$CLASS_PREFIX" \
-  --policy-engine baseline >/dev/null 2>&1
+  --policy-engine baseline >"${OUT}/render-wpc.log" 2>&1
 # The compiler does not know about this run, so the ownership label is added here.
 if "${PYTHON_BIN}" - "${OUT}/wpc/workload-priority-classes.yaml" "$RUN_ID" <<'PY' | kubectl apply -f - >/dev/null
 import sys, yaml

--- a/scripts/validate_kueue_priority.sh
+++ b/scripts/validate_kueue_priority.sh
@@ -137,10 +137,49 @@ wl_class() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priorityClas
 wl_class_group() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priorityClassRef.group}' 2>/dev/null; }
 wl_class_kind() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.spec.priorityClassRef.kind}' 2>/dev/null; }
 wl_created() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null; }
-# The label the compiler puts on a Job it renders with --priority-class, naming the
-# mapping that chose the class. Read off the Job rather than the Workload: Kueue copies
-# the priority and the class reference onto the Workload, not the Job's own labels.
-job_mapping() { kubectl get job "$1" -n "$NS" -o "jsonpath={.metadata.labels['orbital/priority-mapping-version']}" 2>/dev/null; }
+# Queued-and-waiting stated positively. Inferring it from "Admitted is not True" also
+# accepts a workload that is structurally inadmissible, and a lookup that failed.
+wl_quota_reserved() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="QuotaReserved")].status}' 2>/dev/null; }
+wl_quota_reason() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="QuotaReserved")].reason}' 2>/dev/null; }
+wl_admitted_at() { kubectl get workload "$1" -n "$NS" -o jsonpath='{.status.conditions[?(@.type=="Admitted")].lastTransitionTime}' 2>/dev/null; }
+# The label naming the mapping that chose a class, read off two objects the compiler
+# produces separately: the Job (via --priority-class) and the WorkloadPriorityClass
+# itself (via --emit-priority-classes). Comparing those two is the point -- comparing
+# either one against the constant that stamped it only asks the module whether it
+# agrees with itself.
+#
+# The key is written in the escaped bracket form even though it has no dot today. A
+# dotted key in the plain form resolves to empty with status 0, so a prefix moved to
+# a DNS subdomain, which is the Kubernetes convention, would silently turn every
+# reading below into "the label is missing" and blame the compiler for it.
+# Read through `-o json` and pick the key out in Python rather than with kubectl's
+# jsonpath. Two reasons, both of which turn a real failure into a silent empty string
+# under jsonpath: a key containing a dot needs escaping and resolves to empty with
+# status 0 without it, so moving the prefix to a DNS subdomain -- the Kubernetes
+# convention -- would quietly make every reading below say "missing". And an absent
+# label, a label whose value is the empty string (which the API server accepts), and a
+# failed lookup all come back as the same empty string, so the check cannot say which
+# it saw. This reports <absent> and <empty> as distinct, non-empty tokens that no
+# comparison against a real version can accidentally satisfy.
+MAPPING_LABEL="orbital/priority-mapping-version"
+_label_of() { # $1 kubectl args... -> the label value, or <absent>/<empty>/<unreadable>
+  kubectl "$@" -o json 2>/dev/null | "${PYTHON_BIN}" -c '
+import json, sys
+key = sys.argv[1]
+try:
+    obj = json.load(sys.stdin)
+except Exception:
+    print("<unreadable>"); raise SystemExit(0)
+labels = (obj.get("metadata") or {}).get("labels") or {}
+if key not in labels:
+    print("<absent>")
+else:
+    print(labels[key] if labels[key] != "" else "<empty>")
+' "${MAPPING_LABEL}" 2>/dev/null || echo "<unreadable>"
+}
+job_mapping() { _label_of get job "$1" -n "$NS"; }
+class_mapping() { _label_of get workloadpriorityclass "$1"; }
+class_value() { kubectl get workloadpriorityclass "$1" -o jsonpath='{.value}' 2>/dev/null; }
 wait_wl() { # $1 job name -> echo workload name once it exists (up to 30s)
   local w=""; local d=$((SECONDS+30))
   while [ $SECONDS -lt $d ]; do w=$(wl_for_job "$1"); [ -n "$w" ] && break; sleep 2; done
@@ -156,6 +195,29 @@ echo "  namespace=${NS} clusterQueue=${CQ} classes=${HIGH_CLASS},${LOW_CLASS}"
 echo "  compiler commit: $(git -C "$HERE" rev-parse HEAD 2>/dev/null || echo unknown)"
 echo "  working tree   : $( [ -n "$(git -C "$HERE" status --porcelain 2>/dev/null)" ] && echo 'DIRTY -- this capture cannot be rebuilt from a commit' || echo 'clean' )"
 echo "  harness sha256 : $(sha256sum "$0" 2>/dev/null | cut -d' ' -f1 || echo unknown)"
+# Which interpreter, and which copy of the compiler it actually imported. The commit
+# above names the tree; it does not establish that the tree is what ran. `python -c`
+# puts the current directory ahead of PYTHONPATH, so a stray orbital_mission_compiler/
+# beside the caller shadows the checked-out one, and every value below would then come
+# from code no commit describes while the header still cited a commit.
+echo "  interpreter    : $("${PYTHON_BIN}" -c 'import sys; print(sys.executable)' 2>/dev/null || echo unknown)"
+echo "  compiler module: $(PYTHONPATH="${HERE}/src" "${PYTHON_BIN}" -c 'import orbital_mission_compiler.compiler as m; print(m.__file__)' 2>/dev/null || echo unresolved)"
+
+# The environment the result is about. Written by the run rather than typed into the
+# capture afterwards: a version recorded by hand is a claim about the cluster, not
+# evidence from it, and this transcript is what the experiment produces.
+echo "=== environment ==="
+echo "  kubectl client : $(kubectl version --client -o json 2>/dev/null | "${PYTHON_BIN}" -c 'import json,sys; print(json.load(sys.stdin)["clientVersion"]["gitVersion"])' 2>/dev/null || echo unknown)"
+echo "  kube-apiserver : $(kubectl version -o json 2>/dev/null | "${PYTHON_BIN}" -c 'import json,sys; print(json.load(sys.stdin)["serverVersion"]["gitVersion"])' 2>/dev/null || echo unknown)"
+echo "  nodes          : $(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}={.status.nodeInfo.kubeletVersion} {end}' 2>/dev/null || echo unknown)"
+echo "  kueue image    : $(kubectl get deployment -n kueue-system kueue-controller-manager -o jsonpath='{.spec.template.spec.containers[?(@.name=="manager")].image}' 2>/dev/null || echo unknown)"
+echo "  kueue imageID  : $(kubectl get pods -n kueue-system -l control-plane=controller-manager -o jsonpath='{.items[0].status.containerStatuses[?(@.name=="manager")].imageID}' 2>/dev/null || echo unknown)"
+# The sort this experiment measures is affected by Kueue's own configuration, so the
+# gates and the config are captured rather than assumed to be defaults.
+echo "  kueue gates    : $(kubectl get deployment -n kueue-system kueue-controller-manager -o jsonpath='{range .spec.template.spec.containers[?(@.name=="manager")].args[*]}{@}{"\n"}{end}' 2>/dev/null | grep -- '--feature-gates' || echo '(none set; built-in defaults apply)')"
+kubectl get configmap -n kueue-system kueue-manager-config -o yaml > "${OUT}/kueue-manager-config.yaml" 2>/dev/null \
+  && echo "  kueue config   : captured to $(basename "${OUT}")/kueue-manager-config.yaml" \
+  || echo "  kueue config   : not readable"
 
 echo "=== 0. prerequisites ==="
 command -v kubectl >/dev/null 2>&1 && report PASS "kubectl available" || { report FAIL "kubectl missing"; exit 2; }
@@ -206,24 +268,70 @@ fi
 kubectl get workloadpriorityclass "$HIGH_CLASS" "$LOW_CLASS" >/dev/null 2>&1 \
   && report PASS "${HIGH_CLASS} + ${LOW_CLASS} exist" || report FAIL "priority classes missing"
 
-# The ordering claim rests on these two values, so read them back rather than trusting
-# the mapping: a rename that silently changed a value would otherwise pass unnoticed.
-HIGH_VALUE=$(kubectl get workloadpriorityclass "$HIGH_CLASS" -o jsonpath='{.value}' 2>/dev/null)
-LOW_VALUE=$(kubectl get workloadpriorityclass "$LOW_CLASS" -o jsonpath='{.value}' 2>/dev/null)
-if [ "$HIGH_VALUE" = "400" ] && [ "$LOW_VALUE" = "200" ]; then
-  report PASS "class values as mapped (${HIGH_CLASS}=400, ${LOW_CLASS}=200)"
+# Read every emitted value back, not only the two this proof goes on to use. Checking
+# the pair the experiment reads leaves the other two tiers unpinned anywhere: the unit
+# suite asserts the four are strictly decreasing, which a changed value can satisfy, so
+# a mapping could be altered without bumping the version -- the one thing the version
+# exists to make detectable -- and both the tests and this run would still pass.
+VALUES_BAD=""
+for spec in "mission-critical:400" "mission-high:300" "mission-normal:200" "mission-low:100"; do
+  cls="${CLASS_PREFIX}${spec%%:*}"; want="${spec##*:}"; got=$(class_value "$cls")
+  [ "$got" = "$want" ] || VALUES_BAD="${VALUES_BAD} ${cls}=${got:-<none>}(want ${want})"
+done
+if [ -z "$VALUES_BAD" ]; then
+  report PASS "all four emitted classes carry the mapped values (400/300/200/100)"
 else
-  report FAIL "unexpected class values: ${HIGH_CLASS}=${HIGH_VALUE:-<none>} ${LOW_CLASS}=${LOW_VALUE:-<none>}"
+  report FAIL "class values off the mapping:${VALUES_BAD}"
+fi
+
+# And that the classes now on the cluster are the ones this tree describes. Read from
+# the source rather than hard-coded, so a deliberate bump to v3 does not fail the run;
+# what it catches is a cluster holding a generation the tree no longer emits.
+MAPPING_VERSION=$(PYTHONPATH="${HERE}/src" "${PYTHON_BIN}" -c \
+  'from orbital_mission_compiler.compiler import PRIORITY_CLASS_MAPPING_VERSION as v; print(v)' \
+  2>"${OUT}/mapping-version.err")
+if [ -z "$MAPPING_VERSION" ]; then
+  # Distinguished because the two have different culprits: a compiler that stopped
+  # exposing the constant, and an interpreter that could not import the compiler at
+  # all. Reporting the second as the first sends the reader to the wrong file.
+  if [ -s "${OUT}/mapping-version.err" ]; then
+    report FAIL "the compiler could not be imported by ${PYTHON_BIN} (see ${OUT}/mapping-version.err)"
+  else
+    report FAIL "the compiler exposes no mapping version to compare against"
+  fi
+else
+  CLASS_MAP_BAD=""
+  for spec in mission-critical mission-high mission-normal mission-low; do
+    cls="${CLASS_PREFIX}${spec}"; got=$(class_mapping "$cls")
+    [ "$got" = "$MAPPING_VERSION" ] || CLASS_MAP_BAD="${CLASS_MAP_BAD} ${cls}=${got}"
+  done
+  if [ -z "$CLASS_MAP_BAD" ]; then
+    report PASS "all four classes are labelled with the mapping this tree emits (${MAPPING_VERSION})"
+  else
+    report FAIL "classes labelled off ${MAPPING_VERSION}:${CLASS_MAP_BAD}"
+  fi
 fi
 
 echo "=== 3. render HIGH (priority 90) and LOW (priority 50) Jobs ==="
+RENDER_BAD=""
 for p in high low; do
-  PYTHONPATH="${HERE}/src" ${PYTHON_BIN} -m orbital_mission_compiler.cli render-kueue \
+  PYTHONPATH="${HERE}/src" "${PYTHON_BIN}" -m orbital_mission_compiler.cli render-kueue \
     --input "${MANIFESTS}/plan-${p}.yaml" --output-dir "${OUT}/${p}" --queue "$LQ" --namespace "$NS" \
-    --priority-class --priority-class-prefix "$CLASS_PREFIX" --policy-engine baseline >/dev/null 2>&1
+    --priority-class --priority-class-prefix "$CLASS_PREFIX" --policy-engine baseline \
+    >"${OUT}/render-${p}.log" 2>&1 || RENDER_BAD="${RENDER_BAD} ${p}(exit $?)"
 done
 HIGH_JOB_FILE=$(find "${OUT}/high" -name '*-kueue.yaml' | head -1)
 LOW_JOB_FILE=$(find "${OUT}/low" -name '*-kueue.yaml' | head -1)
+# The render had no assertion of its own, so a failure here was only noticed several
+# steps later, as a Workload that never appeared. Both the exit status and the artifact
+# are checked, because a command can succeed and still write nothing this run can use.
+[ -n "$HIGH_JOB_FILE" ] || RENDER_BAD="${RENDER_BAD} high(no -kueue.yaml)"
+[ -n "$LOW_JOB_FILE" ] || RENDER_BAD="${RENDER_BAD} low(no -kueue.yaml)"
+if [ -z "$RENDER_BAD" ]; then
+  report PASS "both Jobs rendered by the compiler"
+else
+  report FAIL "render failed:${RENDER_BAD} (logs in ${OUT})"
+fi
 
 echo "=== 4. blocker holds the cpu=1 quota ==="
 render_template "${MANIFESTS}/01-blocker-job.yaml" | kubectl apply -f - >/dev/null
@@ -250,25 +358,44 @@ HC=$(wl_class "$HIGH_WL"); LC=$(wl_class "$LOW_WL")
 [ "$HC" = "$HIGH_CLASS" ] && [ "$LC" = "$LOW_CLASS" ] \
   && report PASS "workloads reference the emitted classes" \
   || report FAIL "class references: HIGH=${HC:-<none>} LOW=${LC:-<none>}"
-# Which mapping produced those class names, read back off the live Jobs. The compiler
-# supplies the value it stamps, so a later bump to v3 does not make this fail; what it
-# catches is a Job reaching the cluster without the label, or the two disagreeing --
-# either of which would leave `kubectl get jobs -l orbital/priority-mapping-version=...`
-# unable to find what a rename left behind.
-MAPPING_VERSION=$(PYTHONPATH="${HERE}/src" ${PYTHON_BIN} -c \
-  'from orbital_mission_compiler.compiler import PRIORITY_CLASS_MAPPING_VERSION as v; print(v)' 2>/dev/null)
-HM=$(job_mapping "$HIGH_JOB"); LM=$(job_mapping "$LOW_JOB")
-if [ -z "$MAPPING_VERSION" ]; then
-  report FAIL "the compiler exposes no mapping version to compare against"
-elif [ "$HM" = "$MAPPING_VERSION" ] && [ "$LM" = "$MAPPING_VERSION" ]; then
-  report PASS "both Jobs carry the mapping that named their class (${MAPPING_VERSION})"
+# A Job and the class it names come from two different compiler entry points
+# (--priority-class and --emit-priority-classes) and arrive as separate objects, so
+# their agreeing is a statement about what the cluster holds. Comparing either one
+# against the constant that stamped it only asks the module whether it agrees with
+# itself. A Job outliving a rename is the case the label exists to make findable, and
+# it is findable only if the Job and the class name the same generation.
+if [ -z "$HIGH_JOB" ] || [ -z "$LOW_JOB" ]; then
+  # Section 6 makes the same distinction for the Workloads. A Job that was never
+  # created reads back as no label at all, which must not be reported as a compiler
+  # that forgot to stamp one.
+  report FAIL "no Job to read a mapping version from: HIGH=(${HIGH_JOB}) LOW=(${LOW_JOB})"
 else
-  report FAIL "mapping version on the Jobs: HIGH=${HM:-<none>} LOW=${LM:-<none>}, compiler says ${MAPPING_VERSION}"
+  HM=$(job_mapping "$HIGH_JOB"); LM=$(job_mapping "$LOW_JOB")
+  HCM=$(class_mapping "$HIGH_CLASS"); LCM=$(class_mapping "$LOW_CLASS")
+  # <absent>, <empty> and <unreadable> are reported as themselves; an equality test
+  # alone would accept two objects that are both missing the label.
+  case "$HM" in "<"*) MAPPING_READABLE=no ;; *) MAPPING_READABLE=yes ;; esac
+  if [ "$MAPPING_READABLE" = yes ] && [ "$HM" = "$HCM" ] && [ "$LM" = "$LCM" ] && [ "$HM" = "$LM" ]; then
+    report PASS "each Job carries the mapping its own class carries (${HM})"
+  else
+    report FAIL "mapping labels disagree: HIGH job=${HM} class=${HCM}; LOW job=${LM} class=${LCM}"
+  fi
 fi
-HG=$(wl_class_group "$HIGH_WL"); HK=$(wl_class_kind "$HIGH_WL")
-[ "$HG" = "kueue.x-k8s.io" ] && [ "$HK" = "WorkloadPriorityClass" ] \
-  && report PASS "the reference is a WorkloadPriorityClass, not a Pod PriorityClass" \
-  || report FAIL "unexpected class reference: group=${HG:-<none>} kind=${HK:-<none>}"
+# Read the reference on both Workloads. The ordering claim rests on two priorities, and
+# a LOW whose value arrived through the pod-template fallback would leave the comparison
+# measuring something other than this mapping.
+REF_BAD=""
+for pair in "HIGH ${HIGH_WL}" "LOW ${LOW_WL}"; do
+  set -- $pair
+  g=$(wl_class_group "$2"); k=$(wl_class_kind "$2")
+  { [ "$g" = "kueue.x-k8s.io" ] && [ "$k" = "WorkloadPriorityClass" ]; } \
+    || REF_BAD="${REF_BAD} $1(group=${g:-<none>} kind=${k:-<none>})"
+done
+if [ -z "$REF_BAD" ]; then
+  report PASS "both references are WorkloadPriorityClasses, not Pod PriorityClasses"
+else
+  report FAIL "unexpected class reference:${REF_BAD}"
+fi
 # Arrival order is the thing priority has to beat, so read it rather than assume the
 # sleep achieved it.
 HT=$(wl_created "$HIGH_WL"); LT=$(wl_created "$LOW_WL")
@@ -281,12 +408,18 @@ fi
 echo "=== 6. both PENDING while blocker holds quota ==="
 sleep 5
 la=$(wl_admitted "$LOW_WL"); ha=$(wl_admitted "$HIGH_WL")
-# Require both Workloads to actually EXIST and be un-admitted -- a missing Workload
-# (empty name) must NOT be mistaken for "pending".
-if [ -n "$LOW_WL" ] && [ -n "$HIGH_WL" ] && [ "$la" != "True" ] && [ "$ha" != "True" ]; then
-  report PASS "LOW and HIGH both pending under full quota"
+lq=$(wl_quota_reserved "$LOW_WL"); hq=$(wl_quota_reserved "$HIGH_WL")
+lr=$(wl_quota_reason "$LOW_WL"); hr=$(wl_quota_reason "$HIGH_WL")
+# Both Workloads must EXIST, be un-admitted, and say so themselves through a
+# QuotaReserved condition that is present and False. A missing Workload must not be
+# mistaken for a pending one, and neither must a workload that is waiting for
+# something other than quota.
+if [ -n "$LOW_WL" ] && [ -n "$HIGH_WL" ] \
+   && [ "$la" != "True" ] && [ "$ha" != "True" ] \
+   && [ "$lq" = "False" ] && [ "$hq" = "False" ]; then
+  report PASS "LOW and HIGH both waiting on quota (QuotaReserved=False; LOW ${lr:-<no reason>}, HIGH ${hr:-<no reason>})"
 else
-  report FAIL "expected both workloads present and pending, got LOW=($LOW_WL)=$la HIGH=($HIGH_WL)=$ha"
+  report FAIL "expected both workloads present and waiting on quota, got LOW=($LOW_WL) admitted=${la:-<none>} quotaReserved=${lq:-<none>}(${lr:-<none>}) HIGH=($HIGH_WL) admitted=${ha:-<none>} quotaReserved=${hq:-<none>}(${hr:-<none>})"
 fi
 
 echo "=== 7. free quota (delete blocker); the higher-priority pending workload wins ==="
@@ -308,6 +441,31 @@ case "$FIRST" in
   LOW)  report FAIL "LOW admitted first -> creation order, not priority, decided" ;;
   *)    report FAIL "neither workload was admitted within the window" ;;
 esac
+
+echo "=== 7b. LOW was queued behind HIGH, not unable to run at all ==="
+# Winning a race against something that could never have run is not winning. Without
+# this, any asymmetry that made LOW permanently inadmissible -- a larger request, a
+# flavor that does not match, a class name that resolves to nothing -- produces exactly
+# the PASS above, and the earlier steps cannot tell the two apart: "not admitted yet"
+# and "never admissible" both satisfy them.
+d=$((SECONDS+120)); la=""
+while [ $SECONDS -lt $d ]; do la=$(wl_admitted "$LOW_WL"); [ "$la" = "True" ] && break; sleep 3; done
+if [ "$la" = "True" ]; then
+  report PASS "LOW admitted once HIGH released the quota -> it was queued, not inadmissible"
+else
+  report FAIL "LOW never admitted (admitted=${la:-<none>}, quotaReserved=$(wl_quota_reserved "$LOW_WL"):$(wl_quota_reason "$LOW_WL")) -> the ordering result compares against a workload that may never have been runnable"
+fi
+# Second-resolution condition timestamps, kept because they are the cluster's own
+# account of the order rather than the polling loop's.
+echo "  admitted at: HIGH=$(wl_admitted_at "$HIGH_WL") LOW=$(wl_admitted_at "$LOW_WL")"
+
+# The objects the claim is about, kept so a reader can check the resource shapes were
+# symmetric, what quota each reserved, and that neither carried a requeue backoff --
+# none of which is recoverable once the namespace goes.
+kubectl get workloads.kueue.x-k8s.io -n "$NS" -o yaml > "${OUT}/workloads.yaml" 2>/dev/null \
+  && echo "  workloads captured to $(basename "${OUT}")/workloads.yaml" || true
+kubectl get clusterqueue "$CQ" -o yaml > "${OUT}/clusterqueue.yaml" 2>/dev/null \
+  && echo "  defaulted ClusterQueue captured to $(basename "${OUT}")/clusterqueue.yaml" || true
 
 echo "" ; echo "=== Summary ===" ; echo "PASS: ${PASS}  FAIL: ${FAIL}"
 # Teardown runs via the EXIT trap (also covers interrupts).

--- a/tests/test_priority_harness.py
+++ b/tests/test_priority_harness.py
@@ -1,0 +1,121 @@
+"""The live priority harness's own guards, checked without a cluster.
+
+scripts/validate_kueue_priority.sh creates a namespace, queues, a flavor and
+cluster-scoped priority classes, so what it refuses to do matters as much as what
+it proves. CI does not run it and it needs a live Kueue to get past its
+prerequisites, but the checks that run before any of that do not.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path("scripts/validate_kueue_priority.sh")
+
+
+def _run(run_id: str) -> subprocess.CompletedProcess:
+    """Run the harness with the given RUN_ID and no cluster access.
+
+    KUBECONFIG points nowhere, so anything past the identifier check fails at the
+    prerequisite step instead of touching a real cluster.
+    """
+    return subprocess.run(  # noqa: S603
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        # A refusal exits at once; this bound only matters when the guard is gone,
+        # and then a short one turns a ten-minute hang into a prompt failure.
+        timeout=20,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "RUN_ID": run_id,
+            "KUBECONFIG": "/nonexistent/kubeconfig",
+            "HOME": "/nonexistent",
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "run_id",
+    [
+        "UPPER",
+        "-leading-hyphen",
+        "trailing-hyphen-",
+        "has,comma",
+        "has=equals",
+        "has/slash",
+        "has space",
+        "multi\nline",
+        "a" * 33,
+    ],
+)
+def test_an_unusable_run_id_stops_before_the_cluster_is_touched(run_id):
+    """The identifier reaches object names, a label value, a label selector and the
+    YAML templates, so one carrying a comma widens what cleanup deletes and one
+    carrying a newline breaks the manifest.
+    """
+    result = _run(run_id)
+    assert result.returncode == 2, result.stdout
+    assert "RUN_ID is not usable" in result.stderr
+    # Nothing past the check ran: no prerequisite report, no creation.
+    assert "prerequisites" not in result.stdout
+
+
+def test_a_usable_run_id_gets_past_the_check():
+    """A well-formed identifier is not the thing that stops the run.
+
+    What happens after the check needs a cluster and can take as long as its own
+    waits allow, so the run is cut short rather than waited on: getting past the
+    check is exactly the absence of its message.
+    """
+    proc = subprocess.Popen(  # noqa: S603
+        ["bash", str(SCRIPT)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "RUN_ID": "r1785592517",
+            "KUBECONFIG": "/nonexistent/kubeconfig",
+            "HOME": "/nonexistent",
+        },
+    )
+    try:
+        _, err = proc.communicate(timeout=20)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        _, err = proc.communicate()
+
+    assert "RUN_ID is not usable" not in err
+
+
+def test_the_generated_default_would_pass_its_own_check():
+    """The default is r<epoch><pid>, which has to satisfy the rule it is checked by."""
+    import os
+    import re
+    import time
+
+    generated = f"r{int(time.time())}{os.getpid()}"
+    assert re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", generated)
+    assert len(generated) <= 32
+
+def test_the_preflight_covers_every_class_the_compiler_emits():
+    """The run creates one class per tier whether or not the proof reads them back.
+
+    It checked only the two it reads, so the other two were applied over whatever
+    already carried those names. A tier added to the mapping has to appear here too,
+    which is what this compares.
+    """
+    import re
+
+    from orbital_mission_compiler.compiler import render_workload_priority_classes
+
+    prefix = "orbital-rtest-"
+    emitted = sorted(w["metadata"]["name"] for w in render_workload_priority_classes(prefix=prefix))
+
+    listed = re.search(r'ALL_CLASSES="(.+?)"', SCRIPT.read_text(encoding="utf-8"))
+    assert listed, "the harness no longer names the classes it creates"
+    checked = sorted(listed.group(1).replace("${CLASS_PREFIX}", prefix).split())
+
+    assert checked == emitted


### PR DESCRIPTION
## What

A live experiment showing that a mission plan's priority reaches the field Kueue sorts a ClusterQueue on, and that it inverts an admission order the same experiment shows is otherwise decided by arrival.

The original case study submits two CPU Jobs (priority 90 and 50); the first is admitted, the second waits. On its own that only shows **quota gating** — the Job that arrives while quota is free runs, the other waits. It does not isolate priority from arrival order.

**Priority arm.** A ClusterQueue with cpu `nominalQuota=1` and no preemption, so exactly one `cpu=1` Job is admissible at a time. A blocker holds the slot; the **LOW** Job (priority 50 → `orbital-mission-normal`, value 200) goes in **first**; the **HIGH** Job (priority 90 → `orbital-mission-critical`, value 400) goes in **second**; both stay pending; the blocker is deleted. Kueue admits **HIGH** first, despite it arriving last.

**Control arm.** That is still one cell, and inside it "higher priority" and "submitted second" are the same Job — so a mechanism favouring the later arrival predicts the identical result, and "if Kueue used arrival order it would have admitted LOW" is asserted against a null nobody ran. So the run also races the same two plans in the same order rendered **without `--priority-class`**. With no class label Kueue resolves no `WorkloadPriorityClass`, both Workloads take priority 0, the sort falls through to the creation timestamp, and the prediction inverts to the first submitted winning.

It does. The apparatus demonstrably observes arrival order, and the flag is what turns it around. The difference between the arms is one compiler flag and nothing else about the Jobs, which is also what attributes the effect to the compiler rather than to Kueue on its own. The control is itself checked for being a control: its rendered Jobs are read for a `kueue.x-k8s.io/priority-class` label, because a control that silently kept one would agree with the treatment arm and be read as the treatment arm not mattering.

Each arm races five times, because a single race cannot separate a mechanism from a coin toss.

## Result (live)

Kubernetes v1.36.3, Kueue v0.19.0. 21 checks, no failures. Priority arm: HIGH first in 5 of 5. Control arm: LOW first in 5 of 5. The run is committed under `results/`.

The chain is read back off the cluster rather than trusted: all four emitted class values (400/300/200/100, not only the two the race uses), the mapping-version label on each of the four classes, the `spec.priorityClassRef` on **both** Workloads including group and kind, each Job's mapping label against the label on the class it references, the two creation timestamps establishing LOW really did arrive first, and `QuotaReserved` present and False while both wait.

Two of those are worth explaining.

The **group** is read because Kueue's fallback is silent: with no `kueue.x-k8s.io/priority-class` label, `ExtractPriority` takes the pod template's own Kubernetes PriorityClass, writes it into the same `spec.priority` and sorts by it identically. The run would still admit HIGH first while proving nothing about this mapping.

The **Job-against-class** comparison replaces an earlier check that compared the Job's label to the constant that stamped it, which only asks the module whether it agrees with itself. A weaker mutation than the one that motivated it walked straight through: change tier 2 from 300 to 250 and tier 4 from 100 to 150, leave the version at v2, and the unit suite stayed green — it pinned only that the four descend — while the run read back just tiers 1 and 3. The mapping changed with no bump, which is the single thing the version label exists to make detectable. Hence reading all four values, and comparing two objects the compiler produces through different entry points.

## After HIGH wins

The run waits for LOW and requires it to be admitted too. Beating a workload that could never have run is not evidence, and no earlier step could tell "not admitted yet" from "never admissible": any asymmetry making LOW permanently inadmissible produced exactly the same pass.

## Provenance

Each capture records the commit, whether the tree was clean, the harness checksum, the interpreter, and the path of the compiler module that was actually imported — `python -c` puts the working directory ahead of `PYTHONPATH`, so a stray package beside the caller shadows the checked-out one while the header still cites a commit.

The cluster facts are printed by the run: apiserver and kubelet versions, the Kueue image and its digest, the controller feature gates, the Kueue configuration, the defaulted ClusterQueue, and the Workload objects. They were typed into the capture by hand before, which made the transcript's authority a person rather than the cluster.

## Isolation

Every object a run creates is named for it and carries an ownership label; teardown selects on that label, and the run refuses to start if any name it wants is taken — covering all four classes `--emit-priority-classes` writes, not only the two the race reads. `RUN_ID` is validated as an RFC 1123 label capped at 32 characters before its first use, since it reaches object names, a label value, a label selector and the manifest templates. Teardown runs from a trap on EXIT, INT and TERM, and the interrupt handlers exit rather than return, because a handler that returns lets the script carry on and recreate what it just deleted.

## Scope

The README states the boundaries: two of the four tiers are raced, there are two pending workloads rather than k>2, only queue sorting is exercised (preemption and cohort borrowing read the same field and are not), quota is freed one way, the workload shape is a CPU-only single container, and the run uses `--policy-engine baseline`.

That Kueue admits the higher `spec.priority` first is documented Kueue behaviour and not a finding here. What the run establishes is the path: a plan's `priority: 90` becomes an ORCHIDE tier, a class name, a class whose value is 400, and finally the `spec.priority` Kueue sorts on — with the control arm attributing the change to the compiler's flag.

Additions only — the harness, its manifests and sample plans, a README, the run evidence, and unit tests for the harness's own argument handling. No existing file changes.

## Stacking

Stacked on `feature/kueue-priority-mapping`, which defines the `orbital-mission-critical`..`orbital-mission-low` classes this proof asserts on. Rebase target becomes `main` (via `feature/policy-guardrail-hardening`) as the stack merges down.
