### PR TITLE
answer for an input the compiler cannot use instead of raising

### DIFF
--- a/src/orbital_mission_compiler/cli.py
+++ b/src/orbital_mission_compiler/cli.py
@@ -21,6 +21,8 @@ from .compiler import (
     ARGO_LINT_TIMEOUT_SECONDS,
     DEFAULT_POLICY_BUNDLE,
     DEFAULT_POLICY_DECISION,
+    MissionPlanInvalid,
+    MissionPlanUnreadable,
     PolicyEngineUnavailableError,
     PolicyViolationError,
     compile_file,
@@ -47,6 +49,7 @@ from .compiler import (
     sanitize_k8s_name,
     ORCHIDE_PRIORITY_CLASS_PREFIX,
 )
+from .schemas import MissionPlan
 from .policy import eval_policy
 
 _UNSAFE_SKIP_POLICY_HELP = (
@@ -127,14 +130,19 @@ ARGO_EXCLUSIVE_KINDS = {"Workflow"}
 KUEUE_EXCLUSIVE_KINDS = {"Job", "WorkloadPriorityClass"}
 
 
-def _render_scope(source: str | Path) -> frozenset[str]:
-    """The missions this render reconciles, taken from the plan.
+def _scope_of(plan: MissionPlan) -> frozenset[str]:
+    """The missions a render of this plan reconciles.
 
-    Read from the input rather than from what was written, so a revision that
+    Taken from the plan rather than from what was written, so a revision that
     legitimately renders nothing still has a scope to reconcile against. The
     fingerprint is what the artifacts carry, so that is what the scope holds.
     """
-    return frozenset({mission_fingerprint(load_mission_plan(source).mission_id)})
+    return frozenset({mission_fingerprint(plan.mission_id)})
+
+
+def _render_scope(source: str | Path) -> frozenset[str]:
+    """The same, for a command that has not loaded the plan yet."""
+    return _scope_of(load_mission_plan(source))
 
 
 def _report_stale(
@@ -469,6 +477,12 @@ def cmd_render_argo(args: argparse.Namespace) -> None:
     if args.argo_lint:
         _render_argo_with_lint_gate(args)
         return
+    # Read before anything is written, and once. The report for an input this
+    # command cannot use says the run never started, and that has to be true when
+    # it is printed: read after the render instead, the same failure arrives with
+    # manifests already on disk and the report denies it. Once, because three
+    # reads of one file are three chances for it to answer differently.
+    scope = _render_scope(args.input)
     # The same lock the gate takes. Without it an ungated render can replace files
     # in the directory a gated run has just snapshotted and linted and is about to
     # publish into, and the gate's verdict would then describe a directory that no
@@ -508,7 +522,7 @@ def cmd_render_argo(args: argparse.Namespace) -> None:
         try:
             _report_stale(
                 result, args.output_dir, written, args.prune, ARGO_EXCLUSIVE_KINDS,
-                mission_ids=_render_scope(args.input),
+                mission_ids=scope,
             )
         except PruneIncomplete as exc:
             print(json.dumps(_prune_failure_report(exc, written), indent=2))
@@ -1007,7 +1021,8 @@ def _publish(
 
 
 def _reconcile_empty_render(
-    args: argparse.Namespace, out_dir: Path, lock_stack: contextlib.ExitStack
+    args: argparse.Namespace, out_dir: Path, lock_stack: contextlib.ExitStack,
+    scope: Collection[str],
 ) -> None:
     """A plan that renders nothing, asked to make the directory match it.
 
@@ -1028,7 +1043,7 @@ def _reconcile_empty_render(
     try:
         _report_stale(
             empty_result, args.output_dir, [], args.prune, ARGO_EXCLUSIVE_KINDS,
-            mission_ids=_render_scope(args.input),
+            mission_ids=scope,
         )
     except PruneIncomplete as exc:
         print(json.dumps(_prune_failure_report(exc, []), indent=2))
@@ -1059,6 +1074,10 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
     nothing -- a download-only plan is schema-valid and passes the policy layer --
     and an empty render must not be able to report a lint that never ran.
     """
+    # Before the staging directory exists, for the same reason the ungated path
+    # reads it before rendering: an input this command cannot use has to be
+    # refused while there is still nothing to explain away.
+    scope = _render_scope(args.input)
     out_dir = Path(args.output_dir)
     staging = Path(tempfile.mkdtemp(
         prefix=".argo-lint-staging-", dir=_nearest_existing_ancestor(out_dir)
@@ -1075,7 +1094,7 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
         # desired set runs no linter at all, so requiring the binary there made
         # cleanup depend on a tool it never invokes.
         if not written and args.prune:
-            _reconcile_empty_render(args, out_dir, lock_stack)
+            _reconcile_empty_render(args, out_dir, lock_stack, scope)
             return
 
         try:
@@ -1147,7 +1166,7 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
                         p.name
                         for p in attribute_stale(
                             stale_rendered_artifacts(
-                                out_dir, written, mission_ids=_render_scope(args.input),
+                                out_dir, written, mission_ids=scope,
                             ),
                             ARGO_EXCLUSIVE_KINDS,
                         )[0]
@@ -1270,7 +1289,7 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
             try:
                 _report_stale(
                     result_stale, args.output_dir, published, args.prune,
-                    ARGO_EXCLUSIVE_KINDS, mission_ids=_render_scope(args.input),
+                    ARGO_EXCLUSIVE_KINDS, mission_ids=scope,
                 )
             except PruneIncomplete:
                 # An OSError subclass, and a different phase: the scan finished
@@ -1362,6 +1381,9 @@ def cmd_inspect(args: argparse.Namespace) -> None:
 
 def cmd_render_kueue(args: argparse.Namespace) -> None:
     plan = load_mission_plan(args.input)
+    # From the plan in hand. Reading the file again to answer a question this
+    # object already answers is how the two come to disagree.
+    scope = _scope_of(plan)
     if not args.unsafe_skip_policy:
         enforce_policy_or_raise(
             plan, engine=args.policy_engine, bundle=args.bundle, decision=args.decision
@@ -1513,7 +1535,7 @@ def cmd_render_kueue(args: argparse.Namespace) -> None:
         try:
             _report_stale(
                 stale_result, args.output_dir, written, args.prune,
-                KUEUE_EXCLUSIVE_KINDS, mission_ids=_render_scope(args.input),
+                KUEUE_EXCLUSIVE_KINDS, mission_ids=scope,
                 include_unmissioned=True,
             )
         except PruneIncomplete as exc:
@@ -1627,6 +1649,39 @@ def main() -> None:
     args = parser.parse_args()
     try:
         args.func(args)
+    except MissionPlanUnreadable as exc:
+        # The run never started, which is the family policy_engine_unavailable is
+        # in. Exit 2 rather than 1 because 1 is a verdict everywhere else on this
+        # path -- a policy denial, a lint rejection -- and a caller branching on
+        # the contract read a missing file as one.
+        print(
+            json.dumps(
+                {
+                    "status": "error",
+                    "reason": "input_unreadable",
+                    "error": str(exc),
+                    "hint": "check the --input path exists, is a file, and is readable",
+                }
+            ),
+            file=sys.stderr,
+        )
+        raise SystemExit(2) from exc
+    except MissionPlanInvalid as exc:
+        # Read and refused, which is a verdict: the same kind of answer as the
+        # policy layer refusing a plan it understood, and the same exit code.
+        # Reported before any artifact exists, so there is nothing to roll back.
+        print(
+            json.dumps(
+                {
+                    "status": "error",
+                    "reason": "input_invalid",
+                    "error": str(exc),
+                    "hint": "validate the plan against docs/ and configs/mission_plans/",
+                }
+            ),
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from exc
     except PolicyViolationError as exc:
         # Fail closed: a denied plan produces no artifact and a non-zero exit.
         # Emit the TYPED violations (rule/severity/provenance/path/message) so a

--- a/src/orbital_mission_compiler/compiler.py
+++ b/src/orbital_mission_compiler/compiler.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import yaml
+from pydantic import ValidationError
 
 from .schemas import MissionPlan, WorkflowIntent, ResourceClass, WorkflowStep
 
@@ -289,9 +290,52 @@ class _StrictLoader(yaml.SafeLoader):
         return [n for n in candidates if isinstance(n, yaml.MappingNode)]
 
 
+class MissionPlanError(ValueError):
+    """An input the compiler cannot take as a mission plan.
+
+    A ValueError, because that is what a schema rejection has always been here
+    and callers catching it should keep catching it. The two subclasses split
+    where the compiler's own answer splits, and the CLI maps that split onto its
+    exit codes.
+    """
+
+
+class MissionPlanUnreadable(MissionPlanError):
+    """The bytes never arrived: absent, a directory, a broken link, no rights."""
+
+
+class MissionPlanInvalid(MissionPlanError):
+    """The bytes arrived and are not a mission plan."""
+
+
 def load_mission_plan(path: str | Path) -> MissionPlan:
-    raw = yaml.load(Path(path).read_text(encoding="utf-8"), Loader=_StrictLoader)  # noqa: S506
-    return MissionPlan.model_validate(raw)
+    """The one place a plan is read, and so the one place to type the failures.
+
+    Every command reaches a plan through here, directly or through
+    `_load_or_accept_plan`, and each of the three steps below fails in its own
+    library's vocabulary: OSError, yaml.YAMLError, pydantic.ValidationError.
+    Left as they are those reach the CLI as a traceback and exit 1 -- which in
+    the gated render is the code that means the linter rejected something, so a
+    missing file read as a rejected manifest. Named here instead, keeping the
+    original message, which is where the strict loader says which key was
+    duplicated.
+    """
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise MissionPlanUnreadable(f"{path} could not be read: {exc}") from exc
+    except UnicodeDecodeError as exc:
+        # Not an OSError: the file opened and its bytes are not text. Grouped
+        # with the invalid ones, since reading it is what found that out.
+        raise MissionPlanInvalid(f"{path} is not UTF-8 text: {exc}") from exc
+    try:
+        raw = yaml.load(text, Loader=_StrictLoader)  # noqa: S506
+    except yaml.YAMLError as exc:
+        raise MissionPlanInvalid(f"{path} is not valid YAML: {exc}") from exc
+    try:
+        return MissionPlan.model_validate(raw)
+    except ValidationError as exc:
+        raise MissionPlanInvalid(f"{path} is not a valid mission plan: {exc}") from exc
 
 
 def analyze_timeline_conflicts(plan: MissionPlan) -> dict[str, Any]:

--- a/tests/test_input_contract.py
+++ b/tests/test_input_contract.py
@@ -1,0 +1,182 @@
+"""What every command promises when the plan it was given cannot be used.
+
+The commands promise a machine-readable report and a documented exit code, and
+callers branch on both: `validate_live_cluster.sh` reads the JSON, and the gated
+render distinguishes "rejected" (1) from "could not run" (2). An input the
+compiler cannot take escaped both -- a traceback, an empty stdout, and exit 1,
+which in the gated path is the code that means the linter rejected something.
+
+Split where the compiler's own answer splits. A file it cannot read is a run
+that never started, which is the family `policy_engine_unavailable` is in and
+exits 2. A file it read and refused is a verdict, which is the family a policy
+denial is in and exits 1.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from orbital_mission_compiler.cli import main
+
+GOOD_PLAN = Path("configs/mission_plans/sample_maritime_surveillance.yaml")
+
+# Reading a mode-000 file succeeds for root, so the shape under test does not
+# exist there. Skipped rather than quietly asserted, which would pass for the
+# wrong reason wherever tests run in a root container.
+_IS_ROOT = hasattr(os, "geteuid") and os.geteuid() == 0
+
+
+def _plan(tmp_path: Path, shape: str) -> Path:
+    target = tmp_path / f"{shape}.yaml"
+    if shape == "missing":
+        return tmp_path / "no-such-plan.yaml"
+    if shape == "directory":
+        target.mkdir()
+    elif shape == "unreadable":
+        target.write_text(GOOD_PLAN.read_text(encoding="utf-8"), encoding="utf-8")
+        target.chmod(0o000)
+    elif shape == "dangling link":
+        target.symlink_to(tmp_path / "nothing-here.yaml")
+    elif shape == "unparseable":
+        target.write_text("events:\n  - [unclosed\n", encoding="utf-8")
+    elif shape == "not a mapping":
+        target.write_text("- just\n- a\n- list\n", encoding="utf-8")
+    elif shape == "empty":
+        target.write_text("", encoding="utf-8")
+    elif shape == "schema invalid":
+        target.write_text("mission_id: x\nevents: []\n", encoding="utf-8")
+    else:  # pragma: no cover - a shape added to the table and not to the builder
+        raise AssertionError(f"unknown shape {shape!r}")
+    return target
+
+
+def _argv(command: str, plan: Path, out: Path) -> list[str]:
+    common = ["--input", str(plan), "--policy-engine", "baseline"]
+    if command == "render-argo":
+        return ["render-argo", *common, "--output-dir", str(out)]
+    if command == "render-argo --argo-lint":
+        return ["render-argo", *common, "--output-dir", str(out), "--argo-lint"]
+    if command == "render-kueue":
+        return ["render-kueue", *common, "--output-dir", str(out)]
+    if command == "compile":
+        return ["compile", *common, "--output", str(out / "compiled.json")]
+    if command == "inspect":
+        return ["inspect", "--input", str(plan)]
+    raise AssertionError(f"unknown command {command!r}")  # pragma: no cover
+
+
+COMMANDS = [
+    "render-argo",
+    "render-argo --argo-lint",
+    "render-kueue",
+    "compile",
+    "inspect",
+]
+UNREADABLE = ["missing", "directory", "unreadable", "dangling link"]
+INVALID = ["unparseable", "not a mapping", "empty", "schema invalid"]
+
+
+def _run(monkeypatch, capsys, command: str, plan: Path, out: Path):
+    monkeypatch.setattr("sys.argv", ["orbital-mission-compiler", *_argv(command, plan, out)])
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    captured = capsys.readouterr()
+    return excinfo.value.code, captured
+
+
+def _sole_document(captured) -> dict:
+    """The report, wherever the command puts it, and only one of them."""
+    streams = [s for s in (captured.out, captured.err) if s.strip()]
+    assert len(streams) == 1, f"expected one stream to carry the report, got {captured}"
+    return json.loads(streams[0])
+
+
+@pytest.mark.parametrize("command", COMMANDS)
+@pytest.mark.parametrize("shape", UNREADABLE)
+def test_a_plan_that_cannot_be_read_is_a_run_that_never_started(
+    command, shape, tmp_path, monkeypatch, capsys
+):
+    """Exit 2, the code for a command that could not run.
+
+    Exit 1 would collide with the gated render's meaning for it, so a caller
+    branching on the contract read a permission error as a lint rejection.
+    """
+    if shape == "unreadable" and _IS_ROOT:
+        pytest.skip("mode 000 does not stop root reading the file")
+    plan = _plan(tmp_path, shape)
+    out = tmp_path / "out"
+    out.mkdir()
+
+    code, captured = _run(monkeypatch, capsys, command, plan, out)
+
+    assert code == 2, captured
+    report = _sole_document(captured)
+    assert report["status"] == "error", report
+    assert report["reason"] == "input_unreadable", report
+    assert str(plan) in report["error"], report
+
+
+@pytest.mark.parametrize("command", COMMANDS)
+@pytest.mark.parametrize("shape", INVALID)
+def test_a_file_that_is_not_a_plan_is_a_verdict(
+    command, shape, tmp_path, monkeypatch, capsys
+):
+    """Exit 1, the code a policy denial already uses.
+
+    The compiler read the file and refused it, which is the same kind of answer
+    as the policy layer refusing a plan it understood.
+    """
+    plan = _plan(tmp_path, shape)
+    out = tmp_path / "out"
+    out.mkdir()
+
+    code, captured = _run(monkeypatch, capsys, command, plan, out)
+
+    assert code == 1, captured
+    report = _sole_document(captured)
+    assert report["status"] == "error", report
+    assert report["reason"] == "input_invalid", report
+    assert str(plan) in report["error"], report
+
+
+@pytest.mark.parametrize("command", ["render-argo", "render-argo --argo-lint", "render-kueue"])
+@pytest.mark.parametrize("shape", UNREADABLE + INVALID)
+def test_a_rejected_input_leaves_the_output_directory_untouched(
+    command, shape, tmp_path, monkeypatch, capsys
+):
+    """Fail closed, and fail closed before anything exists to clean up.
+
+    The report is only half of it. The gated render makes its staging directory
+    under the output directory when that already exists, so refusing the plan
+    after that point leaves a `.argo-lint-staging-*` in an operator's output for
+    a run that reported doing nothing. Reading the plan first is what keeps the
+    report and the directory agreeing.
+    """
+    if shape == "unreadable" and _IS_ROOT:
+        pytest.skip("mode 000 does not stop root reading the file")
+    plan = _plan(tmp_path, shape)
+    out = tmp_path / "out"
+    out.mkdir()
+
+    _run(monkeypatch, capsys, command, plan, out)
+
+    assert sorted(p.name for p in out.iterdir()) == []
+
+
+def test_the_duplicate_key_refusal_still_names_the_duplicate(tmp_path):
+    """The wrapping must not hide what the strict loader found.
+
+    A duplicate key is the one parse failure this repo has a test for elsewhere,
+    because it is the one that silently keeps a random one of the two values.
+    """
+    from orbital_mission_compiler.compiler import load_mission_plan
+
+    plan = tmp_path / "dupes.yaml"
+    plan.write_text("mission_id: a\nmission_id: b\n", encoding="utf-8")
+
+    with pytest.raises(Exception, match="duplicate key"):
+        load_mission_plan(plan)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -386,9 +386,8 @@ def test_a_duplicate_hidden_in_a_merge_source_cannot_downgrade_a_gpu_step(tmp_pa
     turns an accelerated step into a CPU one while the file still reads as GPU.
     """
     import pytest as _pytest
-    import yaml as _yaml
 
-    from orbital_mission_compiler.compiler import load_mission_plan
+    from orbital_mission_compiler.compiler import MissionPlanInvalid, load_mission_plan
 
     plan = tmp_path / "plan.yaml"
     plan.write_text(
@@ -407,7 +406,11 @@ def test_a_duplicate_hidden_in_a_merge_source_cannot_downgrade_a_gpu_step(tmp_pa
         "            fallback_resource_class: cpu\n",
         encoding="utf-8",
     )
-    with _pytest.raises(_yaml.constructor.ConstructorError, match="duplicate key"):
+    # The refusal is the guarantee, and it is now this package's to make: the
+    # loader's own ConstructorError is wrapped so the CLI can answer with a
+    # report instead of a traceback. The message is still asserted, since naming
+    # the duplicated key is what makes the refusal actionable.
+    with _pytest.raises(MissionPlanInvalid, match="duplicate key"):
         load_mission_plan(plan)
 
 


### PR DESCRIPTION
## Why

`render-argo`, `render-kueue`, `compile` and `inspect` promise a machine-readable report and a documented exit code. An input the compiler cannot take escaped both. Measured across five commands and eight shapes of unusable input — absent, a directory, mode 000, a broken symlink, unparseable YAML, a document that is not a mapping, an empty file, and one that fails the schema — all forty combinations produced a traceback, an empty stdout, and exit 1.

Exit 1 is what makes it more than untidy. On the gated render that code means the linter rejected something, so a caller branching on the contract read a missing file as a rejected manifest and a permission error as a bad workflow.

## What

The split follows the compiler's own answer. A file whose bytes never arrived is a run that never started, which is the family `policy_engine_unavailable` is already in, and exits 2. A file that arrived and is not a mission plan is a verdict — the same kind of answer as the policy layer refusing a plan it understood — and exits 1. Both are reported in the shape those two handlers already use, from the same place in `main()`.

The failures are typed at the one point every command reaches a plan through, directly or through `_load_or_accept_plan`. The three steps there fail in three libraries' vocabularies — `OSError`, `yaml.YAMLError`, `pydantic.ValidationError` — and each is renamed while keeping the original message, which is where the strict loader says which key was duplicated. `MissionPlanError` is a `ValueError`, because that is what a schema rejection has always been here and anything catching it should keep catching it.

One existing test changed. The merge-source test asserted `yaml.constructor.ConstructorError`; it now asserts the refusal this package makes, still matching on the duplicated key. The guarantee is the same and it no longer depends on which class PyYAML raises.

**The prune scope moved to before anything is written.** It was read back off the plan after the render, so this change would have reported "the run never started" over a directory that had just been written to — measured, one manifest on disk under a report denying it. Reading it first makes the claim true. It is also read once now instead of up to three times: `render-kueue` takes it from the plan already in hand, and the gated render takes it before its staging directory exists, so a refused input leaves no `.argo-lint-staging-*` behind in an operator's output either.

What that reordering used to cost was the reason not to do it: reading the plan early meant a schema failure surfaced from the scope read rather than from the render. That mattered while the two reported differently. After this change they do not.

## Verification

Written as failing tests first: 48 of 49 red before the change, the one green being the duplicate-key regression that already held.

Each assertion was then checked against a mutation, since an assertion that cannot fail is worse than none — dropping each of the three typed raises, swapping the two exit codes, dropping the original message from the wrapped one, and moving the scope read back to after the staging directory is made. Each fails the tests that name it, and the last fails all eight shapes on the gated command specifically.

973 pytest passed, 1 skipped. `ruff` clean, `mypy` clean, 15 goldens pass.

## Depends on #81

Stacked on `fix/desired-state-ownership-and-lock-namespace`, not independent of it: this moves the scope that PR introduces, and both change the same three command functions in `cli.py`. Reviewing or merging them separately would mean resolving that overlap at merge time, where a wrong resolution is silent.
