### PR TITLE
reconcile from the declared desired set, and give the publish lock a shared namespace

### DIFF
--- a/.github/actions/setup-opa/action.yml
+++ b/.github/actions/setup-opa/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - name: Cache OPA binary
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: opa-cache
       with:
         path: ~/.local/bin/opa

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           python3 -m pytest -q -rs --cov=orbital_mission_compiler --cov-report=term-missing --cov-report=xml --cov-fail-under=70
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -57,7 +57,7 @@ jobs:
       # prints "skipped argo lint" and the step still passes, so a rendered
       # manifest that Argo would reject reads as a green smoke.
       - name: Cache the Argo CLI archive
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: argo-cache
         with:
           # The archive, not the unpacked binary: the published checksum is of the
@@ -338,10 +338,10 @@ jobs:
   mcp:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip

--- a/src/orbital_mission_compiler/cli.py
+++ b/src/orbital_mission_compiler/cli.py
@@ -38,6 +38,7 @@ from .compiler import (
     resolve_argo_bin,
     argo_lint_path,
     stale_rendered_artifacts,
+    ArtifactOwner,
     _artifact_mission,
     attribute_stale,
     render_workload_priority_classes,
@@ -169,7 +170,10 @@ def _report_stale(
         # its own desired set while leaving the first mission's Jobs pointing at
         # classes that are no longer there. Correct and silent is the wrong half
         # of that, so it is said out loud.
-        shared = [p for p in mine if _artifact_mission(p) is None]
+        shared = [
+            p for p in mine
+            if _artifact_mission(p).owner is ArtifactOwner.UNMISSIONED
+        ]
         if shared:
             print(
                 f"warning: removing {len(shared)} cluster-scoped artifact(s) that carry no "
@@ -200,6 +204,30 @@ def _report_stale(
         f"redeploy them. Re-run with --prune to remove them.",
         file=sys.stderr,
     )
+
+
+def _scan_failure_report(exc: OSError, published: list[Path], lint: str | None = None) -> dict:
+    """A stale scan that could not run, after the output has already changed.
+
+    Its own reason, because the alternatives both lie. Reported as a publish
+    failure it claims a rollback that did not happen -- the manifests are live.
+    Left to escape it is a traceback, and the caller learns neither what was
+    published nor whether anything was removed.
+    """
+    report: dict = {
+        "status": "error",
+        "reason": "stale-scan-failed",
+        "output_modified": True,
+        "files": [str(p) for p in published],
+        "pruned": [],
+        "message": (
+            "the manifests were published, but the directory could not be read "
+            f"back to find artifacts this render replaced: {exc}"
+        ),
+    }
+    if lint is not None:
+        report["lint"] = lint
+    return report
 
 
 def _finite_seconds(raw: str) -> float:
@@ -484,6 +512,9 @@ def cmd_render_argo(args: argparse.Namespace) -> None:
             )
         except PruneIncomplete as exc:
             print(json.dumps(_prune_failure_report(exc, written), indent=2))
+            raise SystemExit(2) from exc
+        except OSError as exc:
+            print(json.dumps(_scan_failure_report(exc, written), indent=2))
             raise SystemExit(2) from exc
     print(json.dumps(result, indent=2))
 
@@ -975,6 +1006,39 @@ def _publish(
     return published
 
 
+def _reconcile_empty_render(
+    args: argparse.Namespace, out_dir: Path, lock_stack: contextlib.ExitStack
+) -> None:
+    """A plan that renders nothing, asked to make the directory match it.
+
+    An empty desired set is a state to reconcile, not a reason to leave the
+    previous generation on disk for the next apply to redeploy. No linter runs,
+    so the verdict is not-applicable and never passed -- and, for the same
+    reason, the Argo binary is not needed to get here.
+    """
+    try:
+        lock_stack.enter_context(_publish_lock(out_dir, args.lock_timeout, args.lock_dir))
+    except PublishLockUnavailable as exc:
+        print(json.dumps({
+            "status": "error", "lint": "not-run", "reason": "publish-lock-unavailable",
+            "message": str(exc),
+        }, indent=2))
+        raise SystemExit(2) from exc
+    empty_result: dict[str, object] = {"status": "ok", "lint": "not-applicable", "files": []}
+    try:
+        _report_stale(
+            empty_result, args.output_dir, [], args.prune, ARGO_EXCLUSIVE_KINDS,
+            mission_ids=_render_scope(args.input),
+        )
+    except PruneIncomplete as exc:
+        print(json.dumps(_prune_failure_report(exc, []), indent=2))
+        raise SystemExit(2) from exc
+    except OSError as exc:
+        print(json.dumps(_scan_failure_report(exc, []), indent=2))
+        raise SystemExit(2) from exc
+    print(json.dumps(empty_result, indent=2))
+
+
 def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
     """Render, lint, and publish only if the linter accepts what it reads.
 
@@ -1005,6 +1069,15 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
     try:
         written = _render_argo(args, staging)
 
+        # Resolved after the prune-only case below and before every other one.
+        # A plan is allowed to render nothing, and an empty render must not be
+        # able to report a lint that never ran -- but reconciling an empty
+        # desired set runs no linter at all, so requiring the binary there made
+        # cleanup depend on a tool it never invokes.
+        if not written and args.prune:
+            _reconcile_empty_render(args, out_dir, lock_stack)
+            return
+
         try:
             resolved = resolve_argo_bin(args.argo_bin)
         except ArgoLintUnavailable as exc:
@@ -1012,42 +1085,15 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
             raise SystemExit(2) from exc
 
         if not written:
-            # A plan may legitimately render nothing, and what that means here
-            # depends on what this command was asked to do. Without --prune there
-            # is nothing to publish and nothing was verified, which is what exit 2
-            # has always said. With --prune the command was asked to make the
-            # directory match the plan, and an empty desired set is a state to
-            # reconcile rather than a reason to leave the previous generation on
-            # disk for the next apply to redeploy. The verdict stays honest either
-            # way: a set that was never linted is reported as not-applicable, and
-            # never as passed.
-            if not args.prune:
-                print(json.dumps({
-                    "status": "error", "lint": "not-run", "reason": "no-manifests",
-                    "message": "the plan rendered no Argo Workflow, so nothing was linted",
-                }, indent=2))
-                raise SystemExit(2)
-            try:
-                lock_stack.enter_context(_publish_lock(out_dir, args.lock_timeout, args.lock_dir))
-            except PublishLockUnavailable as exc:
-                print(json.dumps({
-                    "status": "error", "lint": "not-run", "reason": "publish-lock-unavailable",
-                    "message": str(exc),
-                }, indent=2))
-                raise SystemExit(2) from exc
-            empty_result: dict[str, object] = {
-                "status": "ok", "lint": "not-applicable", "files": [],
-            }
-            try:
-                _report_stale(
-                    empty_result, args.output_dir, [], args.prune, ARGO_EXCLUSIVE_KINDS,
-                    mission_ids=_render_scope(args.input),
-                )
-            except PruneIncomplete as exc:
-                print(json.dumps(_prune_failure_report(exc, []), indent=2))
-                raise SystemExit(2) from exc
-            print(json.dumps(empty_result, indent=2))
-            return
+            # A plan may legitimately render nothing, and without --prune that
+            # means there is nothing to publish and nothing was verified, which
+            # is what exit 2 has always said here. The --prune case was taken
+            # above, before the linter was resolved.
+            print(json.dumps({
+                "status": "error", "lint": "not-run", "reason": "no-manifests",
+                "message": "the plan rendered no Argo Workflow, so nothing was linted",
+            }, indent=2))
+            raise SystemExit(2)
 
         # Taken before the destination is read, not just before it is written.
         # The verdict is about a directory state, and a state read outside the
@@ -1218,10 +1264,23 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
                 [(out_dir / path.name, path.read_text(encoding="utf-8")) for path in written]
             )
             published = _publish(written, out_dir, leftover_backups)
-            _report_stale(
-                result_stale, args.output_dir, published, args.prune,
-                ARGO_EXCLUSIVE_KINDS, mission_ids=_render_scope(args.input),
-            )
+            # Outside the publish try below. _publish has returned, so the
+            # manifests are live; an OSError from the scan reported by that
+            # handler asserts a rollback that did not happen.
+            try:
+                _report_stale(
+                    result_stale, args.output_dir, published, args.prune,
+                    ARGO_EXCLUSIVE_KINDS, mission_ids=_render_scope(args.input),
+                )
+            except PruneIncomplete:
+                # An OSError subclass, and a different phase: the scan finished
+                # and the removals did not. Left to the handler that says so.
+                raise
+            except OSError as exc:
+                print(json.dumps(
+                    _scan_failure_report(exc, published, lint="passed"), indent=2
+                ))
+                raise SystemExit(2) from exc
         except ValueError as exc:
             print(json.dumps({
                 "status": "error", "lint": "passed", "reason": "not-owned",
@@ -1459,6 +1518,9 @@ def cmd_render_kueue(args: argparse.Namespace) -> None:
             )
         except PruneIncomplete as exc:
             print(json.dumps(_prune_failure_report(exc, written), indent=2))
+            raise SystemExit(2) from exc
+        except OSError as exc:
+            print(json.dumps(_scan_failure_report(exc, written), indent=2))
             raise SystemExit(2) from exc
     result: dict[str, object] = {"status": "ok", "files": [str(p) for p in written]}
     result.update(stale_result)

--- a/src/orbital_mission_compiler/cli.py
+++ b/src/orbital_mission_compiler/cli.py
@@ -11,13 +11,14 @@ import stat
 import sys
 import tempfile
 import time
-from collections.abc import Iterator
+from collections.abc import Collection, Iterator
 from pathlib import Path
 
 import yaml
 
 from .compiler import (
     ArgoLintUnavailable,
+    ARGO_LINT_TIMEOUT_SECONDS,
     DEFAULT_POLICY_BUNDLE,
     DEFAULT_POLICY_DECISION,
     PolicyEngineUnavailableError,
@@ -25,6 +26,7 @@ from .compiler import (
     compile_file,
     enforce_policy_or_raise,
     load_mission_plan,
+    mission_fingerprint,
     compile_plan_to_intents,
     render_kueue_job,
     render_resource_claim_templates,
@@ -36,6 +38,7 @@ from .compiler import (
     resolve_argo_bin,
     argo_lint_path,
     stale_rendered_artifacts,
+    _artifact_mission,
     attribute_stale,
     render_workload_priority_classes,
     typed_violations_from_decision,
@@ -62,7 +65,15 @@ _POLICY_ENGINE_HELP = (
 # Long enough that a normal concurrent render finishes first, short enough that a
 # hung one is reported rather than waited on. Overridable because "normal" depends
 # on how much a caller renders at once.
-_DEFAULT_LOCK_TIMEOUT = 30.0
+# Long enough to outlast the thing the lock is held across. The gate takes the
+# lock before it reads the destination and keeps it through `argo lint`, so a
+# wait shorter than the linter's own budget makes a second healthy writer give up
+# while the first is still inside its allowance -- contention reported as a
+# failure, on the defaults, most of the time. Derived rather than written down
+# twice, so raising the lint timeout cannot leave this behind; the margin covers
+# the publish that follows the verdict.
+_LOCK_PUBLISH_MARGIN_SECONDS = 30.0
+_DEFAULT_LOCK_TIMEOUT = float(ARGO_LINT_TIMEOUT_SECONDS) + _LOCK_PUBLISH_MARGIN_SECONDS
 # flock failures that mean "no lock is obtainable here", as opposed to "someone
 # holds it" or "something went wrong". Everything outside both lists is an error,
 # because proceeding unlocked on an unclassified failure is the one outcome that
@@ -115,11 +126,25 @@ ARGO_EXCLUSIVE_KINDS = {"Workflow"}
 KUEUE_EXCLUSIVE_KINDS = {"Job", "WorkloadPriorityClass"}
 
 
+def _render_scope(source: str | Path) -> frozenset[str]:
+    """The missions this render reconciles, taken from the plan.
+
+    Read from the input rather than from what was written, so a revision that
+    legitimately renders nothing still has a scope to reconcile against. The
+    fingerprint is what the artifacts carry, so that is what the scope holds.
+    """
+    return frozenset({mission_fingerprint(load_mission_plan(source).mission_id)})
+
+
 def _report_stale(
     result: dict[str, object], output_dir: str, written: list[Path], prune: bool,
-    exclusive_kinds: set[str],
+    exclusive_kinds: set[str], *, mission_ids: Collection[str] | None = None,
+    include_unmissioned: bool = False,
 ) -> None:
-    stale = stale_rendered_artifacts(output_dir, written)
+    stale = stale_rendered_artifacts(
+        output_dir, written,
+        mission_ids=mission_ids, include_unmissioned=include_unmissioned,
+    )
     if not stale:
         return
     mine, unattributable = attribute_stale(stale, exclusive_kinds)
@@ -137,6 +162,22 @@ def _report_stale(
     if not mine:
         return
     if prune:
+        # A cluster-scoped artifact belongs to no mission, so the mission filter
+        # that keeps one mission's --prune away from another's files does not
+        # cover it. Two missions rendering into one directory therefore share the
+        # priority-class bundle, and the second render removing it is correct for
+        # its own desired set while leaving the first mission's Jobs pointing at
+        # classes that are no longer there. Correct and silent is the wrong half
+        # of that, so it is said out loud.
+        shared = [p for p in mine if _artifact_mission(p) is None]
+        if shared:
+            print(
+                f"warning: removing {len(shared)} cluster-scoped artifact(s) that carry no "
+                f"mission: {', '.join(p.name for p in shared)}. Any other mission rendering "
+                f"into {output_dir} was relying on them; re-run that render with "
+                f"--emit-priority-classes to put them back.",
+                file=sys.stderr,
+            )
         removed: list[str] = []
         for index, path in enumerate(mine):
             try:
@@ -406,7 +447,10 @@ def cmd_render_argo(args: argparse.Namespace) -> None:
         written = _render_argo(args, args.output_dir)
         result: dict[str, object] = {"status": "ok", "files": [str(p) for p in written]}
         try:
-            _report_stale(result, args.output_dir, written, args.prune, ARGO_EXCLUSIVE_KINDS)
+            _report_stale(
+                result, args.output_dir, written, args.prune, ARGO_EXCLUSIVE_KINDS,
+                mission_ids=_render_scope(args.input),
+            )
         except PruneIncomplete as exc:
             print(json.dumps(_prune_failure_report(exc, written), indent=2))
             raise SystemExit(2) from exc
@@ -597,8 +641,45 @@ def _unreadable_documents(directory: Path) -> list[str]:
     return problems
 
 
+def _default_lock_dir() -> str:
+    """Where the publish lock lives when the caller does not say.
+
+    A fixed path rather than tempfile.gettempdir(), which honours TMPDIR and so
+    hands two renders of one output directory two different lock files. Falls
+    back to the temp directory only where the fixed one is unusable, which is
+    also where there is no shared location to be had.
+    """
+    fixed = Path("/tmp")  # noqa: S108 - shared by design; see the caller's O_NOFOLLOW
+    if fixed.is_dir() and os.access(fixed, os.W_OK):
+        return str(fixed)
+    return tempfile.gettempdir()
+
+
+class _SymlinkedManifest(Exception):
+    """A manifest in the destination that is a link to bytes the gate cannot hold."""
+
+    def __init__(self, path: str) -> None:
+        super().__init__(path)
+        self.path = path
+
+
+def publish_lock_path(out_dir: Path | str, lock_dir: str | None = None) -> Path:
+    """Where two renders of this output directory agree the lock is.
+
+    Derived in one place so a caller asking the question and the code taking the
+    lock cannot answer it differently. Tests recomputing it from a copy of this
+    is how a change of location left four of them passing only because the
+    environment happened to agree.
+    """
+    digest = hashlib.sha256(os.path.realpath(out_dir).encode("utf-8")).hexdigest()[:16]
+    return Path(lock_dir or _default_lock_dir()) / f"orbital-publish-{digest}.lock"
+
+
 @contextlib.contextmanager
-def _publish_lock(out_dir: Path, lock_timeout: float = _DEFAULT_LOCK_TIMEOUT) -> Iterator[None]:
+def _publish_lock(
+    out_dir: Path, lock_timeout: float = _DEFAULT_LOCK_TIMEOUT,
+    lock_dir: str | None = None,
+) -> Iterator[None]:
     """Serialise publishing into one output directory.
 
     Two renders publishing at once interleave their files and the directory ends
@@ -606,12 +687,23 @@ def _publish_lock(out_dir: Path, lock_timeout: float = _DEFAULT_LOCK_TIMEOUT) ->
     the output rather than inside it, so taking it does not create the directory
     a failed run has to leave absent.
     """
-    # Keyed by the output path but kept in the system temp directory, for two
-    # reasons. It has to be somewhere that exists whether or not the output
-    # directory does -- anchoring it to the nearest existing ancestor would give
-    # two processes different lock files when one of them runs before the
-    # directory is created and the other after, which is exactly when they would
-    # collide. And a lock file is not something to leave in an operator's output.
+    # Keyed by the output path but kept outside it, for two reasons. It has to be
+    # somewhere that exists whether or not the output directory does -- anchoring
+    # it to the nearest existing ancestor would give two processes different lock
+    # files when one of them runs before the directory is created and the other
+    # after, which is exactly when they would collide. And a lock file is not
+    # something to leave in an operator's output.
+    #
+    # Not tempfile.gettempdir(), which reads TMPDIR: two renders of the same
+    # output directory under different TMPDIR values took two lock files with the
+    # same name in different directories and both entered publication at once,
+    # measured. The key was already shared; only the namespace was not. A fixed
+    # location restores the guarantee on one host.
+    #
+    # It does not restore it between containers that share only the output volume,
+    # because they share no other filesystem and no default can invent one. That
+    # is what --lock-dir is for, pointed at the shared volume; nothing here can
+    # detect the mismatch, so it is stated rather than guessed at.
     try:
         import fcntl  # Unix-only, and only this feature needs it
     except ImportError as exc:
@@ -627,8 +719,7 @@ def _publish_lock(out_dir: Path, lock_timeout: float = _DEFAULT_LOCK_TIMEOUT) ->
     # resolve symlinks, so /data/out and /data/tmp/../out would take different
     # locks on the same directory -- the case the lock exists for.
     canonical = os.path.realpath(out_dir)
-    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
-    lock_path = Path(tempfile.gettempdir()) / f"orbital-publish-{digest}.lock"
+    lock_path = publish_lock_path(out_dir, lock_dir)
     # Openable by whoever can write the output, because that is who has to take it.
     # An earlier revision created it 0600 and never removed it, so once one user had
     # rendered, every other user was refused for good -- flock is released when the
@@ -879,11 +970,42 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
             raise SystemExit(2) from exc
 
         if not written:
-            print(json.dumps({
-                "status": "error", "lint": "not-run", "reason": "no-manifests",
-                "message": "the plan rendered no Argo Workflow, so nothing was linted",
-            }, indent=2))
-            raise SystemExit(2)
+            # A plan may legitimately render nothing, and what that means here
+            # depends on what this command was asked to do. Without --prune there
+            # is nothing to publish and nothing was verified, which is what exit 2
+            # has always said. With --prune the command was asked to make the
+            # directory match the plan, and an empty desired set is a state to
+            # reconcile rather than a reason to leave the previous generation on
+            # disk for the next apply to redeploy. The verdict stays honest either
+            # way: a set that was never linted is reported as not-applicable, and
+            # never as passed.
+            if not args.prune:
+                print(json.dumps({
+                    "status": "error", "lint": "not-run", "reason": "no-manifests",
+                    "message": "the plan rendered no Argo Workflow, so nothing was linted",
+                }, indent=2))
+                raise SystemExit(2)
+            try:
+                lock_stack.enter_context(_publish_lock(out_dir, args.lock_timeout))
+            except PublishLockUnavailable as exc:
+                print(json.dumps({
+                    "status": "error", "lint": "not-run", "reason": "publish-lock-unavailable",
+                    "message": str(exc),
+                }, indent=2))
+                raise SystemExit(2) from exc
+            empty_result: dict[str, object] = {
+                "status": "ok", "lint": "not-applicable", "files": [],
+            }
+            try:
+                _report_stale(
+                    empty_result, args.output_dir, [], args.prune, ARGO_EXCLUSIVE_KINDS,
+                    mission_ids=_render_scope(args.input),
+                )
+            except PruneIncomplete as exc:
+                print(json.dumps(_prune_failure_report(exc, []), indent=2))
+                raise SystemExit(2) from exc
+            print(json.dumps(empty_result, indent=2))
+            return
 
         # Taken before the destination is read, not just before it is written.
         # The verdict is about a directory state, and a state read outside the
@@ -936,7 +1058,10 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
                     {
                         p.name
                         for p in attribute_stale(
-                            stale_rendered_artifacts(out_dir, written), ARGO_EXCLUSIVE_KINDS
+                            stale_rendered_artifacts(
+                                out_dir, written, mission_ids=_render_scope(args.input),
+                            ),
+                            ARGO_EXCLUSIVE_KINDS,
                         )[0]
                     }
                     if args.prune else set()
@@ -944,11 +1069,29 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
                 for existing in existing_manifests:
                     if existing.name in staged_names or existing.name in leaving:
                         continue
+                    if existing.is_symlink():
+                        # Refused rather than followed. Both is_file() and copy2()
+                        # resolve the link, so the verdict would be about the
+                        # target's bytes while the output keeps a link whoever owns
+                        # the target can repoint afterwards. The gate exists to say
+                        # that what was linted is what gets applied, and about a
+                        # symlink it cannot.
+                        raise _SymlinkedManifest(str(existing))
                     if not existing.is_file():
                         continue
                     copy = staging / existing.name
                     shutil.copy2(existing, copy)
                     carried.append(copy)
+        except _SymlinkedManifest as exc:
+            print(json.dumps({
+                "status": "error", "lint": "not-run", "reason": "symlinked-manifest",
+                "message": (
+                    f"{exc.path} is a symbolic link, so the gate cannot promise the "
+                    "bytes it lints are the bytes that will be applied. Replace it "
+                    "with the file itself, or move it out of the output directory."
+                ),
+            }, indent=2))
+            raise SystemExit(2) from exc
         except OSError as exc:
             # Reading the destination can fail on its own: a manifest removed
             # between the glob and the copy, a directory that became
@@ -979,8 +1122,29 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
             raise SystemExit(1)
 
         rc, output = argo_lint_path(staging, argo_bin=args.argo_bin, resolved=resolved)
-        for copy in carried:
-            copy.unlink()
+        try:
+            for copy in carried:
+                copy.unlink()
+        except OSError as exc:
+            # Inside the contract, like everything else this command can fail at.
+            # The verdict is already in hand and the output has not been touched,
+            # which is a third outcome a caller has to be able to tell from "the
+            # linter rejected" and "the linter never answered". Escaping as a
+            # traceback tells them none of that.
+            # The verdict outranks the cleanup. Exit 1 means the linter rejected
+            # something and exit 2 means it never answered, so exiting 2 after a
+            # rejection would throw away the one thing the caller most needs and
+            # contradict the body of this very report.
+            verdict_known = rc != 0
+            print(json.dumps({
+                "status": "error", "lint": "failed" if verdict_known else "passed",
+                "reason": "staging-cleanup-failed", "output_modified": False,
+                "message": (
+                    f"the lint finished and {out_dir} was left unchanged, but the "
+                    f"staged copies in {staging} could not be removed: {exc}"
+                ),
+            }, indent=2))
+            raise SystemExit(1 if verdict_known else 2) from exc
         carried = []
         # A file the CLI cannot parse is logged and skipped, and the run still
         # exits 0 as long as something else in the directory lints -- which is
@@ -1012,7 +1176,10 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
                 [(out_dir / path.name, path.read_text(encoding="utf-8")) for path in written]
             )
             published = _publish(written, out_dir, leftover_backups)
-            _report_stale(result_stale, args.output_dir, published, args.prune, ARGO_EXCLUSIVE_KINDS)
+            _report_stale(
+                result_stale, args.output_dir, published, args.prune,
+                ARGO_EXCLUSIVE_KINDS, mission_ids=_render_scope(args.input),
+            )
         except ValueError as exc:
             print(json.dumps({
                 "status": "error", "lint": "passed", "reason": "not-owned",
@@ -1243,7 +1410,11 @@ def cmd_render_kueue(args: argparse.Namespace) -> None:
         # afterwards, so a gated render could pass its lint, publish, and have its
         # files deleted by this one, while both reported success.
         try:
-            _report_stale(stale_result, args.output_dir, written, args.prune, KUEUE_EXCLUSIVE_KINDS)
+            _report_stale(
+                stale_result, args.output_dir, written, args.prune,
+                KUEUE_EXCLUSIVE_KINDS, mission_ids=_render_scope(args.input),
+                include_unmissioned=True,
+            )
         except PruneIncomplete as exc:
             print(json.dumps(_prune_failure_report(exc, written), indent=2))
             raise SystemExit(2) from exc

--- a/src/orbital_mission_compiler/cli.py
+++ b/src/orbital_mission_compiler/cli.py
@@ -228,6 +228,22 @@ def _finite_seconds(raw: str) -> float:
     return value
 
 
+def _absolute_directory(raw: str) -> str:
+    """A lock directory both writers can name identically.
+
+    A relative path is resolved against the working directory, and two writers
+    that could not agree on a temp directory have no more reason to agree on
+    that. It would fail the same silent way the default does: two lock files,
+    both writers publishing, nothing recording it.
+    """
+    if not os.path.isabs(raw):
+        raise argparse.ArgumentTypeError(
+            f"{raw!r} is relative, so it names a different directory to a writer "
+            "started elsewhere; give the shared path in full"
+        )
+    return raw
+
+
 def _add_lock_args(p: argparse.ArgumentParser) -> None:
     """Add the output-root lock flag to a subcommand that writes artifacts."""
     p.add_argument(
@@ -240,6 +256,18 @@ def _add_lock_args(p: argparse.ArgumentParser) -> None:
         "publish. Waiting without a bound would let a hung holder stall this command "
         "indefinitely, so a timeout exits 2 -- the gate could not run -- rather than "
         "reporting a lint failure the linter never gave.",
+    )
+    p.add_argument(
+        "--lock-dir",
+        type=_absolute_directory,
+        default=None,
+        help="Absolute directory holding the publish lock. The default is a fixed "
+        "path, which is one directory on a host and two inside two containers that "
+        "share only the output volume; pointing both at that volume gives them one "
+        "lock file again. Two things it cannot check for you: the writers have to "
+        "reach the output directory by the same path, since the lock is named after "
+        "that path, and no other user may be able to replace the file -- on the "
+        "default that is what the sticky bit is doing.",
     )
 
 
@@ -424,7 +452,7 @@ def cmd_render_argo(args: argparse.Namespace) -> None:
     # exclusivity of its own.
     lock_stack = contextlib.ExitStack()
     try:
-        lock_stack.enter_context(_publish_lock(Path(args.output_dir), args.lock_timeout))
+        lock_stack.enter_context(_publish_lock(Path(args.output_dir), args.lock_timeout, args.lock_dir))
     except PublishLockUnsupported:
         # Nothing on this platform can lock, so nothing is holding the directory.
         pass
@@ -1000,7 +1028,7 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
                 }, indent=2))
                 raise SystemExit(2)
             try:
-                lock_stack.enter_context(_publish_lock(out_dir, args.lock_timeout))
+                lock_stack.enter_context(_publish_lock(out_dir, args.lock_timeout, args.lock_dir))
             except PublishLockUnavailable as exc:
                 print(json.dumps({
                     "status": "error", "lint": "not-run", "reason": "publish-lock-unavailable",
@@ -1028,7 +1056,7 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
         # against a set the linter never saw. Held across the lint so that the
         # state the verdict describes is the state that gets published.
         try:
-            lock_stack.enter_context(_publish_lock(out_dir, args.lock_timeout))
+            lock_stack.enter_context(_publish_lock(out_dir, args.lock_timeout, args.lock_dir))
         except PublishLockUnavailable as exc:
             print(json.dumps({
                 "status": "error", "lint": "not-run", "reason": "publish-lock-unavailable",
@@ -1340,7 +1368,7 @@ def cmd_render_kueue(args: argparse.Namespace) -> None:
     # of a directory's writers is not a lock on the directory.
     lock_stack = contextlib.ExitStack()
     try:
-        lock_stack.enter_context(_publish_lock(out_dir, args.lock_timeout))
+        lock_stack.enter_context(_publish_lock(out_dir, args.lock_timeout, args.lock_dir))
     except PublishLockUnsupported:
         # No fcntl at all. render-kueue has no lint verdict to protect, so it keeps
         # working here rather than refusing on a platform that cannot serialise --

--- a/src/orbital_mission_compiler/cli.py
+++ b/src/orbital_mission_compiler/cli.py
@@ -289,6 +289,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--argo-lint",
         action="store_true",
         help="After rendering, run the official 'argo lint' as a fail-closed gate. "
+        "It lints the Argo kinds; every other kind in the directory is checked "
+        "only for its apiVersion/kind/metadata envelope, so those specs still "
+        "need server-side validation. "
         "Manifests are staged and published only if lint passes, so a rejected "
         "render leaves the output directory unchanged. A lint failure exits 1; "
         "the gate being unable to run at all -- CLI absent, timeout, no manifest "
@@ -945,7 +948,18 @@ def _publish(
 
 
 def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
-    """Render, lint, and publish only if the linter accepts the whole set.
+    """Render, lint, and publish only if the linter accepts what it reads.
+
+    "Accepts" is narrower than it sounds, and the narrowness is the honest part.
+    Every document in the published set is parsed and checked for the envelope
+    kubectl requires -- apiVersion, kind, metadata -- against the parity tests.
+    Semantic linting is `argo lint`, which covers Workflow, WorkflowTemplate,
+    CronWorkflow and ClusterWorkflowTemplate and silently ignores everything
+    else. Measured on v4.0.8: a Job whose `containers` is a string, which kubectl
+    refuses outright, lints clean beside a valid Workflow. Kueue Jobs and
+    ResourceClaimTemplates in the same directory therefore get the envelope check
+    and nothing more, and a set that needs their specs validated needs
+    server-side validation as well as this.
 
     Order matters. Rendering comes first, so a schema or policy failure is
     reported as itself instead of being masked by a missing linter. The CLI is

--- a/src/orbital_mission_compiler/compiler.py
+++ b/src/orbital_mission_compiler/compiler.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+from collections.abc import Collection
 from importlib import resources
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1554,7 +1555,13 @@ def _artifact_mission(path: Path) -> str | None:
     return missions.pop() if len(missions) == 1 else None
 
 
-def stale_rendered_artifacts(output_dir: str | Path, written: list[Path]) -> list[Path]:
+def stale_rendered_artifacts(
+    output_dir: str | Path,
+    written: list[Path],
+    *,
+    mission_ids: Collection[str] | None = None,
+    include_unmissioned: bool = False,
+) -> list[Path]:
     """Artifacts from an earlier render that this one did not replace.
 
     A render writes the files the current plan produces; it does not empty the
@@ -1577,13 +1584,23 @@ def stale_rendered_artifacts(output_dir: str | Path, written: list[Path]) -> lis
     # in staging -- against resolved paths every one of them would compare as
     # unrelated and the whole previous generation would read as stale.
     current = {p.name for p in written}
-    # Scoped to the missions this render just wrote. Ownership alone is not
-    # enough to delete by: another mission's manifests in the same directory
-    # carry the same managed-by label and are equally ours, but they are not
-    # this render's to remove. Objects without a mission -- the cluster-scoped
-    # WorkloadPriorityClasses the other renderer emits -- are never in scope.
-    missions = {m for m in (_artifact_mission(p) for p in written) if m}
-    if not missions:
+    # Scoped to the missions this render reconciles. Ownership alone is not enough
+    # to delete by: another mission's manifests in the same directory carry the
+    # same managed-by label and are equally ours, but they are not this render's
+    # to remove.
+    #
+    # Declared by the caller, not read back from `written`. A plan whose next
+    # revision legitimately produces nothing wrote no file to read a mission out
+    # of, so the derived scope came back empty and the artifacts that revision
+    # drops stayed on disk: --prune reported nothing to do, and applying the
+    # directory went on redeploying exactly the workload the plan had removed. An
+    # empty desired set is a state to reconcile, not an absence of scope. Deriving
+    # it from `written` remains the fallback for callers that hold no plan.
+    missions = (
+        set(mission_ids) if mission_ids is not None
+        else {m for m in (_artifact_mission(p) for p in written) if m}
+    )
+    if not missions and not include_unmissioned:
         return []
     # Listed rather than globbed. `Path.glob` swallows the OSError scandir
     # raises, so an output directory that cannot be read comes back as an empty
@@ -1609,7 +1626,16 @@ def stale_rendered_artifacts(output_dir: str | Path, written: list[Path]) -> lis
         if p.suffix in (".yaml", ".yml", ".json")
         and p.name not in current
         and _is_rendered_artifact(p)
-        and _artifact_mission(p) in missions
+        # An artifact with no mission is not an unowned one. The
+        # WorkloadPriorityClass bundle is cluster-scoped, so it carries no
+        # fingerprint and mission scoping alone can never retire it: turning
+        # --emit-priority-classes off left the classes on disk for the next apply
+        # to reinstate. A caller that writes such artifacts says so, and
+        # `attribute_stale` still holds each renderer to the kinds only it emits.
+        and (
+            _artifact_mission(p) in missions
+            or (include_unmissioned and _artifact_mission(p) is None)
+        )
     )
 
 

--- a/src/orbital_mission_compiler/compiler.py
+++ b/src/orbital_mission_compiler/compiler.py
@@ -6,9 +6,12 @@ import logging
 import os
 import re
 import shutil
+import stat
 import subprocess
 import tempfile
 from collections.abc import Collection
+from dataclasses import dataclass
+from enum import Enum
 from importlib import resources
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1503,12 +1506,22 @@ def _is_rendered_artifact(path: Path) -> bool:
     render that has already written its output would strand the caller with
     artifacts on disk and no result.
     """
-    if not path.is_file():
-        # Asked before the read, because a read is not guaranteed to return.
-        # A fifo named `something.yaml` in the output directory blocks `open`
-        # until someone writes to the other end, and this runs while the
-        # publish lock is held -- so one directory entry would stall every
-        # render into that directory, not just this one.
+    try:
+        info = path.lstat()
+    except OSError:
+        return False
+    if not stat.S_ISREG(info.st_mode):
+        # A regular file, asked for by lstat, which answers about the entry
+        # rather than what it points at. `is_file()` followed the link, so an
+        # operator's symlink to a managed file was classified from the target's
+        # bytes and then unlinked as the link -- destroying the link and leaving
+        # the file it named. What a link points at says nothing about who owns
+        # the entry --prune would remove.
+        #
+        # Asked before the read for a second reason: a read is not guaranteed to
+        # return. A fifo named `something.yaml` blocks `open` until someone
+        # writes to the other end, and this runs while the publish lock is held,
+        # so one directory entry would stall every render into that directory.
         return False
     try:
         docs = [d for d in yaml.safe_load_all(path.read_text(encoding="utf-8"))]
@@ -1532,6 +1545,29 @@ def _is_rendered_artifact(path: Path) -> bool:
     return True
 
 
+def _in_scope(
+    found: ArtifactMission, missions: set[str], include_unmissioned: bool
+) -> bool:
+    """Whether a stale candidate is this render's to reconcile.
+
+    An artifact with no mission is not an unowned one. The
+    WorkloadPriorityClass bundle is cluster-scoped, so it carries no fingerprint
+    and mission scoping alone can never retire it: turning
+    --emit-priority-classes off left the classes on disk for the next apply to
+    reinstate. A caller that writes such artifacts says so.
+
+    Only the two states that answer the question take part. MIXED and MALFORMED
+    are the states that used to answer `None` alongside the genuinely
+    unmissioned, which is how a file holding another mission's Job came to be
+    deleted as though it were the bundle.
+    """
+    if found.owner is ArtifactOwner.MISSION:
+        return found.mission in missions
+    if found.owner is ArtifactOwner.UNMISSIONED:
+        return include_unmissioned
+    return False
+
+
 def _artifact_kinds(path: Path) -> set[str]:
     """The kinds a rendered file holds, for deciding whose artifact it is."""
     try:
@@ -1541,18 +1577,73 @@ def _artifact_kinds(path: Path) -> set[str]:
     return {d["kind"] for d in docs if isinstance(d, dict) and isinstance(d.get("kind"), str)}
 
 
-def _artifact_mission(path: Path) -> str | None:
-    """The mission fingerprint every document in this file carries, if they agree."""
+class ArtifactOwner(Enum):
+    """What a rendered file says about whose it is.
+
+    Four states, because the previous answer -- a fingerprint or `None` -- could
+    not tell them apart, and the caller that reconciles cluster-scoped artifacts
+    admits everything that answered `None`. A file holding one mission's Job
+    beside an unmissioned document answered the same as the priority-class
+    bundle, so an unrelated mission's --prune deleted it.
+    """
+
+    MISSION = "mission"
+    UNMISSIONED = "unmissioned"
+    MIXED = "mixed"
+    MALFORMED = "malformed"
+
+
+@dataclass(frozen=True)
+class ArtifactMission:
+    """The ownership answer, and the mission when there is exactly one."""
+
+    owner: ArtifactOwner
+    mission: str | None = None
+
+
+def _artifact_mission(path: Path) -> ArtifactMission:
+    """Which mission every document in this file agrees it belongs to.
+
+    Only MISSION and UNMISSIONED are answers a delete may act on. MIXED covers
+    both a file whose documents disagree and one where some name a mission and
+    some do not; MALFORMED covers a fingerprint that is not a name at all, which
+    used to reach `set()` and raise `TypeError: unhashable type: 'list'` from a
+    command that had already published.
+    """
     try:
+        if not stat.S_ISREG(path.lstat().st_mode):
+            # Same reason as _is_rendered_artifact, restated here because this
+            # function answers on its own for any caller: what a link points at
+            # says nothing about the entry a delete would remove.
+            return ArtifactMission(ArtifactOwner.MALFORMED)
         docs = [d for d in yaml.safe_load_all(path.read_text(encoding="utf-8"))]
     except Exception:  # noqa: BLE001 - unreadable is not ours; see _is_rendered_artifact
-        return None
-    missions = {
-        (d.get("metadata") or {}).get("labels", {}).get(MISSION_FINGERPRINT_LABEL)
+        return ArtifactMission(ArtifactOwner.MALFORMED)
+    labelsets = [
+        (d.get("metadata") or {}).get("labels") or {}
         for d in docs
         if isinstance(d, dict)
-    }
-    return missions.pop() if len(missions) == 1 else None
+    ]
+    # Presence is asked separately from value, because `.get` answers `None` both
+    # for a label that is absent and one written with no value. A present label
+    # has to be a name: anything else is refused rather than coerced, since the
+    # value is what a delete is keyed on. A list here used to reach `set()` and
+    # raise `TypeError: unhashable type`.
+    marks: list[Any] = []
+    for labels in labelsets:
+        if not isinstance(labels, dict) or MISSION_FINGERPRINT_LABEL not in labels:
+            marks.append(None)
+            continue
+        value = labels[MISSION_FINGERPRINT_LABEL]
+        if not isinstance(value, str) or not value.strip():
+            return ArtifactMission(ArtifactOwner.MALFORMED)
+        marks.append(value)
+    named = {m for m in marks if m is not None}
+    if not named:
+        return ArtifactMission(ArtifactOwner.UNMISSIONED)
+    if len(named) == 1 and len(named) == len(set(marks)):
+        return ArtifactMission(ArtifactOwner.MISSION, named.pop())
+    return ArtifactMission(ArtifactOwner.MIXED)
 
 
 def stale_rendered_artifacts(
@@ -1598,7 +1689,11 @@ def stale_rendered_artifacts(
     # it from `written` remains the fallback for callers that hold no plan.
     missions = (
         set(mission_ids) if mission_ids is not None
-        else {m for m in (_artifact_mission(p) for p in written) if m}
+        else {
+            found.mission
+            for found in (_artifact_mission(p) for p in written)
+            if found.owner is ArtifactOwner.MISSION and found.mission
+        }
     )
     if not missions and not include_unmissioned:
         return []
@@ -1632,10 +1727,7 @@ def stale_rendered_artifacts(
         # --emit-priority-classes off left the classes on disk for the next apply
         # to reinstate. A caller that writes such artifacts says so, and
         # `attribute_stale` still holds each renderer to the kinds only it emits.
-        and (
-            _artifact_mission(p) in missions
-            or (include_unmissioned and _artifact_mission(p) is None)
-        )
+        and _in_scope(_artifact_mission(p), missions, include_unmissioned)
     )
 
 
@@ -1713,7 +1805,17 @@ def preflight_writable(planned: list[tuple[Path, Any]]) -> None:
             continue
         theirs = _artifact_mission(path)
         ours = _rendered_mission(rendered)
-        if theirs != ours:
+        # Spelled out per state rather than compared as values. A file whose
+        # documents disagree, or whose fingerprint is not a name, answers
+        # neither yes nor no, and a replacement is a delete followed by a
+        # write.
+        if theirs.owner is ArtifactOwner.MISSION:
+            same_owner = theirs.mission == ours
+        elif theirs.owner is ArtifactOwner.UNMISSIONED:
+            same_owner = ours is None
+        else:
+            same_owner = False
+        if not same_owner:
             conflicts.append(f"{path} belongs to a different mission")
     if conflicts:
         raise ValueError(

--- a/tests/test_argo_lint_gate.py
+++ b/tests/test_argo_lint_gate.py
@@ -19,6 +19,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 from orbital_mission_compiler.cli import build_parser, cmd_render_argo
 from orbital_mission_compiler.compiler import (
@@ -1089,15 +1090,12 @@ def test_a_platform_without_fcntl_reports_the_unsupported_kind(tmp_path, monkeyp
 
 def test_an_unopenable_lock_reports_the_plain_unavailable_kind(tmp_path):
     """A lock file this process cannot open is one another process is holding."""
-    import hashlib
     import os
-    import tempfile
 
     from orbital_mission_compiler import cli
 
     out = tmp_path / "out"
-    digest = hashlib.sha256(os.path.realpath(out).encode("utf-8")).hexdigest()[:16]
-    lock = Path(tempfile.gettempdir()) / f"orbital-publish-{digest}.lock"
+    lock = cli.publish_lock_path(out)
     lock.write_text("")
     os.chmod(lock, 0o000)
     try:
@@ -1115,12 +1113,10 @@ def test_an_unopenable_lock_reports_the_plain_unavailable_kind(tmp_path):
 
 
 def _lock_path_for(out: Path) -> Path:
-    import hashlib
-    import os
-    import tempfile
+    """Asked of the code rather than recomputed, so it cannot drift from it."""
+    from orbital_mission_compiler import cli
 
-    digest = hashlib.sha256(os.path.realpath(out).encode("utf-8")).hexdigest()[:16]
-    return Path(tempfile.gettempdir()) / f"orbital-publish-{digest}.lock"
+    return cli.publish_lock_path(out)
 
 
 @pytest.mark.parametrize("umask", [0o022, 0o077])
@@ -1612,3 +1608,334 @@ def test_documents_are_read_the_way_kubectl_reads_them(tmp_path, name, body, exp
     (d / name).write_text(body, encoding="utf-8")
     problems = _unreadable_documents(d)
     assert bool(problems) is expect_reject, problems
+
+
+def _plan_that_renders_nothing(tmp_path: Path, source: str = VALID_PLAN) -> Path:
+    """The same mission, in a revision that legitimately produces no workload.
+
+    Reached by turning every event into a download with no services. Emptying an
+    acquisition event's services instead is refused by policy rule 3, and dropping
+    the events is refused by rule 2, so this is the one shape that is schema-valid,
+    policy-clean and renders nothing.
+    """
+    plan = yaml.safe_load(Path(source).read_text(encoding="utf-8"))
+    for event in plan["events"]:
+        event["event_type"] = "download"
+        event["services"] = []
+        event["ground_visibility"] = True
+        event.setdefault("duration_seconds", 30.0)
+        event.pop("instrument", None)
+    out = tmp_path / "renders-nothing.yaml"
+    out.write_text(yaml.safe_dump(plan, sort_keys=False), encoding="utf-8")
+    return out
+
+
+def test_prune_retires_the_last_artifact_when_the_plan_asks_for_none(tmp_path, capsys):
+    """An empty desired set is a state to reconcile, not an absence of scope.
+
+    The render before this one owned a Workflow. This revision of the same mission
+    owns nothing, so --prune has to retire it: what stays behind is deployable, and
+    `kubectl apply -f <dir>` would put back exactly the workload the plan dropped.
+    """
+    out = tmp_path / "out"
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--prune", "--policy-engine", "baseline",
+    ]))
+    capsys.readouterr()
+    previous = sorted(p.name for p in out.glob("*.yaml"))
+    assert previous, "the first render produced nothing to retire"
+
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", str(_plan_that_renders_nothing(tmp_path)),
+        "--output-dir", str(out), "--prune", "--policy-engine", "baseline",
+    ]))
+    report = json.loads(capsys.readouterr().out)
+
+    assert report["files"] == [], report
+    assert sorted(Path(p).name for p in report.get("pruned", [])) == previous, report
+    assert sorted(p.name for p in out.glob("*.yaml")) == [], sorted(out.iterdir())
+
+
+def test_gated_prune_retires_the_last_artifact_when_the_plan_asks_for_none(tmp_path, capsys):
+    """Nothing to lint is not a reason to leave the previous generation deployed.
+
+    The gate exits before it reaches the lock, so today the artifact the plan no
+    longer asks for survives a run that was asked to prune it.
+    """
+    out = tmp_path / "out"
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--prune", "--policy-engine", "baseline",
+    ]))
+    capsys.readouterr()
+    previous = sorted(p.name for p in out.glob("*.yaml"))
+    assert previous
+
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", str(_plan_that_renders_nothing(tmp_path)),
+        "--output-dir", str(out), "--argo-lint", "--prune",
+        "--policy-engine", "baseline",
+    ]))
+    report = json.loads(capsys.readouterr().out)
+
+    assert report["status"] == "ok", report
+    assert report["lint"] == "not-applicable", report
+    assert sorted(Path(p).name for p in report.get("pruned", [])) == previous, report
+    assert sorted(p.name for p in out.glob("*.yaml")) == []
+
+
+def test_prune_retires_the_priority_class_bundle_once_emission_stops(tmp_path, capsys):
+    """The bundle is cluster-scoped, which is not the same as unowned.
+
+    It carries no mission fingerprint, so mission-scoped stale detection cannot see
+    it, and turning --emit-priority-classes off leaves the classes on disk for the
+    next `kubectl apply` to reinstate.
+    """
+    from orbital_mission_compiler.cli import cmd_render_kueue
+
+    out = tmp_path / "out"
+    base = [
+        "render-kueue", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--priority-class", "--prune", "--policy-engine", "baseline",
+    ]
+    cmd_render_kueue(build_parser().parse_args(base + ["--emit-priority-classes"]))
+    capsys.readouterr()
+    bundle = out / "workload-priority-classes.yaml"
+    assert bundle.exists(), sorted(out.iterdir())
+
+    cmd_render_kueue(build_parser().parse_args(base))
+    report = json.loads(capsys.readouterr().out)
+
+    assert bundle.name in [Path(p).name for p in report.get("pruned", [])], report
+    assert not bundle.exists(), sorted(out.iterdir())
+
+
+OTHER_PLAN = "configs/mission_plans/sample_gpu_cpu_fallback.yaml"
+
+
+def test_an_empty_render_prunes_only_its_own_mission(tmp_path, capsys):
+    """The declared scope is what keeps an empty desired set from sweeping.
+
+    Deriving the scope from the input rather than from what was written is what
+    makes a render-nothing revision able to reconcile at all. The same change is
+    what could let it reconcile far too much: with no scope, or the wrong one, a
+    directory shared with another mission is a directory it would empty.
+    """
+    out = tmp_path / "shared"
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", OTHER_PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline",
+    ]))
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline",
+    ]))
+    capsys.readouterr()
+    before = sorted(p.name for p in out.glob("*.yaml"))
+    others = [n for n in before if "mission-alpha" not in n]
+    assert others, before
+
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", str(_plan_that_renders_nothing(tmp_path)),
+        "--output-dir", str(out), "--prune", "--policy-engine", "baseline",
+    ]))
+    report = json.loads(capsys.readouterr().out)
+
+    pruned = [Path(p).name for p in report.get("pruned", [])]
+    # Both halves. An empty prune satisfies "nothing of another mission's went"
+    # without reconciling anything, which is the bug this whole change is about.
+    assert pruned, report
+    assert all("mission-alpha" in n for n in pruned), pruned
+    remaining = sorted(p.name for p in out.glob("*.yaml"))
+    for name in others:
+        assert name in remaining, f"{name} belongs to another mission and was pruned"
+
+
+def test_an_empty_render_leaves_the_other_renderers_output_alone(tmp_path, capsys):
+    """An empty desired set is still only this renderer's desired set."""
+    from orbital_mission_compiler.cli import cmd_render_kueue
+
+    out = tmp_path / "shared"
+    cmd_render_kueue(build_parser().parse_args([
+        "render-kueue", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline",
+    ]))
+    capsys.readouterr()
+    kueue_files = sorted(p.name for p in out.glob("*.yaml"))
+    assert kueue_files
+
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", str(_plan_that_renders_nothing(tmp_path)),
+        "--output-dir", str(out), "--prune", "--policy-engine", "baseline",
+    ]))
+    report = json.loads(capsys.readouterr().out)
+
+    assert not report.get("pruned"), report
+    assert sorted(p.name for p in out.glob("*.yaml")) == kueue_files
+
+
+def test_claiming_the_bundle_does_not_let_kueue_prune_a_workflow(tmp_path, capsys):
+    """Claiming artifacts without a mission must not widen the renderer scope.
+
+    render-kueue now takes cluster-scoped artifacts into its stale scope so the
+    priority-class bundle can be retired. Attribution by exclusive kind is what
+    still has to keep it away from an Argo Workflow standing in the same
+    directory, whether or not that Workflow carries a mission.
+    """
+    from orbital_mission_compiler.cli import cmd_render_kueue
+
+    out = tmp_path / "shared"
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", OTHER_PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline",
+    ]))
+    capsys.readouterr()
+    workflows = sorted(p.name for p in out.glob("*.yaml"))
+    assert workflows
+
+    cmd_render_kueue(build_parser().parse_args([
+        "render-kueue", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--priority-class", "--prune", "--policy-engine", "baseline",
+    ]))
+    report = json.loads(capsys.readouterr().out)
+
+    assert not report.get("pruned"), report
+    for name in workflows:
+        assert (out / name).exists(), f"{name} is the other renderer's and was pruned"
+
+
+def test_the_lock_wait_outlasts_the_lint_it_is_held_across():
+    """Two constants in two modules that have to stay in step.
+
+    The gate takes the publish lock before it reads the destination and holds it
+    through `argo lint`. A default wait shorter than the linter's own budget makes
+    a second healthy writer give up while the first is still inside its allowance,
+    so contention reads as a failure on the defaults alone.
+    """
+    from orbital_mission_compiler.cli import _DEFAULT_LOCK_TIMEOUT
+    from orbital_mission_compiler.compiler import ARGO_LINT_TIMEOUT_SECONDS
+
+    assert _DEFAULT_LOCK_TIMEOUT >= ARGO_LINT_TIMEOUT_SECONDS, (
+        f"a writer waits {_DEFAULT_LOCK_TIMEOUT}s for a lock held across a lint "
+        f"allowed {ARGO_LINT_TIMEOUT_SECONDS}s"
+    )
+
+
+def test_a_symlinked_manifest_in_the_destination_is_refused(tmp_path, capsys):
+    """The gate cannot promise bytes it does not control.
+
+    A symlink is carried into the lint by its target's bytes, while the output
+    keeps the link. Whoever owns the target can replace it after the verdict, so
+    what gets applied is not what passed. The gate fails closed everywhere else;
+    it has to here too.
+    """
+    out = tmp_path / "out"
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline",
+    ]))
+    capsys.readouterr()
+    target = tmp_path / "elsewhere.yaml"
+    target.write_text((next(out.glob("*.yaml"))).read_text(encoding="utf-8"), encoding="utf-8")
+    link = out / "linked.yaml"
+    link.symlink_to(target)
+
+    with pytest.raises(SystemExit) as exit_info:
+        cmd_render_argo(build_parser().parse_args([
+            "render-argo", "--input", VALID_PLAN, "--output-dir", str(out),
+            "--argo-lint", "--argo-bin", str(_fake_argo(tmp_path, 0)),
+            "--policy-engine", "baseline",
+        ]))
+    report = json.loads(capsys.readouterr().out)
+
+    assert exit_info.value.code == 2, report
+    assert report["status"] == "error", report
+    assert report.get("reason") == "symlinked-manifest", report
+    assert link.is_symlink(), "the destination was modified by a refused render"
+
+
+def test_a_cleanup_failure_after_a_passing_lint_stays_structured(tmp_path, capsys, monkeypatch):
+    """Three outcomes a caller has to be able to tell apart.
+
+    The linter rejected. The linter could not reach a verdict. The linter passed
+    and something after it failed with the output untouched. Cleanup of the
+    carried copies runs after the verdict and outside the structured path, so an
+    unlink that fails there reports the third as a traceback.
+    """
+    out = tmp_path / "out"
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline",
+    ]))
+    capsys.readouterr()
+    # Carried, not staged: the gate only copies an existing manifest whose name
+    # this render does not itself produce, so a same-named file exercises nothing.
+    produced = next(out.glob("*.yaml"))
+    (out / "kept-under-another-name.yaml").write_text(
+        produced.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    before = {p.name: p.read_text(encoding="utf-8") for p in out.glob("*.yaml")}
+
+    real_unlink = Path.unlink
+
+    def refuse(self, *a, **k):
+        if ".argo-lint-staging-" in str(self):
+            raise OSError(13, "Permission denied")
+        return real_unlink(self, *a, **k)
+
+    monkeypatch.setattr(Path, "unlink", refuse)
+
+    with pytest.raises(SystemExit) as exit_info:
+        cmd_render_argo(build_parser().parse_args([
+            "render-argo", "--input", VALID_PLAN, "--output-dir", str(out),
+            "--argo-lint", "--argo-bin", str(_fake_argo(tmp_path, 0)),
+            "--policy-engine", "baseline",
+        ]))
+    report = json.loads(capsys.readouterr().out)
+
+    assert exit_info.value.code == 2, report
+    assert report["status"] == "error", report
+    assert report["lint"] == "passed", report
+    assert report.get("reason") == "staging-cleanup-failed", report
+    assert {p.name: p.read_text(encoding="utf-8") for p in out.glob("*.yaml")} == before
+
+
+def test_a_cleanup_failure_does_not_erase_a_lint_rejection(tmp_path, capsys, monkeypatch):
+    """A rejection is a verdict, and a failed cleanup does not unmake it.
+
+    Exit 1 says the linter rejected something and exit 2 says it never answered.
+    Reporting the rejection in the body while exiting 2 tells the caller both, and
+    the one that matters is the one CI reads.
+    """
+    out = tmp_path / "out"
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline",
+    ]))
+    capsys.readouterr()
+    produced = next(out.glob("*.yaml"))
+    (out / "kept-under-another-name.yaml").write_text(
+        produced.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    real_unlink = Path.unlink
+
+    def refuse(self, *a, **k):
+        if ".argo-lint-staging-" in str(self):
+            raise OSError(13, "Permission denied")
+        return real_unlink(self, *a, **k)
+
+    monkeypatch.setattr(Path, "unlink", refuse)
+
+    with pytest.raises(SystemExit) as exit_info:
+        cmd_render_argo(build_parser().parse_args([
+            "render-argo", "--input", VALID_PLAN, "--output-dir", str(out),
+            "--argo-lint", "--argo-bin", str(_fake_argo(tmp_path, 1)),
+            "--policy-engine", "baseline",
+        ]))
+    report = json.loads(capsys.readouterr().out)
+
+    assert exit_info.value.code == 1, report
+    assert report["lint"] == "failed", report
+    assert report.get("reason") == "staging-cleanup-failed", report

--- a/tests/test_argo_lint_gate.py
+++ b/tests/test_argo_lint_gate.py
@@ -1206,6 +1206,181 @@ def test_a_held_lock_times_out_instead_of_waiting_forever(tmp_path, capsys):
     assert not list(out.glob("*.yaml")), "nothing may be published without the lock"
 
 
+def test_an_explicit_lock_dir_excludes_where_the_default_would_not(tmp_path, monkeypatch):
+    """Two writers sharing the output volume and no other filesystem.
+
+    The default is a fixed path, which is one directory on a host and two inside
+    two containers, and nothing in the process can tell those apart. Making the
+    default answer differently per caller is what unshared means here. The control
+    is the same scenario with no flag: both writers enter, which is the failure,
+    and is also what says the flag is doing the excluding rather than the threads
+    being serialised by something else.
+    """
+    import itertools
+    import threading
+
+    from orbital_mission_compiler import cli
+
+    counter = itertools.count()
+
+    def unshared_default() -> str:
+        private = tmp_path / f"private{next(counter)}"
+        private.mkdir()
+        return str(private)
+
+    monkeypatch.setattr(cli, "_default_lock_dir", unshared_default)
+    out = tmp_path / "out"
+    out.mkdir()
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    def second_holder_blocks(lock_dir: str | None) -> bool:
+        entered = threading.Event()
+        release = threading.Event()
+
+        def second() -> None:
+            with cli._publish_lock(out, 10.0, lock_dir):
+                entered.set()
+                release.wait(timeout=10)
+
+        with cli._publish_lock(out, 10.0, lock_dir):
+            worker = threading.Thread(target=second)
+            worker.start()
+            blocked = not entered.wait(timeout=1.0)
+        assert entered.wait(timeout=10), "the second holder never took the lock"
+        release.set()
+        worker.join(timeout=10)
+        assert not worker.is_alive()
+        return blocked
+
+    assert not second_holder_blocks(None), (
+        "the control is meant to reproduce the split namespace; if it excludes, "
+        "the two writers are sharing something this test did not intend"
+    )
+    assert second_holder_blocks(str(shared)), "an explicit lock dir did not exclude"
+
+
+def test_render_argo_locks_where_lock_dir_points(tmp_path, capsys):
+    """Parsing the flag is not the same as the lock moving.
+
+    Held at the directory the flag names, the render gives up. Held at the default
+    while the flag names somewhere else, the same render goes through -- which is
+    what says the flag relocated the lock, rather than the two happening to be
+    serialised anyway.
+    """
+    from orbital_mission_compiler import cli
+
+    out = tmp_path / "out"
+    out.mkdir()
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    def render_args(*extra: str):
+        return build_parser().parse_args([
+            "render-argo", "--input", VALID_PLAN, "--output-dir", str(out),
+            "--policy-engine", "baseline", "--lock-timeout", "0.3", *extra,
+        ])
+
+    pointed_at_shared = render_args("--lock-dir", str(shared))
+    pointed_at_default = render_args()
+
+    with cli._publish_lock(out, 10.0, str(shared)):
+        with pytest.raises(SystemExit) as excinfo:
+            cmd_render_argo(pointed_at_shared)
+        assert excinfo.value.code == 2
+        refused = json.loads(capsys.readouterr().out)
+        assert refused["reason"] == "publish-lock-unavailable", refused
+        assert not list(out.glob("*.yaml")), "nothing may be published without the lock"
+
+        cmd_render_argo(pointed_at_default)
+        published = json.loads(capsys.readouterr().out)
+
+    assert published["status"] == "ok", published
+    assert list(out.glob("*.yaml"))
+
+
+@pytest.mark.parametrize("value", ["locks", "./locks", "../locks"], ids=["bare", "dot", "parent"])
+def test_a_relative_lock_dir_is_refused(value, capsys):
+    """A path resolved against the working directory cannot be the shared name.
+
+    The flag exists because two writers could not agree on a temp directory.
+    Letting them disagree about a working directory instead moves that failure
+    rather than removing it, and it fails the same silent way: two lock files,
+    both writers publishing. Refused where it is written, not resolved against
+    whichever directory this process happens to be in.
+
+    The message is read, not just the exit: argparse exits 2 for a flag it does
+    not recognise as readily as for one it rejects, so the status alone would
+    pass with no flag at all.
+    """
+    with pytest.raises(SystemExit):
+        build_parser().parse_args([
+            "render-argo", "--input", VALID_PLAN, "--output-dir", "out",
+            "--lock-dir", value,
+        ])
+    assert "is relative" in capsys.readouterr().err
+
+
+def test_render_kueue_honours_the_lock_dir_too(tmp_path, monkeypatch, capsys):
+    """A flag only half the writers read leaves the namespace split.
+
+    Both commands write the output root and both take the lock, so pointing one
+    of them at the shared directory and leaving the other on the default puts
+    them back on two files -- which is the state this flag exists to leave.
+    """
+    import contextlib
+
+    from orbital_mission_compiler import cli
+    from orbital_mission_compiler.cli import cmd_render_kueue
+
+    seen: list[str | None] = []
+
+    @contextlib.contextmanager
+    def _record(out_dir, lock_timeout, lock_dir=None):
+        seen.append(lock_dir)
+        yield
+
+    monkeypatch.setattr(cli, "_publish_lock", _record)
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    cmd_render_kueue(build_parser().parse_args([
+        "render-kueue", "--input", VALID_PLAN, "--output-dir", str(tmp_path / "kueue"),
+        "--policy-engine", "baseline", "--lock-dir", str(shared),
+    ]))
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", VALID_PLAN, "--output-dir", str(tmp_path / "argo"),
+        "--policy-engine", "baseline", "--lock-dir", str(shared),
+    ]))
+    capsys.readouterr()
+
+    assert seen == [str(shared), str(shared)]
+
+
+def test_a_lock_dir_that_cannot_hold_the_file_publishes_nothing(tmp_path, capsys):
+    """Failing closed matters more here than for the default.
+
+    The flag is set precisely when the operator knows the default is not shared,
+    so carrying on unlocked would drop the guarantee in the one case it was turned
+    on for.
+    """
+    out = tmp_path / "out"
+    not_a_directory = tmp_path / "occupied"
+    not_a_directory.write_text("")
+    args = build_parser().parse_args([
+        "render-argo", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline", "--lock-dir", str(not_a_directory),
+    ])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cmd_render_argo(args)
+
+    assert excinfo.value.code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reason"] == "publish-lock-unavailable", payload
+    assert not out.exists() or not list(out.glob("*.yaml"))
+
+
 def test_render_kueue_takes_the_same_lock_as_render_argo(tmp_path, monkeypatch, capsys):
     """Every writer of the output root, not only the Argo ones.
 

--- a/tests/test_argo_lint_gate.py
+++ b/tests/test_argo_lint_gate.py
@@ -1939,3 +1939,31 @@ def test_a_cleanup_failure_does_not_erase_a_lint_rejection(tmp_path, capsys, mon
     assert exit_info.value.code == 1, report
     assert report["lint"] == "failed", report
     assert report.get("reason") == "staging-cleanup-failed", report
+
+
+@pytest.mark.skipif(not ARGO_AVAILABLE, reason="needs the real argo CLI")
+def test_the_gate_does_not_semantically_validate_a_non_argo_kind(tmp_path, capsys):
+    """What the gate does not check, written down where it cannot be forgotten.
+
+    `argo lint` covers the Argo kinds and ignores the rest, so a Job that kubectl
+    refuses outright passes beside a valid Workflow. This renderer's own output
+    shares a directory with Kueue Jobs, which makes that gap worth a test rather
+    than a sentence: if a later Argo release starts rejecting these, this fails
+    and the help text can stop hedging.
+    """
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "broken-job.yaml").write_text(
+        "apiVersion: batch/v1\nkind: Job\nmetadata:\n  name: broken\n"
+        "spec:\n  template:\n    spec:\n      containers: \"not a list\"\n",
+        encoding="utf-8",
+    )
+
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--argo-lint", "--policy-engine", "baseline",
+    ]))
+    report = json.loads(capsys.readouterr().out)
+
+    assert report["lint"] == "passed", report
+    assert (out / "broken-job.yaml").exists()

--- a/tests/test_argo_lint_gate.py
+++ b/tests/test_argo_lint_gate.py
@@ -26,6 +26,7 @@ from orbital_mission_compiler.compiler import (
     ArgoLintUnavailable,
     PolicyViolationError,
     argo_lint_path,
+    stale_rendered_artifacts,
 )
 
 VALID_PLAN = "configs/mission_plans/sample_maritime_surveillance.yaml"
@@ -1884,6 +1885,122 @@ def test_prune_retires_the_priority_class_bundle_once_emission_stops(tmp_path, c
 
     assert bundle.name in [Path(p).name for p in report.get("pruned", [])], report
     assert not bundle.exists(), sorted(out.iterdir())
+
+
+def test_retiring_the_shared_bundle_is_announced(tmp_path, capsys):
+    """Two missions in one directory get a message, and the message is all they get.
+
+    Nothing stops the second render removing classes the first mission's Jobs
+    still name: the bundle carries no fingerprint, so the filter that keeps one
+    mission's --prune away from another's files cannot reach it. Saying so on
+    stderr is the whole of what is on offer, which is what makes it worth pinning
+    -- deleting the message leaves behaviour that is correct for the render doing
+    it and invisible to everyone else.
+    """
+    from orbital_mission_compiler.cli import cmd_render_kueue
+
+    out = tmp_path / "shared"
+    cmd_render_kueue(build_parser().parse_args([
+        "render-kueue", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline", "--emit-priority-classes",
+    ]))
+    capsys.readouterr()
+    assert (out / "workload-priority-classes.yaml").exists()
+
+    cmd_render_kueue(build_parser().parse_args([
+        "render-kueue", "--input", OTHER_PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline", "--prune",
+    ]))
+    warning = capsys.readouterr().err
+
+    assert "workload-priority-classes.yaml" in warning, warning
+    assert "--emit-priority-classes" in warning, "the message has to say how to put them back"
+    assert not (out / "workload-priority-classes.yaml").exists()
+
+
+def test_retiring_only_this_mission_s_own_files_is_not_announced(tmp_path, capsys):
+    """The control, so the warning is attributable to what it claims to be about.
+
+    A prune that removes a mission's own stale artifact touches nothing another
+    mission could be relying on, and a message on every prune would be one
+    operators learn to scroll past.
+    """
+    from orbital_mission_compiler.cli import cmd_render_kueue
+
+    out = tmp_path / "out"
+    argv = [
+        "render-kueue", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline", "--emit-priority-classes",
+    ]
+    cmd_render_kueue(build_parser().parse_args(argv))
+    capsys.readouterr()
+    # A stale artifact of this same mission: the render's own output under a name
+    # the next render will not write, so it carries the fingerprint and is in scope.
+    job = next(p for p in out.glob("*-kueue.yaml"))
+    (out / "left-over-kueue.yaml").write_text(job.read_text(encoding="utf-8"), encoding="utf-8")
+
+    cmd_render_kueue(build_parser().parse_args(argv + ["--prune"]))
+    captured = capsys.readouterr()
+
+    assert "left-over-kueue.yaml" in json.dumps(json.loads(captured.out).get("pruned", [])), \
+        "the control has to actually prune something, or it proves nothing"
+    assert "cluster-scoped" not in captured.err, captured.err
+    assert (out / "workload-priority-classes.yaml").exists()
+
+
+def test_render_argo_prune_leaves_the_priority_class_bundle_alone(tmp_path, capsys):
+    """The Argo renderer never retires the cluster-scoped bundle.
+
+    Two things keep it off and either is sufficient: it does not claim
+    unmissioned artifacts, so the bundle never enters its stale set, and the
+    bundle's kinds are not its to attribute even if it did. Measured: removing
+    one leaves this passing and removing both fails it, which is the same
+    boundary as the bundle surviving. Pinned at the outcome deliberately, since
+    that is what the other renderer depends on and either mechanism may be the
+    one that changes.
+    """
+    from orbital_mission_compiler.cli import cmd_render_kueue
+
+    out = tmp_path / "shared"
+    cmd_render_kueue(build_parser().parse_args([
+        "render-kueue", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline", "--emit-priority-classes",
+    ]))
+    bundle = out / "workload-priority-classes.yaml"
+    assert bundle.exists()
+
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline", "--prune",
+    ]))
+    capsys.readouterr()
+
+    assert bundle.exists(), "render-argo pruned an artifact only render-kueue emits"
+
+
+def test_unmissioned_artifacts_stay_in_scope_with_no_missions_declared(tmp_path, capsys):
+    """`include_unmissioned` is not a modifier on a non-empty mission list.
+
+    The early return exists to stop a render with no scope sweeping the
+    directory. A caller reconciling only the cluster-scoped artifacts declares no
+    missions on purpose, and that return would otherwise read it as nothing to do.
+    """
+    from orbital_mission_compiler.cli import cmd_render_kueue
+
+    out = tmp_path / "out"
+    cmd_render_kueue(build_parser().parse_args([
+        "render-kueue", "--input", VALID_PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline", "--emit-priority-classes",
+    ]))
+    capsys.readouterr()
+
+    with_unmissioned = stale_rendered_artifacts(
+        out, [], mission_ids=set(), include_unmissioned=True
+    )
+    without = stale_rendered_artifacts(out, [], mission_ids=set())
+
+    assert [p.name for p in with_unmissioned] == ["workload-priority-classes.yaml"]
+    assert without == []
 
 
 OTHER_PLAN = "configs/mission_plans/sample_gpu_cpu_fallback.yaml"

--- a/tests/test_argo_lint_gate.py
+++ b/tests/test_argo_lint_gate.py
@@ -1887,6 +1887,111 @@ def test_prune_retires_the_priority_class_bundle_once_emission_stops(tmp_path, c
     assert not bundle.exists(), sorted(out.iterdir())
 
 
+
+def test_an_empty_prune_only_run_needs_no_linter(tmp_path, capsys):
+    """It runs no linter, so it must not depend on one.
+
+    The verdict for this branch is not-applicable: nothing was linted because
+    there was nothing to lint. Resolving the Argo binary first made retiring a
+    previous generation fail on a tool that would never have been invoked.
+    """
+    from orbital_mission_compiler import cli
+
+    out = tmp_path / "out"
+    cmd_render_argo(_render_argo_args(VALID_PLAN, out))
+    capsys.readouterr()
+    assert list(out.glob("*.yaml"))
+
+    empty = _plan_that_renders_nothing(tmp_path)
+    args = build_parser().parse_args([
+        "render-argo", "--input", str(empty), "--output-dir", str(out),
+        "--policy-engine", "baseline", "--prune", "--argo-lint",
+        "--argo-bin", str(tmp_path / "no-such-argo"),
+    ])
+    cli.cmd_render_argo(args)
+    report = json.loads(capsys.readouterr().out)
+
+    assert report["status"] == "ok" and report["lint"] == "not-applicable", report
+    assert list(out.glob("*.yaml")) == [], "the previous generation should be retired"
+
+
+def test_an_empty_run_without_prune_still_needs_the_linter(tmp_path, capsys):
+    """The control for the reordering.
+
+    Without --prune the command publishes nothing and verifies nothing, and
+    reporting a lint that never ran is what the CLI check is there to prevent.
+    """
+    from orbital_mission_compiler import cli
+
+    out = tmp_path / "out"
+    empty = _plan_that_renders_nothing(tmp_path)
+    args = build_parser().parse_args([
+        "render-argo", "--input", str(empty), "--output-dir", str(out),
+        "--policy-engine", "baseline", "--argo-lint",
+        "--argo-bin", str(tmp_path / "no-such-argo"),
+    ])
+    with pytest.raises(SystemExit) as excinfo:
+        cli.cmd_render_argo(args)
+
+    assert excinfo.value.code == 2
+    assert json.loads(capsys.readouterr().out)["lint"] == "unavailable"
+
+
+@pytest.mark.parametrize(
+    "command,extra",
+    [("render-argo", []), ("render-argo", ["--argo-lint"]), ("render-kueue", [])],
+    ids=["ungated", "gated", "kueue"],
+)
+def test_a_scan_that_fails_after_publishing_says_the_output_changed(
+    command, extra, tmp_path, monkeypatch, capsys
+):
+    """The third outcome, which used to be a traceback or a false rollback.
+
+    The manifests are live by the time the directory is read back. Escaping as
+    an OSError tells the caller nothing; reporting it through the publish
+    handler tells them the directory was restored, which it was not.
+    """
+    from orbital_mission_compiler import cli
+
+    out = tmp_path / "out"
+    exe = _fake_argo(tmp_path, 0)
+    argv = [
+        command, "--input", VALID_PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline", *extra,
+    ]
+    if "--argo-lint" in extra:
+        argv += ["--argo-bin", str(exe)]
+    runner = cli.cmd_render_kueue if command == "render-kueue" else cmd_render_argo
+    runner(build_parser().parse_args(argv))
+    capsys.readouterr()
+
+    # The gated path scans twice: once before the lint, to know which files are
+    # leaving, and once after publishing. Only the second is the phase under
+    # test -- failing the first is a snapshot failure, which this path already
+    # reports as its own thing, and letting it through is what proves the two
+    # are told apart.
+    real_scan = cli.stale_rendered_artifacts
+    survives = 1 if "--argo-lint" in extra else 0
+    seen = {"n": 0}
+
+    def unreadable(*a, **k):
+        seen["n"] += 1
+        if seen["n"] <= survives:
+            return real_scan(*a, **k)
+        raise PermissionError(13, "Permission denied", str(out))
+
+    monkeypatch.setattr(cli, "stale_rendered_artifacts", unreadable)
+    with pytest.raises(SystemExit) as excinfo:
+        runner(build_parser().parse_args([*argv, "--prune"]))
+
+    assert excinfo.value.code == 2
+    report = json.loads(capsys.readouterr().out)
+    assert report["reason"] == "stale-scan-failed", report
+    assert report["output_modified"] is True, report
+    assert "rolled back" not in report["message"], report
+    assert report["files"], "the caller has to learn what did get published"
+    assert seen["n"] == survives + 1, "the post-publish scan is the one under test"
+
 def test_retiring_the_shared_bundle_is_announced(tmp_path, capsys):
     """Two missions in one directory get a message, and the message is all they get.
 

--- a/tests/test_artifact_ownership.py
+++ b/tests/test_artifact_ownership.py
@@ -1,0 +1,150 @@
+"""Who a file in the output directory belongs to, when the answer is not one mission.
+
+`--prune` deletes, so the question it asks has to be answerable. Inferring the
+answer from a fingerprint that is either a mission or `None` cannot distinguish
+"no document names a mission" from "some do and some do not", from "two名 disagree",
+from "the label is not even a string" -- and the caller that reconciles
+cluster-scoped artifacts admits everything that answered `None`.
+
+Each case here was reproduced against the previous model before being written.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from orbital_mission_compiler.compiler import (
+    ArtifactOwner,
+    _artifact_mission,
+    _is_rendered_artifact,
+    stale_rendered_artifacts,
+)
+
+MANAGED = "app.kubernetes.io/managed-by: orbital-mission-compiler"
+
+
+def _doc(kind: str, name: str, mission: str | None, raw_label: str | None = None) -> str:
+    label = ""
+    if raw_label is not None:
+        label = f"    orbital/mission-fingerprint:\n{raw_label}\n"
+    elif mission is not None:
+        label = f"    orbital/mission-fingerprint: {mission}\n"
+    return (
+        f"apiVersion: v1\nkind: {kind}\nmetadata:\n  name: {name}\n  labels:\n"
+        f"    {MANAGED}\n{label}"
+    )
+
+
+def _write(tmp_path: Path, name: str, *docs: str) -> Path:
+    path = tmp_path / name
+    path.write_text("---\n".join(docs), encoding="utf-8")
+    return path
+
+
+def test_every_document_naming_one_mission_is_that_mission(tmp_path):
+    path = _write(tmp_path, "one.yaml", _doc("Job", "a", "aaaa"), _doc("Job", "b", "aaaa"))
+    result = _artifact_mission(path)
+    assert result.owner is ArtifactOwner.MISSION
+    assert result.mission == "aaaa"
+
+
+def test_no_document_naming_a_mission_is_unmissioned(tmp_path):
+    path = _write(tmp_path, "global.yaml", _doc("WorkloadPriorityClass", "w", None))
+    assert _artifact_mission(path).owner is ArtifactOwner.UNMISSIONED
+
+
+def test_one_missioned_document_beside_an_unmissioned_one_is_mixed(tmp_path):
+    """The case that lost data.
+
+    `render-kueue` admits unmissioned files into its global reconciliation, and
+    this file answered `None` exactly like the cluster-scoped bundle does, so an
+    unrelated mission's --prune deleted a Job belonging to someone else.
+    """
+    path = _write(
+        tmp_path, "mixed.yaml",
+        _doc("Job", "j", "aaaa"),
+        _doc("WorkloadPriorityClass", "w", None),
+    )
+    assert _artifact_mission(path).owner is ArtifactOwner.MIXED
+
+
+def test_two_missions_in_one_file_is_mixed(tmp_path):
+    path = _write(tmp_path, "two.yaml", _doc("Job", "a", "aaaa"), _doc("Job", "b", "bbbb"))
+    assert _artifact_mission(path).owner is ArtifactOwner.MIXED
+
+
+@pytest.mark.parametrize(
+    "raw_label",
+    ["      - a list", "      a: mapping", "      "],
+    ids=["list", "mapping", "empty"],
+)
+def test_a_fingerprint_that_is_not_a_name_is_malformed(raw_label, tmp_path):
+    """A list used to reach `set()` and raise TypeError: unhashable type.
+
+    That surfaced as a traceback from a command that had usually already
+    published, so the caller got no report and no exit code it could branch on.
+    """
+    path = _write(tmp_path, "bad.yaml", _doc("Job", "j", None, raw_label=raw_label))
+    assert _artifact_mission(path).owner is ArtifactOwner.MALFORMED
+
+
+def test_only_the_unmissioned_state_joins_global_reconciliation(tmp_path):
+    """Mixed and malformed files stay, and stay visible.
+
+    Erring toward a file that survives is the right direction for a delete.
+    """
+    _write(tmp_path, "global.yaml", _doc("WorkloadPriorityClass", "w", None))
+    _write(tmp_path, "mixed.yaml", _doc("Job", "j", "aaaa"), _doc("Job", "w", None))
+    _write(tmp_path, "malformed.yaml", _doc("Job", "j", None, raw_label="      - a list"))
+
+    stale = stale_rendered_artifacts(tmp_path, [], mission_ids=set(), include_unmissioned=True)
+
+    assert [p.name for p in stale] == ["global.yaml"]
+
+
+def test_a_symlink_is_never_this_compiler_s_artifact(tmp_path):
+    """Classified from the target's bytes, then unlinked as the link.
+
+    `path.is_file()` follows the link, so an operator's symlink pointing at a
+    managed file was read as managed and removed by --prune, destroying the link
+    and leaving the file it named.
+    """
+    target = tmp_path / "target.yaml"
+    target.write_text(_doc("Job", "j", "aaaa"), encoding="utf-8")
+    link = tmp_path / "link.yaml"
+    link.symlink_to(target)
+
+    assert _is_rendered_artifact(target)
+    assert not _is_rendered_artifact(link)
+    assert _artifact_mission(link).owner is not ArtifactOwner.MISSION
+
+
+def test_prune_does_not_reach_a_symlink(tmp_path):
+    """The end of the same story, at the level that does the deleting."""
+    out = tmp_path / "out"
+    out.mkdir()
+    target = tmp_path / "elsewhere.yaml"
+    target.write_text(_doc("Job", "j", "aaaa"), encoding="utf-8")
+    (out / "link.yaml").symlink_to(target)
+
+    stale = stale_rendered_artifacts(out, [], mission_ids={"aaaa"})
+
+    assert stale == []
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="no mkfifo on this platform")
+def test_a_named_pipe_is_not_read(tmp_path):
+    """Reading it would block while the publish lock is held.
+
+    The old guard got this right through `is_file()`; the replacement has to keep
+    it, which is why the check is for a regular file rather than "not a link".
+    """
+    fifo = tmp_path / "pipe.yaml"
+    os.mkfifo(fifo)
+    assert stat.S_ISFIFO(fifo.lstat().st_mode)
+
+    assert not _is_rendered_artifact(fifo)


### PR DESCRIPTION
## Why

Reviewing what #77 through #80 actually left on main turned up three gaps that share one cause: ownership was inferred from the files a render had written, rather than declared from the plan it was given. A set of files cannot express "this mission now owns nothing", and it cannot express "this artifact belongs to no mission at all", so both cases fell out of `--prune`'s reach and the directory kept serving a workload the plan had dropped.

The publish lock had the mirror-image problem one level down. Its key was right — the canonical output path — and its namespace was not, so two writers could agree on which directory they were fighting over and still take different locks.

## What

Four commits, each reviewable on its own.

**`15c66b6` reconcile from the declared desired set, and lock where writers can see it.** `stale_rendered_artifacts` takes the missions from the plan instead of reading them back off what was written, so a revision that legitimately renders nothing now has a scope to reconcile against and the gated path treats it as a prune-only transaction. Reaching that state is narrow enough to be worth recording: emptying an acquisition event's services is refused by policy rule 3 and dropping the events by rule 2, so only an all-downloads plan gets there, and the test says so.

The cluster-scoped priority-class bundle carries no mission fingerprint, so mission scoping alone could never retire it; it is claimed by the renderer that writes it. Two missions sharing an output directory now share that bundle, and the second render removing it is correct for its own desired set while leaving the first mission's Jobs pointing at classes that are gone — said on stderr rather than done quietly. The durable answer is still open; it is tracked outside this repository's issue tracker for now.

The lock moved out of `tempfile.gettempdir()`, which reads TMPDIR: two renders of one output directory under different TMPDIR values took two lock files of the same name in different directories and both entered publication at once, measured with timestamps. Three smaller ones on the same path go with it — a symlinked manifest was linted by its target's bytes while the output kept the link, the lock wait defaulted to 30s while the lint it is held across is allowed 120s, and a cleanup failure after a rejection could exit 2 and erase the rejection.

**`4dee083` say what the gate lints and what it only reads.** It described itself as accepting the whole set. Every document is parsed and checked for the envelope kubectl requires, but semantic linting is `argo lint`, which covers four Argo kinds and ignores the rest. Measured on v4.0.8: a Job whose `containers` is a string, which kubectl refuses outright, lints clean beside a valid Workflow and the directory is reported as passed. This renderer shares a directory with Kueue Jobs, so the gap is not hypothetical here. A test pins the behaviour, so if a later Argo release starts rejecting these the hedging can come back out.

**`15ba698` move the actions off the Node 20 runtime.** `checkout@v4`, `setup-python@v5` and `cache@v4` are what the deprecation warning on every job is about; their first majors on node24 are v5, v6 and v5. One major each rather than the current latest, since the further jumps cross release notes I cannot exercise from here. `codecov-action` is left alone: at v5 it is already a composite action, so it was never part of this warning.

**`77d2a1a` let the operator name the directory holding the publish lock.** The fixed path settles two renders on one host. It settles nothing for two containers that mount the same output volume and share no other filesystem, where that path names a directory inside each of them. No default can invent a filesystem they have in common, so `--lock-dir` does it explicitly; a relative path is refused rather than resolved, because writers that could not agree on a temp directory have no more reason to agree on a working directory. Two things the flag cannot check are in the help rather than implied away: the lock is named after the output path, so one volume reached at two mount points is two locks again, and the sticky bit that protects the file on the default is the operator's to provide on a directory they choose.

## Verification

Every gap was reproduced as a failing test before the model changed, and every new assertion was then checked against a mutation, because an assertion that cannot fail is worse than none.

The lock work is observed rather than recomputed: one holder is taken and the other watched to block, and the control — the same scenario with no `--lock-dir` under a per-caller default — reproduces the split, so the exclusion is attributable to the flag rather than to the threads. The mutations run were dropping the argument at either render path and removing the absoluteness check; each fails the test that names it.

`pytest` 904 passed, 1 skipped. `ruff` clean, `mypy` clean over `src/orbital_mission_compiler`, 15 goldens pass. The IR-level golden corpus is untouched by design: it pins the compiled intent, not the rendered YAML.

## Open questions this does not settle

Two questions have to be decided together, and neither has an issue here yet. Staging and backup are created under the published root when the output directory already exists, so a recursive reader can see manifests before the verdict; and the ungated path takes the lock but still writes file by file, so a failure part-way leaves a half-updated generation. Routing the ungated path through staging is the appealing answer to the second and makes the first worse, so the publication layout comes first.

