### PR TITLE
chore: keep local scratch out of the lint walk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ paper/
 # Claude Code local-only state
 .claude/worktrees/
 .claude/settings.local.json
+
+# Local scratch. Untracked and unignored, ruff walked into it and reported
+# findings from files no pull request contains.
+scratchpad/


### PR DESCRIPTION
## What this does

`scratchpad/` is neither tracked nor ignored, so `ruff check .` walks into it and reports findings from files no pull request contains. That cost me a false alarm while verifying #81: four `E741` errors that looked like the branch had introduced them, when the branch does not touch that directory at all and a clean checkout of it lints clean.

Ignoring the directory fixes both halves: ruff respects `.gitignore` by default, and the scratch can no longer be committed by accident.

## How it was checked

The scratch files are still on disk in my working copy, and `ruff check .` there goes from `Found 4 errors.` to `All checks passed!` with this one line. CI never saw the problem because it checks out clean, which is also why it went unnoticed.
