### PR TITLE
let an artifact say who owns it instead of inferring it from its kinds

### DIFF
--- a/src/orbital_mission_compiler/cli.py
+++ b/src/orbital_mission_compiler/cli.py
@@ -39,6 +39,9 @@ from .compiler import (
     preflight_writable,
     resolve_argo_bin,
     argo_lint_path,
+    RENDERER_ARGO,
+    RENDERER_KUEUE,
+    SCOPE_INSTALLATION,
     stale_rendered_artifacts,
     ArtifactOwner,
     _artifact_mission,
@@ -122,12 +125,6 @@ _KUEUE_DEPLOY_NOTE = (
 )
 
 
-# The kind only one renderer emits. Both write ResourceClaimTemplate, so it is not
-# a discriminator: attribution has to rest on a kind that is exclusively one
-# side's, or the RCT-only scheduler-fallback file is claimed by whichever command
-# ran last.
-ARGO_EXCLUSIVE_KINDS = {"Workflow"}
-KUEUE_EXCLUSIVE_KINDS = {"Job", "WorkloadPriorityClass"}
 
 
 def _scope_of(plan: MissionPlan) -> frozenset[str]:
@@ -147,16 +144,18 @@ def _render_scope(source: str | Path) -> frozenset[str]:
 
 def _report_stale(
     result: dict[str, object], output_dir: str, written: list[Path], prune: bool,
-    exclusive_kinds: set[str], *, mission_ids: Collection[str] | None = None,
-    include_unmissioned: bool = False,
+    renderer: str, *, mission_ids: Collection[str] | None = None,
+    include_unmissioned: bool = False, installation: str | None = None,
+    prune_global: bool = False,
 ) -> None:
     stale = stale_rendered_artifacts(
         output_dir, written,
         mission_ids=mission_ids, include_unmissioned=include_unmissioned,
+        installation=installation,
     )
     if not stale:
         return
-    mine, unattributable = attribute_stale(stale, exclusive_kinds)
+    mine, unattributable = attribute_stale(stale, renderer)
     if unattributable:
         # Reported and never deleted. These hold no kind either renderer owns --
         # the standalone scheduler-fallback template is the real case -- so this
@@ -170,6 +169,47 @@ def _report_stale(
         )
     if not mine:
         return
+    # Cluster-scoped artifacts are separated out before anything is removed.
+    # They are this installation's, but a mission-scoped run does not know
+    # whether another mission's Jobs still name the classes in them, so removing
+    # one takes the explicit opt-in. Without it they are reported and left,
+    # because leaving them silently is how an operator finds out by having a
+    # workload fail admission.
+    theirs: list[Path] = []
+    held_back: list[Path] = []
+    for path in list(mine):
+        found = _artifact_mission(path)
+        if found.scope != SCOPE_INSTALLATION:
+            continue
+        if found.owner_id != installation:
+            theirs.append(path)
+        elif not prune_global:
+            held_back.append(path)
+    if theirs:
+        result["stale_other_installation"] = [str(p) for p in theirs]
+        print(
+            f"note: {len(theirs)} cluster-scoped artifact(s) in {output_dir} belong to "
+            f"another installation: {', '.join(p.name for p in theirs)}. They are left "
+            "alone whatever this run was asked to do; only the installation that wrote "
+            "them, named by --priority-class-prefix, can retire them.",
+            file=sys.stderr,
+        )
+    if held_back:
+        result["stale_cluster_scoped"] = [str(p) for p in held_back]
+        if prune:
+            print(
+                f"note: leaving {len(held_back)} cluster-scoped artifact(s) in "
+                f"{output_dir}: {', '.join(p.name for p in held_back)}. They belong to "
+                "this installation rather than to one mission, so another mission's "
+                "Jobs may still reference them. Re-run with --prune-global to retire "
+                "them.",
+                file=sys.stderr,
+            )
+    skip = set(theirs) | set(held_back)
+    if skip:
+        mine = [p for p in mine if p not in skip]
+        if not mine:
+            return
     if prune:
         # A cluster-scoped artifact belongs to no mission, so the mission filter
         # that keeps one mission's --prune away from another's files does not
@@ -307,6 +347,21 @@ def _add_lock_args(p: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_global_prune_args(p: argparse.ArgumentParser) -> None:
+    """Add the opt-in for retiring cluster-scoped artifacts."""
+    p.add_argument(
+        "--prune-global",
+        action="store_true",
+        help="With --prune, also retire cluster-scoped artifacts this installation "
+        "owns -- the WorkloadPriorityClass bundle. Separate from --prune because a "
+        "mission-scoped run does not hold the installation's desired set: it cannot "
+        "tell a class nobody needs any more from one another mission's Jobs still "
+        "reference, and removing it leaves those Jobs naming classes that are gone. "
+        "Only the installation that wrote them, identified by "
+        "--priority-class-prefix, may retire them.",
+    )
+
+
 def _add_policy_args(p: argparse.ArgumentParser) -> None:
     """Add the shared policy-gate flags to an artifact-producing subcommand."""
     p.add_argument("--unsafe-skip-policy", action="store_true", help=_UNSAFE_SKIP_POLICY_HELP)
@@ -422,6 +477,7 @@ def build_parser() -> argparse.ArgumentParser:
         "collisions on the cluster-scoped names.",
     )
     _add_lock_args(kueue_p)
+    _add_global_prune_args(kueue_p)
     _add_policy_args(kueue_p)
     kueue_p.set_defaults(func=cmd_render_kueue)
 
@@ -521,7 +577,7 @@ def cmd_render_argo(args: argparse.Namespace) -> None:
         result: dict[str, object] = {"status": "ok", "files": [str(p) for p in written]}
         try:
             _report_stale(
-                result, args.output_dir, written, args.prune, ARGO_EXCLUSIVE_KINDS,
+                result, args.output_dir, written, args.prune, RENDERER_ARGO,
                 mission_ids=scope,
             )
         except PruneIncomplete as exc:
@@ -1042,7 +1098,7 @@ def _reconcile_empty_render(
     empty_result: dict[str, object] = {"status": "ok", "lint": "not-applicable", "files": []}
     try:
         _report_stale(
-            empty_result, args.output_dir, [], args.prune, ARGO_EXCLUSIVE_KINDS,
+            empty_result, args.output_dir, [], args.prune, RENDERER_ARGO,
             mission_ids=scope,
         )
     except PruneIncomplete as exc:
@@ -1168,7 +1224,7 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
                             stale_rendered_artifacts(
                                 out_dir, written, mission_ids=scope,
                             ),
-                            ARGO_EXCLUSIVE_KINDS,
+                            RENDERER_ARGO,
                         )[0]
                     }
                     if args.prune else set()
@@ -1289,7 +1345,7 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
             try:
                 _report_stale(
                     result_stale, args.output_dir, published, args.prune,
-                    ARGO_EXCLUSIVE_KINDS, mission_ids=scope,
+                    RENDERER_ARGO, mission_ids=scope,
                 )
             except PruneIncomplete:
                 # An OSError subclass, and a different phase: the scan finished
@@ -1535,8 +1591,15 @@ def cmd_render_kueue(args: argparse.Namespace) -> None:
         try:
             _report_stale(
                 stale_result, args.output_dir, written, args.prune,
-                KUEUE_EXCLUSIVE_KINDS, mission_ids=scope,
+                RENDERER_KUEUE, mission_ids=scope,
+                # The global opt-in and the identity it applies to. Without the
+                # flag a cluster-scoped artifact is reported and left; with it,
+                # only this installation's own is retired.
+                # This renderer writes the cluster-scoped bundle, so it always
+                # looks for it; whether it may remove one is the opt-in below.
                 include_unmissioned=True,
+                installation=args.priority_class_prefix,
+                prune_global=args.prune_global,
             )
         except PruneIncomplete as exc:
             print(json.dumps(_prune_failure_report(exc, written), indent=2))

--- a/src/orbital_mission_compiler/compiler.py
+++ b/src/orbital_mission_compiler/compiler.py
@@ -634,11 +634,15 @@ def render_argo_workflow(
                 "mission-id": sanitize_k8s_name(intent.mission_id),
                 "service-id": sanitize_k8s_name(intent.service_id),
                 "priority": str(intent.priority),
-                MANAGED_BY_LABEL: MANAGED_BY_VALUE,
                 MISSION_FINGERPRINT_LABEL: mission_fingerprint(intent.mission_id),
+                **_ownership_labels(RENDERER_ARGO, ROLE_WORKFLOW),
             },
             "annotations": _require_annotations_fit(
-                {**wf_annotations, RAW_MISSION_ID_ANNOTATION: intent.mission_id},
+                {
+                    **wf_annotations,
+                    RAW_MISSION_ID_ANNOTATION: intent.mission_id,
+                    OWNER_ID_ANNOTATION: intent.mission_id,
+                },
                 f"Workflow {intent.workflow_name}",
             ),
         },
@@ -704,7 +708,9 @@ def _dra_fallback_steps(intent: WorkflowIntent) -> list[WorkflowStep]:
     ]
 
 
-def _first_available_rct(intent: WorkflowIntent, namespace: str | None) -> dict[str, Any] | None:
+def _first_available_rct(
+    intent: WorkflowIntent, namespace: str | None, renderer: str
+) -> dict[str, Any] | None:
     """The scheduler-route ``firstAvailable`` ResourceClaimTemplate for the intent's
     driver-backed accelerator-with-fallback step, or ``None`` if no step qualifies.
 
@@ -739,11 +745,14 @@ def _first_available_rct(intent: WorkflowIntent, namespace: str | None) -> dict[
             # from -- can tell that this claim is not what the Job was admitted on.
             "labels": {
                 DRA_ROUTE_LABEL: "scheduler",
-                MANAGED_BY_LABEL: MANAGED_BY_VALUE,
                 MISSION_FINGERPRINT_LABEL: mission_fingerprint(intent.mission_id),
+                **_ownership_labels(renderer, ROLE_SCHEDULER_FALLBACK),
             },
             "annotations": _require_annotations_fit(
-                {RAW_MISSION_ID_ANNOTATION: intent.mission_id},
+                {
+                    RAW_MISSION_ID_ANNOTATION: intent.mission_id,
+                    OWNER_ID_ANNOTATION: intent.mission_id,
+                },
                 f"ResourceClaimTemplate {_rct_name_for_intent(intent, 'accel')}",
             ),
         },
@@ -818,7 +827,7 @@ def render_resource_claim_templates(
     _require_k8s_label(namespace, "namespace")
     templates: list[dict[str, Any]] = []
     if dra_fallback:
-        rct = _first_available_rct(intent, namespace)
+        rct = _first_available_rct(intent, namespace, RENDERER_KUEUE)
         if rct is not None:
             templates.append(rct)
             # Fall through: also emit the exactly GPU RCT below (Kueue route).
@@ -839,11 +848,14 @@ def render_resource_claim_templates(
                 "namespace": namespace,
                 "labels": {
                     DRA_ROUTE_LABEL: "kueue",
-                    MANAGED_BY_LABEL: MANAGED_BY_VALUE,
                     MISSION_FINGERPRINT_LABEL: mission_fingerprint(intent.mission_id),
+                    **_ownership_labels(RENDERER_KUEUE, ROLE_KUEUE_JOB),
                 },
                 "annotations": _require_annotations_fit(
-                {RAW_MISSION_ID_ANNOTATION: intent.mission_id},
+                {
+                    RAW_MISSION_ID_ANNOTATION: intent.mission_id,
+                    OWNER_ID_ANNOTATION: intent.mission_id,
+                },
                 f"ResourceClaimTemplate {_rct_name_for_intent(intent, 'gpu')}",
             ),
             },
@@ -938,9 +950,17 @@ def render_workload_priority_classes(
             "metadata": {
                 "name": _priority_class_name(tier, prefix),
                 "labels": {
-                    "app.kubernetes.io/managed-by": "orbital-mission-compiler",
                     "orbital/priority-mapping-version": PRIORITY_CLASS_MAPPING_VERSION,
+                    **_ownership_labels(
+                        RENDERER_KUEUE, ROLE_PRIORITY_CLASSES, SCOPE_INSTALLATION
+                    ),
                 },
+                # The prefix is the installation. It is what keeps two
+                # installations' classes from colliding on cluster-scoped names,
+                # so it is the identity these belong to -- and naming it is what
+                # stops a second installation replacing the first's set while
+                # the first's Jobs go on referencing it.
+                "annotations": {OWNER_ID_ANNOTATION: prefix},
             },
             "value": _PRIORITY_CLASS_TIERS[tier][1],
             "description": (
@@ -1117,6 +1137,7 @@ def render_kueue_job(
         "orbital/priority": str(intent.priority),
         "orbital/orchide-priority": str(scale_priority_orchide(intent.priority)),
         RAW_MISSION_ID_ANNOTATION: intent.mission_id,
+        OWNER_ID_ANNOTATION: intent.mission_id,
         "orbital/executed-step": primary.name,
         # Named explicitly so an operator reading the applied Job can see that it
         # does not run the whole service, without having to diff it against the plan.
@@ -1140,8 +1161,8 @@ def render_kueue_job(
             "namespace": namespace,
             "labels": {
                 "kueue.x-k8s.io/queue-name": queue_name,
-                MANAGED_BY_LABEL: MANAGED_BY_VALUE,
                 MISSION_FINGERPRINT_LABEL: mission_fingerprint(intent.mission_id),
+                **_ownership_labels(RENDERER_KUEUE, ROLE_KUEUE_JOB),
                 "mission-id": sanitize_k8s_name(intent.mission_id),
                 "service-id": sanitize_k8s_name(intent.service_id),
                 "priority": str(intent.priority),
@@ -1456,7 +1477,7 @@ def render_workflows_for_file(
     intents = compile_plan_to_intents(plan)
     objects: list[dict[str, Any]] = []
     for intent in intents:
-        rct = _first_available_rct(intent, namespace) if dra_fallback else None
+        rct = _first_available_rct(intent, namespace, RENDERER_ARGO) if dra_fallback else None
         if rct is not None:
             objects.append(rct)
         objects.append(
@@ -1522,6 +1543,46 @@ def _require_annotations_fit(annotations: dict[str, str], what: str) -> dict[str
 
 MISSION_FINGERPRINT_LABEL = "orbital/mission-fingerprint"
 RAW_MISSION_ID_ANNOTATION = "orbital/raw-mission-id"
+
+# Who wrote an artifact, for whom, and as what. Said by the document rather than
+# guessed from the kinds it holds. Guessing failed on both sides: a
+# ResourceClaimTemplate is written by either renderer, so the RCT-only scheduler
+# fallback belonged to neither and the renderer that wrote it could not take it
+# back; and the priority-class bundle carries no mission, so a second
+# installation's render replaced the first's classes with nothing raised.
+RENDERER_LABEL = "orbital/renderer"
+OWNER_SCOPE_LABEL = "orbital/owner-scope"
+ARTIFACT_ROLE_LABEL = "orbital/artifact-role"
+OWNERSHIP_SCHEMA_LABEL = "orbital/ownership-schema"
+# Versioned because a later shape has to be able to tell itself from this one.
+# An artifact carrying no schema at all predates the label and is reported
+# rather than acted on: adopting it would mean guessing again.
+OWNERSHIP_SCHEMA_VERSION = "v1"
+# The owner's own name, in an annotation because it is not a selector and does
+# not have to survive label syntax. For a mission that is the raw id, which the
+# fingerprint label is a 64-bit digest of; checking both means a digest
+# collision cannot decide a delete on its own.
+OWNER_ID_ANNOTATION = "orbital/owner-id"
+
+RENDERER_ARGO = "argo"
+RENDERER_KUEUE = "kueue"
+SCOPE_MISSION = "mission"
+SCOPE_INSTALLATION = "installation"
+ROLE_WORKFLOW = "workflow"
+ROLE_KUEUE_JOB = "kueue-job"
+ROLE_SCHEDULER_FALLBACK = "scheduler-fallback"
+ROLE_PRIORITY_CLASSES = "workload-priority-classes"
+
+
+def _ownership_labels(renderer: str, role: str, scope: str = SCOPE_MISSION) -> dict[str, str]:
+    """The labels every document this compiler writes carries."""
+    return {
+        MANAGED_BY_LABEL: MANAGED_BY_VALUE,
+        RENDERER_LABEL: renderer,
+        OWNER_SCOPE_LABEL: scope,
+        ARTIFACT_ROLE_LABEL: role,
+        OWNERSHIP_SCHEMA_LABEL: OWNERSHIP_SCHEMA_VERSION,
+    }
 
 
 def mission_fingerprint(mission_id: str) -> str:
@@ -1590,7 +1651,10 @@ def _is_rendered_artifact(path: Path) -> bool:
 
 
 def _in_scope(
-    found: ArtifactMission, missions: set[str], include_unmissioned: bool
+    found: ArtifactMission,
+    missions: set[str],
+    include_unmissioned: bool,
+    installation: str | None = None,
 ) -> bool:
     """Whether a stale candidate is this render's to reconcile.
 
@@ -1607,8 +1671,22 @@ def _in_scope(
     """
     if found.owner is ArtifactOwner.MISSION:
         return found.mission in missions
-    if found.owner is ArtifactOwner.UNMISSIONED:
+    if found.owner is not ArtifactOwner.UNMISSIONED:
+        return False
+    if found.scope == SCOPE_INSTALLATION:
+        # In scope to be *seen* by the installation that wrote them, so a run
+        # that leaves them still says they are there. Whether they may be
+        # removed is decided one level up, by the explicit opt-in: a
+        # mission-scoped run does not hold the installation's desired set and
+        # cannot tell a class nobody needs from one another mission's Jobs still
+        # reference.
+        # Visible to any renderer that manages cluster-scoped artifacts, whoever
+        # owns them. Whose they are decides what may happen to them, not whether
+        # they are mentioned: a bundle another installation owns that goes
+        # unmentioned is one an operator never learns is in their directory.
         return include_unmissioned
+    # No scope label at all: rendered before the schema existed. Reported, not
+    # removed -- there is nothing on it to decide by.
     return False
 
 
@@ -1639,10 +1717,18 @@ class ArtifactOwner(Enum):
 
 @dataclass(frozen=True)
 class ArtifactMission:
-    """The ownership answer, and the mission when there is exactly one."""
+    """The ownership answer, and who it names when there is exactly one.
+
+    `scope`, `owner_id` and `renderer` come from the labels the writer stamps.
+    They are absent on an artifact rendered before the schema existed, which is
+    reported rather than acted on: adopting it would mean guessing again.
+    """
 
     owner: ArtifactOwner
     mission: str | None = None
+    scope: str | None = None
+    owner_id: str | None = None
+    renderer: str | None = None
 
 
 def _artifact_mission(path: Path) -> ArtifactMission:
@@ -1682,11 +1768,39 @@ def _artifact_mission(path: Path) -> ArtifactMission:
         if not isinstance(value, str) or not value.strip():
             return ArtifactMission(ArtifactOwner.MALFORMED)
         marks.append(value)
+    # The provenance tuple, which every document in one file has to agree on.
+    # A file whose documents name different writers, scopes or owners is not one
+    # artifact and is not anyone's to remove.
+    stamps = {
+        (
+            labels.get(RENDERER_LABEL),
+            labels.get(OWNER_SCOPE_LABEL),
+            labels.get(OWNERSHIP_SCHEMA_LABEL),
+        )
+        for labels in labelsets
+        if isinstance(labels, dict)
+    }
+    owner_ids = {
+        ((d.get("metadata") or {}).get("annotations") or {}).get(OWNER_ID_ANNOTATION)
+        for d in docs
+        if isinstance(d, dict)
+    }
+    if len(stamps) > 1 or len(owner_ids) > 1:
+        return ArtifactMission(ArtifactOwner.MIXED)
+    renderer, scope, schema = stamps.pop() if stamps else (None, None, None)
+    owner_id = owner_ids.pop() if owner_ids else None
+    if schema is not None and schema != OWNERSHIP_SCHEMA_VERSION:
+        return ArtifactMission(ArtifactOwner.MALFORMED)
+
     named = {m for m in marks if m is not None}
     if not named:
-        return ArtifactMission(ArtifactOwner.UNMISSIONED)
+        return ArtifactMission(
+            ArtifactOwner.UNMISSIONED, None, scope, owner_id, renderer
+        )
     if len(named) == 1 and len(named) == len(set(marks)):
-        return ArtifactMission(ArtifactOwner.MISSION, named.pop())
+        return ArtifactMission(
+            ArtifactOwner.MISSION, named.pop(), scope, owner_id, renderer
+        )
     return ArtifactMission(ArtifactOwner.MIXED)
 
 
@@ -1696,6 +1810,7 @@ def stale_rendered_artifacts(
     *,
     mission_ids: Collection[str] | None = None,
     include_unmissioned: bool = False,
+    installation: str | None = None,
 ) -> list[Path]:
     """Artifacts from an earlier render that this one did not replace.
 
@@ -1771,7 +1886,7 @@ def stale_rendered_artifacts(
         # --emit-priority-classes off left the classes on disk for the next apply
         # to reinstate. A caller that writes such artifacts says so, and
         # `attribute_stale` still holds each renderer to the kinds only it emits.
-        and _in_scope(_artifact_mission(p), missions, include_unmissioned)
+        and _in_scope(_artifact_mission(p), missions, include_unmissioned, installation)
     )
 
 
@@ -1780,46 +1895,55 @@ def stale_rendered_artifacts(
 _ALL_EXCLUSIVE_KINDS = frozenset({"Workflow", "Job", "WorkloadPriorityClass"})
 
 
-def attribute_stale(stale: list[Path], exclusive_kinds: set[str]) -> tuple[list[Path], list[Path]]:
+def attribute_stale(
+    stale: list[Path], renderer: str, exclusive_kinds: set[str] | None = None
+) -> tuple[list[Path], list[Path]]:
     """Split stale candidates into this renderer's, and everyone else's.
 
-    Ownership and mission are not enough to delete by. An Argo Workflow and a
-    Kueue Job for one mission carry the same managed-by label and the same
-    fingerprint, so `render-kueue --prune` deleted a Workflow an Argo render had
-    just published -- with the gate, one it had linted and reported as published.
+    Read from the label the writer stamped, not guessed from the kinds the file
+    holds. Guessing could not answer for a ResourceClaimTemplate, which both
+    renderers emit: the standalone `-scheduler-fallback.yaml` holds nothing else,
+    so it was a subset of both sets and belonged to neither -- the renderer that
+    wrote it could not take it back when --dra-fallback was turned off, and it
+    was not reported either.
 
-    Attribution is by a kind only one renderer emits: Workflow on one side, Job
-    and WorkloadPriorityClass on the other. A subset test over everything a
-    renderer *can* write does not work, because both write ResourceClaimTemplate:
-    the standalone `-scheduler-fallback.yaml` is RCT-only, so it is a subset of
-    both sets and whichever command ran last deleted the other's copy. Measured,
-    after a first fix that closed only one direction.
+    A file with no renderer label was written before this schema and is returned
+    in the second list: reported, never deleted. Erring toward a file that stays
+    is the right direction for a delete, and reporting it is what keeps that from
+    being silent. Re-rendering adopts it.
 
-    A file with no exclusive kind is attributed to neither and returned in the
-    second list: reported, never deleted. Erring toward a file that stays is the
-    right direction for a delete, and reporting it keeps that from being silent.
+    `exclusive_kinds` is accepted and ignored, so callers that still pass the old
+    argument keep working while they are updated.
     """
-    everyone_elses = _ALL_EXCLUSIVE_KINDS - exclusive_kinds
+    del exclusive_kinds
     mine: list[Path] = []
     unattributable: list[Path] = []
     for path in stale:
-        kinds = _artifact_kinds(path)
-        # Mine AND not also theirs. "Intersects mine" alone let a file holding both
-        # a Workflow and a Job -- what an operator gets by concatenating the two
-        # renders into one bundle for `kubectl apply -f` -- be deleted by whichever
-        # command ran, which is the cross-renderer loss this function exists to
-        # stop, needing only the two kinds in one file.
-        if kinds & exclusive_kinds and not kinds & everyone_elses:
+        found = _artifact_mission(path)
+        if found.renderer == renderer and found.owner in (
+            ArtifactOwner.MISSION,
+            ArtifactOwner.UNMISSIONED,
+        ):
             mine.append(path)
-        elif kinds & everyone_elses and not kinds & exclusive_kinds:
-            # Unambiguously the other renderer's. Not stale and not this command's
-            # business, so it is neither deleted nor reported: warning about it on
-            # every run of a directory that holds both renders would be noise, and
-            # noise about a live artifact invites someone to delete it.
-            continue
         else:
             unattributable.append(path)
     return mine, unattributable
+
+def _rendered_owner_id(rendered: str | list[Any]) -> str | None:
+    """The owner a pending document set names, if they all name one."""
+    if isinstance(rendered, str):
+        try:
+            docs: list[Any] = list(yaml.safe_load_all(rendered))
+        except yaml.YAMLError:
+            return None
+    else:
+        docs = list(rendered)
+    owners = {
+        ((d.get("metadata") or {}).get("annotations") or {}).get(OWNER_ID_ANNOTATION)
+        for d in docs
+        if isinstance(d, dict)
+    }
+    return owners.pop() if len(owners) == 1 else None
 
 
 def preflight_writable(planned: list[tuple[Path, Any]]) -> None:
@@ -1856,7 +1980,11 @@ def preflight_writable(planned: list[tuple[Path, Any]]) -> None:
         if theirs.owner is ArtifactOwner.MISSION:
             same_owner = theirs.mission == ours
         elif theirs.owner is ArtifactOwner.UNMISSIONED:
-            same_owner = ours is None
+            # Unmissioned is not ownerless. The priority-class bundle belongs to
+            # an installation, and both bundles being unmissioned is how a second
+            # installation's render replaced the first's class set with nothing
+            # raised -- the Jobs naming those classes stayed where they were.
+            same_owner = ours is None and theirs.owner_id == _rendered_owner_id(rendered)
         else:
             same_owner = False
         if not same_owner:
@@ -1986,7 +2114,7 @@ def write_individual_workflows(
     written: list[Path] = []
     planned: list[tuple[Path, list[dict[str, Any]]]] = []
     for intent in intents:
-        rct = _first_available_rct(intent, namespace) if dra_fallback else None
+        rct = _first_available_rct(intent, namespace, RENDERER_ARGO) if dra_fallback else None
         # Stamp the namespace only when the template ships with the Workflow:
         # the two must agree for the Pod to resolve it. A plain render keeps its
         # previous namespace-less output, so a caller that selects the namespace

--- a/tests/test_argo_lint_gate.py
+++ b/tests/test_argo_lint_gate.py
@@ -1873,7 +1873,7 @@ def test_prune_retires_the_priority_class_bundle_once_emission_stops(tmp_path, c
     out = tmp_path / "out"
     base = [
         "render-kueue", "--input", VALID_PLAN, "--output-dir", str(out),
-        "--priority-class", "--prune", "--policy-engine", "baseline",
+        "--priority-class", "--prune", "--prune-global", "--policy-engine", "baseline",
     ]
     cmd_render_kueue(build_parser().parse_args(base + ["--emit-priority-classes"]))
     capsys.readouterr()
@@ -1992,15 +1992,14 @@ def test_a_scan_that_fails_after_publishing_says_the_output_changed(
     assert report["files"], "the caller has to learn what did get published"
     assert seen["n"] == survives + 1, "the post-publish scan is the one under test"
 
-def test_retiring_the_shared_bundle_is_announced(tmp_path, capsys):
-    """Two missions in one directory get a message, and the message is all they get.
+def test_an_ordinary_prune_leaves_the_shared_bundle_and_says_so(tmp_path, capsys):
+    """What used to be a warning after the fact is now a refusal with a note.
 
-    Nothing stops the second render removing classes the first mission's Jobs
-    still name: the bundle carries no fingerprint, so the filter that keeps one
-    mission's --prune away from another's files cannot reach it. Saying so on
-    stderr is the whole of what is on offer, which is what makes it worth pinning
-    -- deleting the message leaves behaviour that is correct for the render doing
-    it and invisible to everyone else.
+    Two missions rendering into one directory used to mean the second could
+    remove classes the first's Jobs still named, announced on stderr. The
+    artifact carries its installation now, so an ordinary --prune leaves it --
+    and still says it is there, because leaving it silently is how an operator
+    finds out by having a workload fail admission.
     """
     from orbital_mission_compiler.cli import cmd_render_kueue
 
@@ -2010,17 +2009,18 @@ def test_retiring_the_shared_bundle_is_announced(tmp_path, capsys):
         "--policy-engine", "baseline", "--emit-priority-classes",
     ]))
     capsys.readouterr()
-    assert (out / "workload-priority-classes.yaml").exists()
+    bundle = out / "workload-priority-classes.yaml"
+    assert bundle.exists()
 
     cmd_render_kueue(build_parser().parse_args([
         "render-kueue", "--input", OTHER_PLAN, "--output-dir", str(out),
         "--policy-engine", "baseline", "--prune",
     ]))
-    warning = capsys.readouterr().err
+    captured = capsys.readouterr()
 
-    assert "workload-priority-classes.yaml" in warning, warning
-    assert "--emit-priority-classes" in warning, "the message has to say how to put them back"
-    assert not (out / "workload-priority-classes.yaml").exists()
+    assert bundle.exists(), "an ordinary --prune must not retire a cluster-scoped artifact"
+    assert "--prune-global" in captured.err, captured.err
+    assert bundle.name in json.dumps(json.loads(captured.out).get("stale_cluster_scoped", []))
 
 
 def test_retiring_only_this_mission_s_own_files_is_not_announced(tmp_path, capsys):

--- a/tests/test_artifact_ownership.py
+++ b/tests/test_artifact_ownership.py
@@ -27,15 +27,26 @@ from orbital_mission_compiler.compiler import (
 MANAGED = "app.kubernetes.io/managed-by: orbital-mission-compiler"
 
 
-def _doc(kind: str, name: str, mission: str | None, raw_label: str | None = None) -> str:
+def _doc(
+    kind: str, name: str, mission: str | None, raw_label: str | None = None,
+    scope: str = "mission", owner: str = "aaaa",
+) -> str:
+    """A document as the renderers write them, provenance and all.
+
+    Hand-written without the ownership labels it would be an artifact from
+    before the schema, which is a separate state and is never reconciled.
+    """
     label = ""
     if raw_label is not None:
         label = f"    orbital/mission-fingerprint:\n{raw_label}\n"
     elif mission is not None:
         label = f"    orbital/mission-fingerprint: {mission}\n"
     return (
-        f"apiVersion: v1\nkind: {kind}\nmetadata:\n  name: {name}\n  labels:\n"
-        f"    {MANAGED}\n{label}"
+        f"apiVersion: v1\nkind: {kind}\nmetadata:\n  name: {name}\n"
+        f"  annotations:\n    orbital/owner-id: {owner}\n  labels:\n"
+        f"    {MANAGED}\n    orbital/renderer: kueue\n"
+        f"    orbital/owner-scope: {scope}\n    orbital/artifact-role: test\n"
+        f"    orbital/ownership-schema: v1\n{label}"
     )
 
 
@@ -97,13 +108,66 @@ def test_only_the_unmissioned_state_joins_global_reconciliation(tmp_path):
 
     Erring toward a file that survives is the right direction for a delete.
     """
-    _write(tmp_path, "global.yaml", _doc("WorkloadPriorityClass", "w", None))
+    _write(tmp_path, "global.yaml",
+           _doc("WorkloadPriorityClass", "w", None, scope="installation", owner="orbital-"))
     _write(tmp_path, "mixed.yaml", _doc("Job", "j", "aaaa"), _doc("Job", "w", None))
     _write(tmp_path, "malformed.yaml", _doc("Job", "j", None, raw_label="      - a list"))
 
-    stale = stale_rendered_artifacts(tmp_path, [], mission_ids=set(), include_unmissioned=True)
+    stale = stale_rendered_artifacts(
+        tmp_path, [], mission_ids=set(), include_unmissioned=True, installation="orbital-"
+    )
 
     assert [p.name for p in stale] == ["global.yaml"]
+
+
+def test_documents_that_disagree_about_their_writer_are_not_one_artifact(tmp_path):
+    """A file is prunable as a whole or not at all.
+
+    An operator concatenating two renders into one bundle for `kubectl apply -f`
+    produces a file with two writers in it. Deleting that on either one's say-so
+    removes the other's work, so the file answers for nobody.
+    """
+    path = tmp_path / "concatenated.yaml"
+    path.write_text(
+        _doc("Job", "j", "aaaa").replace("orbital/renderer: kueue", "orbital/renderer: argo")
+        + "---\n"
+        + _doc("Job", "k", "aaaa"),
+        encoding="utf-8",
+    )
+
+    assert _artifact_mission(path).owner is ArtifactOwner.MIXED
+
+
+def test_documents_that_disagree_about_their_owner_are_not_one_artifact(tmp_path):
+    """Same file, same writer, two owners named in the annotations.
+
+    The fingerprint label is 64 bits of a digest and the raw owner sits beside
+    it, so checking both is what keeps a digest collision from deciding a delete
+    on its own.
+    """
+    path = tmp_path / "two-owners.yaml"
+    path.write_text(
+        _doc("Job", "j", "aaaa", owner="mission-alpha")
+        + "---\n"
+        + _doc("Job", "k", "aaaa", owner="mission-beta"),
+        encoding="utf-8",
+    )
+
+    assert _artifact_mission(path).owner is ArtifactOwner.MIXED
+
+
+def test_a_file_that_disagrees_is_never_pruned(tmp_path):
+    """The end of that story, at the level that deletes."""
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "concatenated.yaml").write_text(
+        _doc("Job", "j", "aaaa", owner="mission-alpha")
+        + "---\n"
+        + _doc("Job", "k", "aaaa", owner="mission-beta"),
+        encoding="utf-8",
+    )
+
+    assert stale_rendered_artifacts(out, [], mission_ids={"aaaa"}) == []
 
 
 def test_a_symlink_is_never_this_compiler_s_artifact(tmp_path):

--- a/tests/test_artifact_provenance.py
+++ b/tests/test_artifact_provenance.py
@@ -1,0 +1,193 @@
+"""What a rendered file says about who owns it, rather than what is inferred.
+
+Attribution used to be guessed from the kinds a file holds, and ownership from a
+mission fingerprint that cluster-scoped artifacts do not carry. Both guesses
+failed in ways that were measured:
+
+- the RCT-only scheduler fallback holds no kind unique to either renderer, so the
+  renderer that wrote it could not reclaim it;
+- the priority-class bundle carries no mission, so a second installation's render
+  replaced the first's classes with nothing raised;
+- and a mission-scoped --prune deleted a cluster-scoped bundle another mission's
+  Jobs still referenced.
+
+So every document says who wrote it, for whom, and in what role.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from orbital_mission_compiler.cli import build_parser, cmd_render_argo, cmd_render_kueue
+from orbital_mission_compiler.compiler import (
+    ARTIFACT_ROLE_LABEL,
+    OWNER_ID_ANNOTATION,
+    OWNER_SCOPE_LABEL,
+    OWNERSHIP_SCHEMA_LABEL,
+    RENDERER_LABEL,
+)
+
+PLAN = "configs/mission_plans/demo_gpu_fallback_fixed.yaml"
+OTHER_PLAN = "configs/mission_plans/sample_download_only.yaml"
+BUNDLE = "workload-priority-classes.yaml"
+
+
+def _docs(path: Path) -> list[dict]:
+    return [d for d in yaml.safe_load_all(path.read_text(encoding="utf-8")) if d]
+
+
+def _meta(doc: dict) -> tuple[dict, dict]:
+    metadata = doc.get("metadata") or {}
+    return metadata.get("labels") or {}, metadata.get("annotations") or {}
+
+
+def _render(command, out: Path, *extra: str, plan: str = PLAN):
+    argv = [command, "--input", plan, "--output-dir", str(out), "--policy-engine", "baseline", *extra]
+    runner = cmd_render_kueue if command == "render-kueue" else cmd_render_argo
+    runner(build_parser().parse_args(argv))
+
+
+@pytest.mark.parametrize(
+    "command,extra,renderer",
+    [
+        ("render-argo", ["--dra-fallback"], "argo"),
+        ("render-kueue", ["--dra-fallback"], "kueue"),
+    ],
+)
+def test_every_document_names_the_renderer_that_wrote_it(
+    command, extra, renderer, tmp_path, capsys
+):
+    """Including the ResourceClaimTemplates, which both renderers emit.
+
+    A kind both can write cannot say whose a file is, which is how the RCT-only
+    fallback ended up owned by neither.
+    """
+    out = tmp_path / "out"
+    _render(command, out, *extra)
+    capsys.readouterr()
+
+    seen = 0
+    for path in sorted(out.glob("*.yaml")):
+        for doc in _docs(path):
+            labels, _ = _meta(doc)
+            assert labels.get(RENDERER_LABEL) == renderer, (path.name, doc.get("kind"), labels)
+            assert labels.get(OWNERSHIP_SCHEMA_LABEL), (path.name, labels)
+            assert labels.get(ARTIFACT_ROLE_LABEL), (path.name, labels)
+            seen += 1
+    assert seen, "the render produced nothing to check"
+
+
+def test_the_priority_class_bundle_is_owned_by_an_installation(tmp_path, capsys):
+    """It is cluster-scoped, so a mission cannot be its owner.
+
+    The prefix is what keeps two installations' classes from colliding in one
+    cluster, so it is the identity the bundle belongs to.
+    """
+    out = tmp_path / "out"
+    _render("render-kueue", out, "--emit-priority-classes", "--priority-class-prefix", "team-a-")
+    capsys.readouterr()
+
+    for doc in _docs(out / BUNDLE):
+        labels, annotations = _meta(doc)
+        assert labels.get(OWNER_SCOPE_LABEL) == "installation", labels
+        assert annotations.get(OWNER_ID_ANNOTATION) == "team-a-", annotations
+
+
+def test_a_second_installation_may_not_replace_the_first_s_bundle(tmp_path, capsys):
+    """The silent overwrite.
+
+    Both bundles are unmissioned, so the ownership check compared `None` with
+    `None` and allowed it; the first installation's class names simply vanished
+    while its Jobs went on naming them.
+    """
+    out = tmp_path / "out"
+    _render("render-kueue", out, "--emit-priority-classes", "--priority-class-prefix", "team-a-")
+    capsys.readouterr()
+    before = (out / BUNDLE).read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        _render("render-kueue", out, "--emit-priority-classes", "--priority-class-prefix", "team-b-")
+
+    assert (out / BUNDLE).read_text(encoding="utf-8") == before
+    assert "team-a-" in before
+
+
+def test_the_same_installation_may_replace_its_own_bundle(tmp_path, capsys):
+    """The control: refusing everything would be no ownership check at all."""
+    out = tmp_path / "out"
+    for _ in range(2):
+        _render("render-kueue", out, "--emit-priority-classes", "--priority-class-prefix", "team-a-")
+    capsys.readouterr()
+
+    assert "team-a-" in (out / BUNDLE).read_text(encoding="utf-8")
+
+
+def test_an_ordinary_prune_leaves_the_cluster_scoped_bundle(tmp_path, capsys):
+    """A mission-scoped run does not know whether anyone else still needs it.
+
+    It reports the bundle rather than removing it, so the operator learns it is
+    there without another mission's Jobs losing the classes they name.
+    """
+    out = tmp_path / "out"
+    _render("render-kueue", out, "--emit-priority-classes")
+    capsys.readouterr()
+    _render("render-kueue", out, "--prune", plan=OTHER_PLAN)
+    report = json.loads(capsys.readouterr().out)
+
+    assert (out / BUNDLE).exists(), "an ordinary --prune must not delete a global artifact"
+    assert BUNDLE in json.dumps(report), report
+
+
+def test_pruning_the_bundle_takes_the_explicit_flag_and_the_owner(tmp_path, capsys):
+    """And only from the installation that owns it."""
+    out = tmp_path / "out"
+    _render("render-kueue", out, "--emit-priority-classes", "--priority-class-prefix", "team-a-")
+    capsys.readouterr()
+
+    # Another installation asking for it does not get it, and is told so rather
+    # than left to wonder why the directory still has it.
+    _render("render-kueue", out, "--prune", "--prune-global",
+            "--priority-class-prefix", "team-b-", plan=OTHER_PLAN)
+    captured = capsys.readouterr()
+    assert (out / BUNDLE).exists(), "another installation may not retire it either"
+    assert BUNDLE in json.dumps(json.loads(captured.out).get("stale_other_installation", []))
+
+    _render("render-kueue", out, "--prune", "--prune-global",
+            "--priority-class-prefix", "team-a-", plan=OTHER_PLAN)
+    capsys.readouterr()
+    assert not (out / BUNDLE).exists()
+
+
+def test_a_renderer_reclaims_its_own_rct_only_artifact(tmp_path, capsys):
+    """The fallback nobody could delete.
+
+    `*-scheduler-fallback.yaml` holds only a ResourceClaimTemplate, which both
+    renderers emit, so kind-based attribution placed it with neither. Turning
+    --dra-fallback off left it in the desired-state directory for good.
+    """
+    out = tmp_path / "out"
+    _render("render-kueue", out, "--dra-fallback")
+    capsys.readouterr()
+    fallback = [p for p in out.glob("*scheduler-fallback.yaml")]
+    assert fallback, sorted(p.name for p in out.iterdir())
+
+    _render("render-kueue", out, "--prune")
+    capsys.readouterr()
+
+    assert not [p for p in out.glob("*scheduler-fallback.yaml")]
+
+
+def test_the_other_renderer_still_does_not_touch_it(tmp_path, capsys):
+    """Reclaimable by its writer is not the same as reclaimable by anyone."""
+    out = tmp_path / "out"
+    _render("render-kueue", out, "--dra-fallback")
+    capsys.readouterr()
+
+    _render("render-argo", out, "--prune")
+    capsys.readouterr()
+
+    assert [p for p in out.glob("*scheduler-fallback.yaml")]


### PR DESCRIPTION
## Why

Three findings from the review of #81, all reproduced against its head before anything changed here. They are one problem: the compiler was inferring ownership from things that cannot express it.

**Attribution was a kind only one renderer emits.** A `ResourceClaimTemplate` is not one — both write it — so the standalone `*-scheduler-fallback.yaml` holds nothing that decides. It was a subset of both sets, belonged to neither, and turning `--dra-fallback` off left the previous generation in the desired-state directory permanently. Measured: after `--prune`, the file is still there and `stale_unattributable` is absent, so nothing tells the operator either.

**Ownership was a mission fingerprint.** The priority-class bundle has none: it is cluster-scoped, one set per installation, which is what `--priority-class-prefix` exists to keep from colliding. Two bundles both answering "no mission" is how the ownership check compared `None` with `None` and let a second installation replace the first's class set. Measured: `team-a-` class names gone, no warning, and the Jobs referencing them untouched.

**A mission-scoped `--prune` deleted that bundle outright.** One invocation does not hold the installation's desired set, so it cannot tell a class nobody needs from one another mission's Jobs still reference. A warning after the fact is not ownership.

## What

Every document carries `orbital/renderer`, `orbital/owner-scope`, `orbital/artifact-role` and `orbital/ownership-schema`, with the owner's own name in `orbital/owner-id` beside the fingerprint — 64 bits of a digest should not decide a delete by itself.

The bundle's owner is the prefix, because that is what makes one installation's classes distinct from another's in a cluster. A cross-owner replacement is refused; the same installation replacing its own is not.

Ordinary `--prune` manages mission scope. `--prune-global` is the opt-in for cluster-scoped artifacts, and only for the installation that wrote them. Either way they are named in the report and on stderr, because leaving them silently is how an operator finds out by having a workload fail admission.

Every document in one file has to agree on that tuple. An operator concatenating two renders into one bundle for `kubectl apply -f` produces a file that answers for nobody, and it is not deleted on either writer's say-so.

An artifact carrying no schema label predates this and is reported rather than acted on. Adopting it would mean guessing again; re-rendering adopts it properly. That is a deliberate behaviour change for a directory written by an older version, and it fails closed.

## Verification

Written as failing tests first, then each guarantee checked against a mutation: attributing by kind again, dropping the installation comparison in preflight, giving the bundle mission scope, letting an ordinary prune take it, letting another installation take it, and letting a file's documents disagree.

The last one was not caught. The agreement rule had no test at all, which is why there are three now — and re-running that mutation fails all three.

The three original reproductions were re-run end to end: the second prefix now exits 2 with `team-a-` intact, the scheduler fallback is retired by its own renderer and not by the other, and a second mission's `--prune` leaves the bundle and says why.

1001 pytest passed, 1 skipped. `ruff` clean, `mypy` clean, 15 goldens pass.

## Depends on #82

Third in the stack: #81, then #82, then this. It rewrites the ownership model #81 introduced, so reviewing them apart would mean resolving that overlap at merge time.
