### PR TITLE
stage a render beside the output rather than inside it

### DIFF
--- a/src/orbital_mission_compiler/cli.py
+++ b/src/orbital_mission_compiler/cli.py
@@ -690,18 +690,38 @@ def _staging_root(out_dir: Path, staging_dir: str | None = None) -> Path:
     on that filesystem to write, so this refuses and says so rather than falling
     back inside and quietly exposing the staged set.
     """
+    # Whatever the output will be renamed into is what staging has to share a
+    # filesystem with: the directory itself once it exists, and the nearest
+    # existing ancestor before that, since publishing creates the rest.
+    anchor = out_dir if out_dir.is_dir() else _nearest_existing_ancestor(out_dir)
     if staging_dir is not None:
-        return Path(staging_dir)
+        chosen = Path(staging_dir)
+        if not _same_filesystem(chosen, anchor):
+            raise StagingUnavailable(
+                f"--staging-dir {chosen} is on a different filesystem from {anchor}, "
+                "and publishing is a rename, which cannot cross one"
+            )
+        return chosen
     if not out_dir.is_dir():
-        return _nearest_existing_ancestor(out_dir)
+        # Nothing to shadow yet, and the ancestor is already outside the output
+        # that a rejected render must leave absent.
+        return anchor
     beside = out_dir.absolute().parent
-    if beside.is_dir() and _same_filesystem(beside, out_dir):
-        return beside
-    raise StagingUnavailable(
-        f"{out_dir} is on a different filesystem from {beside}, so a render cannot "
-        "be staged beside it and published by rename; give --staging-dir a "
-        "directory on the same filesystem that consumers of the output do not read"
-    )
+    if beside == out_dir.absolute():
+        raise StagingUnavailable(
+            f"{out_dir} is its own parent, so there is nowhere beside it to stage "
+            "a render that a consumer of the output would not read"
+        )
+    if not beside.is_dir() or not _same_filesystem(beside, out_dir):
+        raise StagingUnavailable(
+            f"{out_dir} is on a different filesystem from {beside}, so a render cannot "
+            "be staged beside it and published by rename"
+        )
+    # Whether it can actually be written is left to the attempt in
+    # _make_staging. os.access answers about the mode bits and not about ACLs or
+    # a read-only mount, and a pre-check that is right less often than the
+    # operation it guards only hides which one is doing the work.
+    return beside
 
 
 class PublishLockUnavailable(Exception):
@@ -951,6 +971,28 @@ def publish_lock_path(
     return Path(lock_dir or _default_lock_dir()) / f"orbital-publish-{digest}.lock"
 
 
+def _make_staging(out_dir: Path, staging_dir: str | None, prefix: str) -> Path:
+    """A directory to assemble in, or a refusal that says how to get one.
+
+    The creation is here rather than at each call site because every way it can
+    fail means the same thing to the caller: there is nowhere to stage this
+    render. Left to escape, a parent this process cannot write reached the
+    command line as a PermissionError traceback.
+    """
+    root = _staging_root(out_dir, staging_dir)
+    try:
+        return Path(tempfile.mkdtemp(prefix=prefix, dir=root))
+    except OSError as exc:
+        # Where an unwritable parent lands. Staging used to go inside the output,
+        # which the operator can write by definition; beside it needs the parent,
+        # and a directory handed to a team inside a parent someone else owns is
+        # ordinary. It has to be the documented could-not-run answer rather than
+        # a PermissionError traceback.
+        raise StagingUnavailable(
+            f"a staging directory could not be created in {root}: {exc}"
+        ) from exc
+
+
 @contextlib.contextmanager
 def _publish_lock(
     out_dir: Path, lock_timeout: float = _DEFAULT_LOCK_TIMEOUT,
@@ -1169,9 +1211,7 @@ def _publish(
     # Beside the output, not inside it. What a rename displaces is the whole of
     # the previous generation, and a cleanup that fails leaves it where a
     # recursive apply collects it alongside the new set.
-    backup_dir = Path(tempfile.mkdtemp(
-        prefix=".orbital-publish-backup-", dir=_staging_root(out_dir, staging_dir)
-    ))
+    backup_dir = _make_staging(out_dir, staging_dir, ".orbital-publish-backup-")
     out_dir.mkdir(parents=True, exist_ok=True)
 
     displaced: dict[Path, Path] = {}
@@ -1287,9 +1327,7 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
     plan = load_mission_plan(args.input)
     scope, owners = _scope_of(plan), _owner_of(plan)
     out_dir = Path(args.output_dir)
-    staging = Path(tempfile.mkdtemp(
-        prefix=".argo-lint-staging-", dir=_staging_root(out_dir, args.staging_dir)
-    ))
+    staging = _make_staging(out_dir, args.staging_dir, ".argo-lint-staging-")
     carried: list[Path] = []
     result_stale: dict[str, object] = {}
     lock_stack = contextlib.ExitStack()
@@ -1689,9 +1727,7 @@ def cmd_render_kueue(args: argparse.Namespace) -> None:
         # some from the last, with nothing saying so. The Job and the classes it
         # references are exactly such a set -- a Job from the new render beside
         # priority classes from the old one names values that have moved.
-        staging = Path(tempfile.mkdtemp(
-            prefix=".kueue-render-staging-", dir=_staging_root(out_dir, args.staging_dir)
-        ))
+        staging = _make_staging(out_dir, args.staging_dir, ".kueue-render-staging-")
         try:
             out_dir.mkdir(parents=True, exist_ok=True)
             staged: list[Path] = []

--- a/src/orbital_mission_compiler/cli.py
+++ b/src/orbital_mission_compiler/cli.py
@@ -389,6 +389,22 @@ def _add_global_prune_args(p: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_staging_args(p: argparse.ArgumentParser) -> None:
+    """Add the flag naming where a render is assembled."""
+    p.add_argument(
+        "--staging-dir",
+        type=_absolute_directory,
+        default=None,
+        help="Absolute directory to assemble a render in before publishing it. "
+        "Publishing is a rename, so this has to be on the same filesystem as the "
+        "output directory, and it must not be somewhere consumers of the output "
+        "read: `kubectl apply -R` descends into dotted directories, so a render "
+        "staged inside the output can be collected before it has been verified. "
+        "By default it is the directory beside the output, which is refused when "
+        "the output is its own mount point because no rename can cross that.",
+    )
+
+
 def _add_policy_args(p: argparse.ArgumentParser) -> None:
     """Add the shared policy-gate flags to an artifact-producing subcommand."""
     p.add_argument("--unsafe-skip-policy", action="store_true", help=_UNSAFE_SKIP_POLICY_HELP)
@@ -458,6 +474,7 @@ def build_parser() -> argparse.ArgumentParser:
         "the ResourceClaimTemplate document).",
     )
     _add_lock_args(render_p)
+    _add_staging_args(render_p)
     _add_policy_args(render_p)
     render_p.set_defaults(func=cmd_render_argo)
 
@@ -504,6 +521,7 @@ def build_parser() -> argparse.ArgumentParser:
         "collisions on the cluster-scoped names.",
     )
     _add_lock_args(kueue_p)
+    _add_staging_args(kueue_p)
     _add_global_prune_args(kueue_p)
     _add_policy_args(kueue_p)
     kueue_p.set_defaults(func=cmd_render_kueue)
@@ -626,15 +644,7 @@ def cmd_render_argo(args: argparse.Namespace) -> None:
 
 
 def _nearest_existing_ancestor(path: Path) -> Path:
-    """The closest existing directory at or above ``path``.
-
-    Staging goes here so publishing is a same-filesystem rename, without having
-    to create the output directory first: a denied plan or a rejected lint must
-    leave a path that did not exist before the command exactly as absent. When
-    the output directory does exist this is the directory itself, which is
-    deliberate -- an output directory that is a mount point has a parent on a
-    different filesystem, and a rename across that boundary cannot work.
-    """
+    """The closest existing directory at or above ``path``."""
     current = path.absolute()
     while not current.is_dir():
         parent = current.parent
@@ -642,6 +652,56 @@ def _nearest_existing_ancestor(path: Path) -> Path:
             break
         current = parent
     return current
+
+
+def _same_filesystem(a: Path, b: Path) -> bool:
+    """Whether a rename between these two can work.
+
+    Its own function so the refusal below can be exercised: an output directory
+    that is its own mount point is not something a test can conjure without
+    root.
+    """
+    return a.stat().st_dev == b.stat().st_dev
+
+
+class StagingUnavailable(Exception):
+    """There is nowhere to stage this render that a consumer will not read."""
+
+
+def _staging_root(out_dir: Path, staging_dir: str | None = None) -> Path:
+    """Where a render assembles its output before publishing it.
+
+    Two constraints, and they pull apart. Publishing is a rename, so staging has
+    to share a filesystem with the output directory. And the output directory is
+    what a consumer reads: `kubectl apply -R -f <dir>` descends into directories
+    whose names begin with a dot and collects dotted files at the top level too,
+    measured on v1.36.3, so staging inside it is not hidden from anyone. A
+    recursive apply during a gated render would collect manifests the linter has
+    not passed, and a backup a failed cleanup left behind is a second copy of the
+    previous generation sitting where it will be applied.
+
+    So it goes beside the output rather than inside it. When the output does not
+    exist yet the nearest existing ancestor is already outside it and is used as
+    before, which is what keeps a rejected render from creating a directory that
+    was not there.
+
+    An output directory that is its own mount point has a parent on another
+    filesystem and no rename can cross that. Only the operator knows where else
+    on that filesystem to write, so this refuses and says so rather than falling
+    back inside and quietly exposing the staged set.
+    """
+    if staging_dir is not None:
+        return Path(staging_dir)
+    if not out_dir.is_dir():
+        return _nearest_existing_ancestor(out_dir)
+    beside = out_dir.absolute().parent
+    if beside.is_dir() and _same_filesystem(beside, out_dir):
+        return beside
+    raise StagingUnavailable(
+        f"{out_dir} is on a different filesystem from {beside}, so a render cannot "
+        "be staged beside it and published by rename; give --staging-dir a "
+        "directory on the same filesystem that consumers of the output do not read"
+    )
 
 
 class PublishLockUnavailable(Exception):
@@ -1090,7 +1150,8 @@ def _discard_backup(backup_dir: Path, leftover_backups: list[str] | None) -> Non
 
 
 def _publish(
-    staged: list[Path], out_dir: Path, leftover_backups: list[str] | None = None
+    staged: list[Path], out_dir: Path, leftover_backups: list[str] | None = None,
+    staging_dir: str | None = None,
 ) -> list[Path]:
     """Move a rendered set into the output directory, all of it or none of it.
 
@@ -1105,7 +1166,12 @@ def _publish(
     while not probe.is_dir():
         created_dirs.append(probe)
         probe = probe.parent
-    backup_dir = Path(tempfile.mkdtemp(prefix=".orbital-publish-backup-", dir=probe))
+    # Beside the output, not inside it. What a rename displaces is the whole of
+    # the previous generation, and a cleanup that fails leaves it where a
+    # recursive apply collects it alongside the new set.
+    backup_dir = Path(tempfile.mkdtemp(
+        prefix=".orbital-publish-backup-", dir=_staging_root(out_dir, staging_dir)
+    ))
     out_dir.mkdir(parents=True, exist_ok=True)
 
     displaced: dict[Path, Path] = {}
@@ -1222,7 +1288,7 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
     scope, owners = _scope_of(plan), _owner_of(plan)
     out_dir = Path(args.output_dir)
     staging = Path(tempfile.mkdtemp(
-        prefix=".argo-lint-staging-", dir=_nearest_existing_ancestor(out_dir)
+        prefix=".argo-lint-staging-", dir=_staging_root(out_dir, args.staging_dir)
     ))
     carried: list[Path] = []
     result_stale: dict[str, object] = {}
@@ -1424,7 +1490,7 @@ def _render_argo_with_lint_gate(args: argparse.Namespace) -> None:
             preflight_writable(
                 [(out_dir / path.name, path.read_text(encoding="utf-8")) for path in written]
             )
-            published = _publish(written, out_dir, leftover_backups)
+            published = _publish(written, out_dir, leftover_backups, args.staging_dir)
             # Outside the publish try below. _publish has returned, so the
             # manifests are live; an OSError from the scan reported by that
             # handler asserts a rollback that did not happen.
@@ -1624,7 +1690,7 @@ def cmd_render_kueue(args: argparse.Namespace) -> None:
         # references are exactly such a set -- a Job from the new render beside
         # priority classes from the old one names values that have moved.
         staging = Path(tempfile.mkdtemp(
-            prefix=".kueue-render-staging-", dir=_nearest_existing_ancestor(out_dir)
+            prefix=".kueue-render-staging-", dir=_staging_root(out_dir, args.staging_dir)
         ))
         try:
             out_dir.mkdir(parents=True, exist_ok=True)
@@ -1634,7 +1700,7 @@ def cmd_render_kueue(args: argparse.Namespace) -> None:
                 atomic_write(staged_file, text)
                 staged.append(staged_file)
             try:
-                written = _publish(staged, out_dir, leftover_backups)
+                written = _publish(staged, out_dir, leftover_backups, args.staging_dir)
             except PublishRolledBackPartially as exc:
                 print(json.dumps({
                     "status": "error", "reason": "rollback-incomplete",
@@ -1798,6 +1864,23 @@ def main() -> None:
     args = parser.parse_args()
     try:
         args.func(args)
+    except StagingUnavailable as exc:
+        # The command could not run: same family as policy_engine_unavailable,
+        # and the same exit code. Nothing was staged and nothing published, so
+        # this is never a verdict.
+        print(
+            json.dumps(
+                {
+                    "status": "error",
+                    "reason": "staging_unavailable",
+                    "error": str(exc),
+                    "hint": "give --staging-dir a directory on the output's filesystem "
+                    "that consumers of the output do not read",
+                }
+            ),
+            file=sys.stderr,
+        )
+        raise SystemExit(2) from exc
     except MissionPlanUnreadable as exc:
         # The run never started, which is the family policy_engine_unavailable is
         # in. Exit 2 rather than 1 because 1 is a verdict everywhere else on this

--- a/tests/test_staging_visibility.py
+++ b/tests/test_staging_visibility.py
@@ -238,3 +238,77 @@ def test_an_output_on_its_own_filesystem_refuses_rather_than_staging_inside(
     assert report["reason"] == "staging_unavailable", report
     assert "--staging-dir" in report["hint"], report
     assert not [p.name for p in out.iterdir()], "nothing may be staged or published"
+
+
+def test_an_unwritable_parent_refuses_instead_of_raising(tmp_path, monkeypatch, capsys):
+    """A precondition this change introduced, so it has to answer for it.
+
+    Staging used to go inside the output, which the operator can write by
+    definition. Beside it needs the parent writable, which is a new requirement
+    and not always met: a directory handed to a team inside a root-owned parent
+    is ordinary. It has to be the documented could-not-run answer naming
+    --staging-dir, not a PermissionError traceback.
+    """
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("root writes regardless of the mode bits")
+    parent = tmp_path / "locked"
+    parent.mkdir()
+    out = parent / "out"
+    out.mkdir()
+    os.chmod(parent, 0o555)
+    monkeypatch.setattr("sys.argv", [
+        "orbital-mission-compiler", "render-kueue", "--input", PLAN,
+        "--output-dir", str(out), "--policy-engine", "baseline",
+    ])
+    try:
+        with pytest.raises(SystemExit) as excinfo:
+            cli.main()
+    finally:
+        os.chmod(parent, 0o755)
+
+    assert excinfo.value.code == 2
+    report = json.loads(capsys.readouterr().err)
+    assert report["reason"] == "staging_unavailable", report
+    assert "--staging-dir" in report["hint"], report
+    assert not list(out.iterdir()), "nothing may be written"
+
+
+def test_a_staging_dir_on_another_filesystem_is_refused_up_front(
+    tmp_path, monkeypatch, capsys
+):
+    """The explicit case has to be checked like the default one.
+
+    A rename cannot cross a filesystem, so this fails either way. Refusing when
+    the flag is read costs a message; discovering it at publish time costs a
+    render, and in the gated path a lint as well.
+    """
+    out = tmp_path / "out"
+    out.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.setattr(cli, "_same_filesystem", lambda a, b: False)
+    monkeypatch.setattr("sys.argv", [
+        "orbital-mission-compiler", "render-kueue", "--input", PLAN,
+        "--output-dir", str(out), "--policy-engine", "baseline",
+        "--staging-dir", str(elsewhere),
+    ])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main()
+
+    assert excinfo.value.code == 2
+    report = json.loads(capsys.readouterr().err)
+    assert report["reason"] == "staging_unavailable", report
+    assert not list(out.iterdir()), "nothing may be written"
+
+
+def test_an_output_that_is_its_own_root_has_nowhere_beside_it(tmp_path, monkeypatch):
+    """`/` is its own parent, so beside it is inside it.
+
+    Absurd as an output directory and still worth refusing: the whole point of
+    the move is that staging is not somewhere a consumer reads.
+    """
+    monkeypatch.setattr(cli.Path, "is_dir", lambda self: True)
+
+    with pytest.raises(cli.StagingUnavailable):
+        cli._staging_root(Path("/"))

--- a/tests/test_staging_visibility.py
+++ b/tests/test_staging_visibility.py
@@ -1,0 +1,240 @@
+"""What a reader of the output directory can see while a render is in flight.
+
+`kubectl apply -R -f <dir>` descends into directories whose names begin with a
+dot and picks up dotted files at the top level too, measured on v1.36.3. So
+staging named `.argo-lint-staging-*` inside the output directory is not hidden
+from the consumer at all: a recursive apply during a gated render collects
+manifests the linter has not passed yet, and a backup left behind by a failed
+cleanup is a second copy of the previous generation sitting where it will be
+applied.
+
+Observed from the reader's position rather than from the implementation's: the
+linter is where the gate is holding a verdict it has not given, so that is the
+moment to look at the directory.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from orbital_mission_compiler import cli
+from orbital_mission_compiler.cli import build_parser, cmd_render_argo, cmd_render_kueue
+
+PLAN = "configs/mission_plans/demo_gpu_fallback_fixed.yaml"
+
+
+def _snapshot_at_lint(monkeypatch, out_dir: Path) -> list[list[str]]:
+    """Everything in the output directory each time the linter is invoked."""
+    seen: list[list[str]] = []
+    real = cli.argo_lint_path
+
+    def watching(staging, **kwargs):
+        seen.append(sorted(p.name for p in out_dir.iterdir()) if out_dir.exists() else [])
+        return real(staging, **kwargs)
+
+    monkeypatch.setattr(cli, "argo_lint_path", watching)
+    return seen
+
+
+def test_a_gated_render_puts_no_staging_in_the_published_directory(
+    tmp_path, monkeypatch, capsys
+):
+    """The directory a consumer reads holds only published manifests.
+
+    Checked while the linter runs, which is precisely when the gate is holding a
+    verdict it has not given and the staged copies exist.
+    """
+    from tests.test_argo_lint_gate import _fake_argo
+
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "pre-existing.yaml").write_text(
+        "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: already-here\n", encoding="utf-8"
+    )
+    seen = _snapshot_at_lint(monkeypatch, out)
+
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline", "--argo-lint",
+        "--argo-bin", str(_fake_argo(tmp_path, 0)),
+    ]))
+    capsys.readouterr()
+
+    assert seen, "the linter never ran, so nothing was observed"
+    for listing in seen:
+        assert listing == ["pre-existing.yaml"], listing
+
+
+def test_publishing_puts_no_backup_in_the_published_directory(tmp_path, monkeypatch, capsys):
+    """The previous generation is set aside outside what a consumer reads.
+
+    A backup inside the output is a full second copy of the last generation, and
+    `kubectl apply` picks up a dotted file at the top level, so a cleanup that
+    fails leaves the old manifests to be applied alongside the new ones.
+    """
+    from tests.test_argo_lint_gate import _fake_argo
+
+    out = tmp_path / "out"
+    # The gated path, because it is the one that publishes through a backup. The
+    # ungated path writes straight into the directory and takes no backup at all,
+    # which is its own gap and not this one.
+    argv = [
+        "render-argo", "--input", PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline", "--argo-lint",
+        "--argo-bin", str(_fake_argo(tmp_path, 0)),
+    ]
+    cmd_render_argo(build_parser().parse_args(argv))
+    capsys.readouterr()
+
+    # Snapshotted just before the backup is discarded, which is the window it
+    # exists in. Looking afterwards sees a cleaned-up directory and proves
+    # nothing about what a reader could have collected.
+    seen: list[list[str]] = []
+    real_discard = cli._discard_backup
+
+    def watching(backup_dir, leftover=None):
+        seen.append(sorted(p.name for p in out.iterdir()) if out.exists() else [])
+        return real_discard(backup_dir, leftover)
+
+    monkeypatch.setattr(cli, "_discard_backup", watching)
+    cmd_render_argo(build_parser().parse_args(argv))
+    capsys.readouterr()
+
+    assert seen, "no backup was ever taken, so nothing was observed"
+    for listing in seen:
+        assert not [n for n in listing if n.startswith(".")], listing
+
+
+def test_render_kueue_stages_outside_the_published_directory(tmp_path, monkeypatch, capsys):
+    """The other writer stages too, into the same directory consumers read."""
+    out = tmp_path / "out"
+    out.mkdir()
+    # Observed on entry to the publish step, when the staged copies exist and
+    # nothing has been moved into place yet.
+    seen: list[list[str]] = []
+    real_publish = cli._publish
+
+    def watching(staged, out_dir, leftover=None, staging_dir=None):
+        seen.append(sorted(p.name for p in out_dir.iterdir()) if out_dir.exists() else [])
+        return real_publish(staged, out_dir, leftover, staging_dir)
+
+    monkeypatch.setattr(cli, "_publish", watching)
+    cmd_render_kueue(build_parser().parse_args([
+        "render-kueue", "--input", PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline",
+    ]))
+    capsys.readouterr()
+
+    assert seen, "the publish step never ran, so nothing was observed"
+    for listing in seen:
+        assert not [n for n in listing if n.startswith(".")], listing
+
+
+def test_a_rejected_render_still_leaves_an_absent_directory_absent(tmp_path, capsys):
+    """The constraint the old placement existed for, which has to survive.
+
+    Staging cannot be created by first creating the output directory: a denied
+    plan or a rejected lint must leave a path that did not exist exactly as it
+    was.
+    """
+    from tests.test_argo_lint_gate import _fake_argo
+
+    out = tmp_path / "never" / "created"
+    with pytest.raises(SystemExit):
+        cmd_render_argo(build_parser().parse_args([
+            "render-argo", "--input", PLAN, "--output-dir", str(out),
+            "--policy-engine", "baseline", "--argo-lint",
+            "--argo-bin", str(_fake_argo(tmp_path, 1)),
+        ]))
+    capsys.readouterr()
+
+    assert not out.exists()
+
+
+def test_a_staging_dir_the_caller_names_is_used(tmp_path, monkeypatch, capsys):
+    """For an output directory whose parent is on another filesystem.
+
+    Publishing is a rename, so staging has to share a filesystem with the
+    output. When the output is a mount point its parent does not, and only the
+    operator knows where else on that filesystem to put it.
+    """
+    from tests.test_argo_lint_gate import _fake_argo
+
+    out = tmp_path / "out"
+    out.mkdir()
+    staging_root = tmp_path / "elsewhere"
+    staging_root.mkdir()
+    before = set(os.listdir(staging_root))
+    seen: list[list[str]] = []
+    real_lint = cli.argo_lint_path
+
+    def watching(staging, **kwargs):
+        seen.append(sorted(p.name for p in staging_root.iterdir()))
+        return real_lint(staging, **kwargs)
+
+    monkeypatch.setattr(cli, "argo_lint_path", watching)
+
+    cmd_render_argo(build_parser().parse_args([
+        "render-argo", "--input", PLAN, "--output-dir", str(out),
+        "--policy-engine", "baseline", "--staging-dir", str(staging_root),
+        "--argo-lint", "--argo-bin", str(_fake_argo(tmp_path, 0)),
+    ]))
+    capsys.readouterr()
+
+    assert list(out.glob("*.yaml")), "the render still has to publish"
+    assert set(os.listdir(staging_root)) == before, "staging is cleaned up after itself"
+    # Emptiness afterwards is true whether or not the flag was read, so what
+    # says it was read is that the directory held the staged set while the
+    # linter was looking at it.
+    assert any(during for during in seen), (
+        "nothing was ever staged in the directory the flag named"
+    )
+
+
+@pytest.mark.parametrize("value", ["relative/dir", "./x"], ids=["bare", "dot"])
+def test_a_relative_staging_dir_is_refused(value, capsys):
+    """Same reason as the lock directory: resolved against whichever working
+    directory this process happens to be in, which is not a location."""
+    with pytest.raises(SystemExit):
+        build_parser().parse_args([
+            "render-argo", "--input", PLAN, "--output-dir", "out",
+            "--staging-dir", value,
+        ])
+    assert "is relative" in capsys.readouterr().err
+
+
+def test_an_output_on_its_own_filesystem_refuses_rather_than_staging_inside(
+    tmp_path, monkeypatch, capsys
+):
+    """No rename crosses a mount boundary, and falling back inside is the harm.
+
+    Staging inside the output is what a consumer reads, so quietly doing that
+    when the parent is elsewhere would trade a visible failure for an invisible
+    exposure. Only the operator knows what else lives on that filesystem.
+    """
+    from tests.test_argo_lint_gate import _fake_argo
+
+    out = tmp_path / "out"
+    out.mkdir()
+    monkeypatch.setattr(cli, "_same_filesystem", lambda a, b: False)
+
+    # Driven through main(), because the promise of one report and a documented
+    # exit code is made there.
+    monkeypatch.setattr("sys.argv", [
+        "orbital-mission-compiler", "render-argo", "--input", PLAN,
+        "--output-dir", str(out), "--policy-engine", "baseline", "--argo-lint",
+        "--argo-bin", str(_fake_argo(tmp_path, 0)),
+    ])
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main()
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    report = json.loads(captured.err)
+    assert report["reason"] == "staging_unavailable", report
+    assert "--staging-dir" in report["hint"], report
+    assert not [p.name for p in out.iterdir()], "nothing may be staged or published"


### PR DESCRIPTION
## Why

The dot prefix on `.argo-lint-staging-*` was doing nothing. Measured on kubectl v1.36.3 with a dry-run apply over a directory holding a top-level manifest, a hidden file, a visible subdirectory and a hidden subdirectory:

```
kubectl apply -R --dry-run=client -f out
  configmap/hidden-file created (dry run)
  configmap/inside-hidden-dir created (dry run)
  configmap/top-level created (dry run)
  configmap/inside-visible-dir created (dry run)
```

`kubectl apply -R` descends into dotted directories, and plain `kubectl apply -f <dir>` collects dotted files at the top level too. So a consumer reading the output during a gated render collects manifests the linter has not passed, and a backup that a failed cleanup left behind is a full second copy of the previous generation sitting exactly where it will be applied beside the new set.

## What

Staging and the publish backup go beside the output directory. When the output does not exist yet, the nearest existing ancestor is already outside it and is used as before — which is what keeps a rejected render from creating a directory that was not there.

The old placement had a real reason and it still holds: publishing is a rename, so staging has to share a filesystem with the output, and an output directory that is its own mount point has a parent that does not. That case refuses now, naming `--staging-dir`, rather than falling back inside. Trading a visible failure for an invisible exposure is the wrong direction, and only the operator knows what else lives on that filesystem. The refusal is reported through `main()` in the shape the other could-not-run cases use, with exit 2.

## Verification

Observed from the reader's position rather than the implementation's: the output directory is listed while the linter is running, and while the backup exists, because those are the moments a consumer could collect either. Looking afterwards sees a tidied-up directory and proves nothing — which is what two of these tests did before they were rewritten.

Four mutations: staging inside again, the backup inside again, falling back inside instead of refusing, and ignoring the flag. The last two were not caught at first. The cross-filesystem refusal had no test, and the flag test asserted a directory that ends up empty whether or not the flag was read. So the device comparison moved behind a seam a test can reach, and the flag test now watches the named directory while the linter is holding the staged set.

1024 pytest passed, 1 skipped. `ruff` clean, `mypy` clean, 15 goldens pass.

## Not in this one

The ungated `render-argo` path still writes file by file rather than staging and publishing, so a failure part-way leaves a half-updated generation. It takes no backup at all, which is why the backup test here drives the gated path. That is the other half of the same review finding and follows separately.

## Depends on #85

Sixth in the stack: #81, #82, #83, #84, #85, then this.
