### PR TITLE
render the plan the reconciliation scope was taken from

### DIFF
--- a/src/orbital_mission_compiler/cli.py
+++ b/src/orbital_mission_compiler/cli.py
@@ -142,15 +142,6 @@ def _scope_of(plan: MissionPlan) -> frozenset[str]:
     return frozenset({mission_fingerprint(plan.mission_id)})
 
 
-def _render_scope(source: str | Path) -> tuple[frozenset[str], frozenset[str]]:
-    """The same, for a command that has not loaded the plan yet.
-
-    Both halves together: the fingerprints the artifacts carry, and the raw ids
-    they are digests of.
-    """
-    plan = load_mission_plan(source)
-    return _scope_of(plan), _owner_of(plan)
-
 
 def _report_stale(
     result: dict[str, object], output_dir: str, written: list[Path], prune: bool,
@@ -534,12 +525,20 @@ def cmd_compile(args: argparse.Namespace) -> None:
     print(json.dumps({"status": "ok", "workflows": len(payload["workflows"])}, indent=2))
 
 
-def _render_argo(args: argparse.Namespace, output_dir: str | Path) -> list[Path]:
+def _render_argo(
+    args: argparse.Namespace, output_dir: str | Path, plan: MissionPlan
+) -> list[Path]:
+    # The plan object, not the path it came from. The reconciliation scope is
+    # taken from the same load, and two reads of one file can answer
+    # differently: a file replaced in between renders one plan's manifests and
+    # reconciles them under another plan's scope. `_load_or_accept_plan` exists
+    # so a caller that has judged a plan renders the object it judged.
+    #
     # args.namespace goes straight through: the writer supplies one for a DRA
     # bundle, whose two documents have to share it, and leaves an ordinary render
     # namespace-less so it is chosen when the manifest is applied.
     return write_individual_workflows(
-        args.input, output_dir, enforce_policy=not args.unsafe_skip_policy,
+        plan, output_dir, enforce_policy=not args.unsafe_skip_policy,
         policy_engine=args.policy_engine, bundle=args.bundle, decision=args.decision,
         dra_fallback=args.dra_fallback, namespace=args.namespace,
         service_account=args.service_account,
@@ -574,7 +573,8 @@ def cmd_render_argo(args: argparse.Namespace) -> None:
     # it is printed: read after the render instead, the same failure arrives with
     # manifests already on disk and the report denies it. Once, because three
     # reads of one file are three chances for it to answer differently.
-    scope, owners = _render_scope(args.input)
+    plan = load_mission_plan(args.input)
+    scope, owners = _scope_of(plan), _owner_of(plan)
     # The same lock the gate takes. Without it an ungated render can replace files
     # in the directory a gated run has just snapshotted and linted and is about to
     # publish into, and the gate's verdict would then describe a directory that no
@@ -609,7 +609,7 @@ def cmd_render_argo(args: argparse.Namespace) -> None:
         )
         raise SystemExit(2) from exc
     with lock_stack:
-        written = _render_argo(args, args.output_dir)
+        written = _render_argo(args, args.output_dir, plan)
         result: dict[str, object] = {"status": "ok", "files": [str(p) for p in written]}
         try:
             _report_stale(
@@ -1218,7 +1218,8 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
     # Before the staging directory exists, for the same reason the ungated path
     # reads it before rendering: an input this command cannot use has to be
     # refused while there is still nothing to explain away.
-    scope, owners = _render_scope(args.input)
+    plan = load_mission_plan(args.input)
+    scope, owners = _scope_of(plan), _owner_of(plan)
     out_dir = Path(args.output_dir)
     staging = Path(tempfile.mkdtemp(
         prefix=".argo-lint-staging-", dir=_nearest_existing_ancestor(out_dir)
@@ -1227,7 +1228,7 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
     result_stale: dict[str, object] = {}
     lock_stack = contextlib.ExitStack()
     try:
-        written = _render_argo(args, staging)
+        written = _render_argo(args, staging, plan)
 
         # Resolved after the prune-only case below and before every other one.
         # A plan is allowed to render nothing, and an empty render must not be

--- a/tests/test_one_plan_read.py
+++ b/tests/test_one_plan_read.py
@@ -1,0 +1,129 @@
+"""The plan a command renders is the plan its reconciliation scope came from.
+
+Ownership is declared from the input rather than read back off what was
+written, which is what lets a revision that renders nothing reconcile at all.
+That only holds while there is one input. Both Argo paths read the file twice --
+once to derive the scope, once inside the renderer -- so a file edited between
+the two reads publishes one plan's manifests under another plan's scope.
+
+`_load_or_accept_plan` exists for exactly this: a caller that judged a plan can
+render the object it judged rather than handing the path back.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from orbital_mission_compiler import cli, compiler
+from orbital_mission_compiler.cli import build_parser, cmd_render_argo, cmd_render_kueue
+
+PLAN = "configs/mission_plans/demo_gpu_fallback_fixed.yaml"
+OTHER = "configs/mission_plans/sample_download_only.yaml"
+
+
+def _count_reads(monkeypatch) -> dict:
+    """Count how often a command goes back to the file for the plan."""
+    seen = {"n": 0}
+    real = compiler.load_mission_plan
+
+    def counting(path):
+        seen["n"] += 1
+        return real(path)
+
+    monkeypatch.setattr(compiler, "load_mission_plan", counting)
+    monkeypatch.setattr(cli, "load_mission_plan", counting)
+    return seen
+
+
+@pytest.mark.parametrize(
+    "argv_extra,label",
+    [([], "ungated"), (["--argo-lint"], "gated")],
+)
+def test_render_argo_reads_the_plan_once(argv_extra, label, tmp_path, monkeypatch, capsys):
+    """One read, so the scope and the render cannot describe different plans."""
+    from tests.test_argo_lint_gate import _fake_argo
+
+    out = tmp_path / "out"
+    argv = [
+        "render-argo", "--input", PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline", "--prune", *argv_extra,
+    ]
+    if argv_extra:
+        argv += ["--argo-bin", str(_fake_argo(tmp_path, 0))]
+    seen = _count_reads(monkeypatch)
+
+    cmd_render_argo(build_parser().parse_args(argv))
+    capsys.readouterr()
+
+    assert seen["n"] == 1, f"{label} read the plan {seen['n']} times"
+
+
+def test_render_kueue_reads_the_plan_once(tmp_path, monkeypatch, capsys):
+    """Already true, and pinned so it stays that way."""
+    out = tmp_path / "out"
+    seen = _count_reads(monkeypatch)
+
+    cmd_render_kueue(build_parser().parse_args([
+        "render-kueue", "--input", PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline", "--prune",
+    ]))
+    capsys.readouterr()
+
+    assert seen["n"] == 1, f"read the plan {seen['n']} times"
+
+
+@pytest.mark.parametrize(
+    "argv_extra,label",
+    [([], "ungated"), (["--argo-lint"], "gated")],
+)
+def test_a_plan_replaced_mid_run_does_not_split_the_render_from_its_scope(
+    argv_extra, label, tmp_path, monkeypatch, capsys
+):
+    """The failure the second read allowed.
+
+    Swapping the file for a different mission between the scope read and the
+    renderer's own read produced manifests for one mission reconciled under the
+    other's scope. With one read the swap cannot land between them, so whichever
+    plan the command took, it renders and reconciles the same one.
+    """
+    from tests.test_argo_lint_gate import _fake_argo
+
+    plan = tmp_path / "plan.yaml"
+    plan.write_text(Path(PLAN).read_text(encoding="utf-8"), encoding="utf-8")
+    out = tmp_path / "out"
+    argv = [
+        "render-argo", "--input", str(plan), "--output-dir", str(out),
+        "--policy-engine", "baseline", "--prune", *argv_extra,
+    ]
+    if argv_extra:
+        argv += ["--argo-bin", str(_fake_argo(tmp_path, 0))]
+
+    real = compiler.load_mission_plan
+    swapped = {"done": False}
+
+    def swap_after_first(path):
+        result = real(path)
+        if not swapped["done"]:
+            swapped["done"] = True
+            plan.write_text(Path(OTHER).read_text(encoding="utf-8"), encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(compiler, "load_mission_plan", swap_after_first)
+    monkeypatch.setattr(cli, "load_mission_plan", swap_after_first)
+
+    cmd_render_argo(build_parser().parse_args(argv))
+    report = json.loads(capsys.readouterr().out)
+
+    written = [Path(p).name for p in report.get("files", [])]
+    assert written, report
+    missions = {
+        (yaml.safe_load((out / name).read_text(encoding="utf-8")) or {})
+        .get("metadata", {}).get("labels", {}).get("mission-id")
+        for name in written
+    }
+    # One mission, and the one the first read took.
+    assert missions == {"demo-gpu-fallback-fixed"}, (missions, report)


### PR DESCRIPTION
## Why

The last of the review's plan-reading finding. `render-kueue` already read the plan once; both Argo paths read it twice — once to derive the reconciliation scope, once inside the renderer.

Two reads of one file can answer differently. Measured by replacing the input with a different mission between them: the command wrote one plan's manifests and reconciled them under the other plan's scope. That is the failure the declared scope was introduced to remove, reappearing one layer down.

## What

`write_individual_workflows` already accepts a `MissionPlan`, and `_load_or_accept_plan` exists for exactly this — a caller that has judged a plan renders the object it judged rather than handing the path back. Both Argo commands load once and pass the object on. `_render_scope` had no caller left and goes with them.

## Verification

The swap test is the one that matters, and it deliberately does not assert that a second read is absent: it asserts the manifests and the scope name the same mission, whichever plan the command took. A read count on its own would pass for a command that read once and read the wrong thing.

Mutations: handing the path back to the writer, and reloading in the gated path only. Each fails the cases that name it, while the `render-kueue` control keeps passing — which is what says the count assertions are about the Argo paths rather than about the counting.

1016 pytest passed, 1 skipped. `ruff` clean, `mypy` clean, 15 goldens pass.

## Depends on #84

Fifth in the stack: #81, #82, #83, #84, then this.
